### PR TITLE
feat: Add pr_number input to workflow_call for wrapper manual triggers

### DIFF
--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -3,6 +3,10 @@ name: Claude PR Assistant (v2)
 on:
   workflow_call:
     inputs:
+      pr_number:
+        description: 'PR number (optional, for manual wrapper triggers)'
+        type: number
+        required: false
       trigger_labels:
         type: string
         required: false


### PR DESCRIPTION
### **User description**
## Purpose
Enable wrappers to pass `pr_number` for manual trigger support via `workflow_call`.

## Problem
- Wrapper workflows want to support manual triggers
- But `workflow_call` didn't accept `pr_number` input
- Only `workflow_dispatch` had it

## Solution
✅ Add `pr_number` as optional input to `workflow_call`  
✅ Backward compatible (defaults to PR event if not provided)  
✅ Unified handling in `env.PR_NUMBER`

## Use Case
Wrapper can now do:

```yaml
on:
  workflow_dispatch:
    inputs:
      pr_number:
        type: number
        required: true

jobs:
  call_central:
    uses: merglbot-core/github/.github/workflows/claude-pr-assistant.yml@v2.0.2
    with:
      pr_number: ${{ inputs.pr_number }}
    secrets:
      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
```

## Testing
- [ ] Merge to main
- [ ] Tag v2.0.2
- [ ] Update wrapper in merglbot-public/docs
- [ ] Test manual trigger

---
**Ready to merge**


___

### **PR Type**
Enhancement


___

### **Description**
- Add `pr_number` input to `workflow_call` for manual wrapper triggers

- Maintain backward compatibility with optional parameter

- Enable unified PR number handling across trigger types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["workflow_call"] --> B["pr_number input"]
  B --> C["wrapper workflows"]
  C --> D["manual triggers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-pr-assistant.yml</strong><dd><code>Add pr_number input to workflow_call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude-pr-assistant.yml

<ul><li>Add optional <code>pr_number</code> input parameter to <code>workflow_call</code><br> <li> Enable wrapper workflows to pass PR number for manual execution<br> <li> Maintain backward compatibility with optional requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/3/files#diff-0887ef6353f4a29e8df4b624c69315c57e6ca8d63137774fc1d2c0f522752fef">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Accepts optional `pr_number` in `workflow_call` and wires it through env/concurrency with validation to support manual wrapper triggers.
> 
> - **CI/CD (GitHub Actions)**:
>   - Add optional `pr_number` input to `workflow_call` to enable wrapper-driven manual triggers.
>   - Plumb `inputs.pr_number` into `env.PR_NUMBER` and `concurrency` group fallback (`pull_request.number || inputs.pr_number`).
>   - Add a validation step to require `PR_NUMBER` and exit early if missing.
>   - Scope label gating and early-exit steps to only run on `pull_request` events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 568e9de8701b2294a3ac217c5eef034117778fdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->