### PR TITLE
feat: Add workflow_dispatch trigger for manual AI review execution

### DIFF
--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -34,6 +34,45 @@ on:
     secrets:
       ANTHROPIC_API_KEY:
         required: false
+  
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number (required for manual trigger)'
+        type: number
+        required: true
+      model:
+        description: 'AI model'
+        type: choice
+        required: false
+        default: 'claude-3-5-sonnet-20241022'
+        options:
+          - claude-3-5-sonnet-20241022
+          - claude-3-opus-20240229
+          - claude-3-sonnet-20240229
+      temperature:
+        description: 'Temperature (0.0-1.0, lower = more conservative)'
+        type: number
+        required: false
+        default: 0.2
+      mode:
+        description: 'Review mode'
+        type: choice
+        required: false
+        default: 'suggest'
+        options:
+          - suggest
+          - apply-suggestions
+      max_output_chars:
+        description: 'Max output length'
+        type: number
+        required: false
+        default: 4000
+      max_diff_lines:
+        description: 'Max diff lines to analyze'
+        type: number
+        required: false
+        default: 8000
 
 permissions:
   contents: read
@@ -44,12 +83,20 @@ jobs:
   ai_review:
     runs-on: ubuntu-latest
     concurrency:
-      group: claude-pr-v2-${{ github.event.pull_request.number || github.run_id }}
+      group: claude-pr-v2-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
       cancel-in-progress: true
+    
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+    
     steps:
-      - name: Ensure pull_request context
-        if: ${{ github.event_name != 'pull_request' }}
-        run: echo "Only pull_request supported"; exit 0
+      - name: Validate PR context
+        run: |
+          if [ -z "$PR_NUMBER" ]; then
+            echo "❌ PR number missing. Use workflow_dispatch with pr_number input or trigger from PR event."
+            exit 1
+          fi
+          echo "✅ Processing PR #$PR_NUMBER"
 
       - uses: actions/checkout@v4
         with:
@@ -57,6 +104,7 @@ jobs:
 
       - name: Label gates
         id: gates
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -69,8 +117,8 @@ jobs:
             core.setOutput('run', (hasTrig && !hasSkip) ? 'true':'false');
 
       - name: Stop if gated off
-        if: steps.gates.outputs.run != 'true'
-        run: echo "Gated off"; exit 0
+        if: github.event_name == 'pull_request' && steps.gates.outputs.run != 'true'
+        run: echo "Gated off by labels"; exit 0
 
       - name: Fetch PR diff (truncated)
         id: diff
@@ -78,15 +126,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh pr diff "${{ github.event.pull_request.number }}" --patch > pr.diff || true
+          gh pr diff "$PR_NUMBER" --patch > pr.diff || true
           head -n "${{ inputs.max_diff_lines }}" pr.diff > pr.trunc.diff || true
 
+      - name: Fetch PR metadata
+        id: pr_info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q .title)
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+          echo "title=$PR_TITLE" >> $GITHUB_OUTPUT
+          echo "body=$PR_BODY" >> $GITHUB_OUTPUT
+      
       - name: Build prompt
         run: |
           set -euo pipefail
           mkdir -p .tmp
-          printf "%s" "${{ github.event.pull_request.title }}" | head -c 300 > .tmp/title.txt
-          printf "%s" "${{ github.event.pull_request.body }}"  | head -c 2000 > .tmp/body.txt
+          printf "%s" "${{ steps.pr_info.outputs.title }}" | head -c 300 > .tmp/title.txt
+          printf "%s" "${{ steps.pr_info.outputs.body }}"  | head -c 2000 > .tmp/body.txt
           {
             echo "You are a helpful, cautious code reviewer."
             echo "Rules: no secrets; least-privilege; safe shell; no destructive infra."
@@ -118,10 +177,10 @@ jobs:
           echo "$resp" | jq -r '.content[0].text // ""' | head -c "${{ inputs.max_output_chars }}" > .tmp/review.md
 
       - name: Create/update comment (idempotent)
-        if: ${{ inputs.mode == 'suggest' }}
+        if: ${{ inputs.mode == 'suggest' || github.event.inputs.mode == 'suggest' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ env.PR_NUMBER }}
           body-path: .tmp/review.md
           edit-mode: replace
           reactions: hooray

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Centralized Reusable Workflows for Merglbot Enterprise
+
+This repository provides centralized, reusable GitHub Actions workflows for the Merglbot enterprise.
+
+For detailed usage instructions and documentation on the available workflows, please see the [Claude PR Assistant v2 Documentation](./docs/claude-pr-assistant.md).


### PR DESCRIPTION
### **User description**
## Purpose
Enable manual triggering of AI review workflow via GitHub UI without requiring labels.

## Changes
✅ **New trigger**: `workflow_dispatch` with `pr_number` input  
✅ **Unified PR handling**: `env.PR_NUMBER` works for both triggers  
✅ **Dynamic PR fetch**: Uses `gh pr view` for manual runs  
✅ **Backward compatible**: Existing label-based trigger unchanged  

## How to use (Manual trigger)
1. Go to Actions → Claude PR Assistant (v2) → Run workflow
2. Select branch: `main`
3. Enter PR number (e.g., `20`)
4. Choose model, temperature, mode (optional)
5. Click **Run workflow**

## How to use (Label-based - unchanged)
1. Add `ai-review` label to any PR → auto-triggers

## Example UI inputs
- **pr_number**: `6` (required)
- **model**: `claude-3-5-sonnet-20241022` (dropdown)
- **temperature**: `0.2` (0.0-1.0)
- **mode**: `suggest` / `apply-suggestions`
- **max_output_chars**: `4000`
- **max_diff_lines**: `8000`

## Testing plan
- [x] Branch pushed with new `workflow_dispatch` trigger
- [ ] Merge to `main`
- [ ] Tag new version (`v2.0.1`)
- [ ] Test manual trigger on `merglbot-public/docs#6`
- [ ] Verify label-based trigger still wor- [ ] Verify label-based trigger still wor- [ ] Verify label-based table = stejně na manualní trigger"
- Same pattern as original v1 workflow

---
**Ready to merge** after quick review.


___

### **PR Type**
Enhancement


___

### **Description**
- Add manual workflow trigger via GitHub UI

- Support both label-based and manual PR review execution

- Unified PR handling with dynamic metadata fetching

- Backward compatible with existing label-based triggers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub UI"] -- "workflow_dispatch" --> B["Manual Trigger"]
  C["PR Labels"] -- "pull_request" --> D["Label-based Trigger"]
  B --> E["Unified PR Handler"]
  D --> E
  E --> F["AI Review Process"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-pr-assistant.yml</strong><dd><code>Add manual workflow dispatch trigger support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude-pr-assistant.yml

<ul><li>Add <code>workflow_dispatch</code> trigger with PR number input<br> <li> Add model, temperature, mode selection options<br> <li> Implement unified PR handling via <code>env.PR_NUMBER</code><br> <li> Add dynamic PR metadata fetching with <code>gh pr view</code><br> <li> Update concurrency grouping and validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/2/files#diff-0887ef6353f4a29e8df4b624c69315c57e6ca8d63137774fc1d2c0f522752fef">+70/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add repository description and documentation link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add basic repository description<br> <li> Include reference to Claude PR Assistant documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds manual workflow_dispatch trigger with PR inputs and unifies PR handling/metadata fetching while updating README.
> 
> - **Workflow updates** (`.github/workflows/claude-pr-assistant.yml`):
>   - **Manual trigger**: Add `workflow_dispatch` with inputs: `pr_number`, `model`, `temperature`, `mode`, `max_output_chars`, `max_diff_lines`.
>   - **Unified PR resolution**: Introduce `env.PR_NUMBER` and a validation step; update concurrency group to include `inputs.pr_number`.
>   - **PR data sourcing**: Fetch PR metadata via `gh pr view` and use it to build the prompt; fetch diff using `PR_NUMBER`.
>   - **Conditional logic**: Scope label gates/early-exit to `pull_request` events; adjust comment step to honor `mode` from manual inputs.
> - **Docs**:
>   - Update `README.md` with repository purpose and link to Claude PR Assistant v2 documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21f9a5b9f719ecb00462c9eefee5f71c327e7bfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->