### PR TITLE
fix: Multiline output encoding (EOF syntax)

### DIFF
--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -141,8 +141,16 @@ jobs:
           set -euo pipefail
           PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q .title)
           PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
-          echo "title=$PR_TITLE" >> $GITHUB_OUTPUT
-          echo "body=$PR_BODY" >> $GITHUB_OUTPUT
+          
+          # GitHub Actions multiline string syntax
+          {
+            echo "title<<EOF"
+            echo "$PR_TITLE"
+            echo "EOF"
+            echo "body<<EOF"
+            echo "$PR_BODY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       
       - name: Build prompt
         run: |


### PR DESCRIPTION
### **User description**
## Fix
Resolve GITHUB_OUTPUT parse error for multiline PR body.

## Problem
```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '## Purpose'
```

**Root cause**: PR body with markdown headers (`## Purpose`) triggers parse error in `GITHUB_OUTPUT` when using simple assignment.

## Solution
Use **heredoc EOF syntax** per [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings):

```bash
{
  echo "key<<EOF"
  echo "$MULTILINE_VALUE"
  echo "EOF"
} >> "$GITHUB_OUTPUT"
```

## Why This Is THE Final Fix
✅ Handles markdown headers  
✅ Handles special chars  
✅ GitHub Actions official pattern  
✅ Tested on PR body with `##` headers

---
**This unblocks end-to-end workflow execution!**


___

### **PR Type**
Bug fix


___

### **Description**
- Fix multiline output encoding using EOF syntax

- Resolve GITHUB_OUTPUT parse error for PR bodies

- Handle markdown headers and special characters properly

- Use GitHub Actions official heredoc pattern


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR metadata fetch"] --> B["Simple assignment"] 
  B --> C["Parse error with markdown"]
  A --> D["EOF heredoc syntax"]
  D --> E["Successful multiline handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-pr-assistant.yml</strong><dd><code>Implement EOF syntax for multiline outputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude-pr-assistant.yml

<ul><li>Replace simple variable assignment with EOF heredoc syntax<br> <li> Wrap PR title and body output in multiline string blocks<br> <li> Add proper delimiter handling for GitHub Actions output</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/5/files#diff-0887ef6353f4a29e8df4b624c69315c57e6ca8d63137774fc1d2c0f522752fef">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use heredoc (<<EOF) for PR title/body outputs in the workflow to correctly handle multiline PR metadata.
> 
> - **Workflows**:
>   - Update `.github/workflows/claude-pr-assistant.yml` to write PR metadata outputs (`title`, `body`) to `GITHUB_OUTPUT` using heredoc `<<EOF` syntax to support multiline values and avoid parse errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5904855bd995d7af707a54fd32e9c325830c2623. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->