### PR TITLE
fix: Change pr_number type to string (type validation)

### DIFF
--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       pr_number:
         description: 'PR number (optional, for manual wrapper triggers)'
-        type: number
+        type: string
         required: false
       trigger_labels:
         type: string
@@ -43,7 +43,7 @@ on:
     inputs:
       pr_number:
         description: 'PR number (required for manual trigger)'
-        type: number
+        type: string
         required: true
       model:
         description: 'AI model'


### PR DESCRIPTION
## Fix
Resolve GitHub Actions type validation error.

## Problem
```
Invalid type found: one of string, number, boolean were expected but integer was found
```

**Root cause**: GitHub Actions distinguishes between `number` (float) and `integer`. When `workflow_dispatch` passes an integer to `workflow_call` expecting `type: number`, validation fails.

## Solution
Change `pr_number` input type from `number` to `string` in **both** triggers:
```yaml
workflow_call:
  inputs:
    pr_number:
      type: string  # was: number

workflow_dispatch:
  inputs:
    pr_number:
      type: string  # was: number
```

**Why this works**:
✅ Shell scripts handle both strings and numbers transparently  
✅ `gh pr diff "6"` works the same as `gh pr diff 6`  
✅ Avoids type coercion issues between workflow types  

---
**Critical fix** - Final type validation fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `pr_number` input type from number to string in both `workflow_call` and `workflow_dispatch` to satisfy Actions type validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10f7bb710b9706afd392f1e07bab10c2a2d581b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->