### PR TITLE
fix(workflow): close jq JSON in suggest mode; indent heredoc block

### DIFF
--- a/.github/workflows/claude-pr-assistant-v2-reusable.yml
+++ b/.github/workflows/claude-pr-assistant-v2-reusable.yml
@@ -357,7 +357,20 @@ jobs:
                     },
                     {
                       "type": "text",
-                      "text": "\n\nPR Diff:\n
+                      "text": "\n\nPR Diff:\n```\n"
+                    },
+                    {
+                      "type": "text",
+                      "text": $diff
+                    },
+                    {
+                      "type": "text",
+                      "text": "\n```"
+                    }
+                  ]
+                }
+              ]
+            }')
 
           RESP=$(curl -s https://api.anthropic.com/v1/messages \
             -H "content-type: application/json" \
@@ -634,15 +647,15 @@ jobs:
           
           # Build comment body with safe substitution
           BODY=$(cat <<'EOF'
-## 🤖 Claude Assistant - Apply Mode Complete
-
-Status: STATUS_PLACEHOLDER
-
-CHANGES_PLACEHOLDER
-
-RESULT_PLACEHOLDER
-EOF
-)
+          ## 🤖 Claude Assistant - Apply Mode Complete
+          
+          Status: STATUS_PLACEHOLDER
+          
+          CHANGES_PLACEHOLDER
+          
+          RESULT_PLACEHOLDER
+          EOF
+          )
           
           # Safe substitutions
           BODY="${BODY//STATUS_PLACEHOLDER/$STATUS}"

--- a/.github/workflows/claude-pr-assistant-v2-reusable.yml
+++ b/.github/workflows/claude-pr-assistant-v2-reusable.yml
@@ -646,15 +646,15 @@ jobs:
           COMMIT_SUMMARY="${{ steps.apply_commit.outputs.commit_summary }}"
           
           # Build comment body with safe substitution
-          BODY=$(cat <<'EOF'
-          ## 🤖 Claude Assistant - Apply Mode Complete
-          
-          Status: STATUS_PLACEHOLDER
-          
-          CHANGES_PLACEHOLDER
-          
-          RESULT_PLACEHOLDER
-          EOF
+          BODY=$(cat <<-'EOF'
+          	## 🤖 Claude Assistant - Apply Mode Complete
+          	
+          	Status: STATUS_PLACEHOLDER
+          	
+          	CHANGES_PLACEHOLDER
+          	
+          	RESULT_PLACEHOLDER
+          	EOF
           )
           
           # Safe substitutions


### PR DESCRIPTION
### **User description**
Summary
- Fix unclosed jq JSON payload in "Call LLM (suggest mode)" step (complete message body with fenced diff section and proper object closure).
- Indent heredoc content and terminator within the run: | block to satisfy YAML parsing (avoids multiline key error).

Validation
- Local YAML validation: python yaml.safe_load OK.
- File: .github/workflows/claude-pr-assistant-v2-reusable.yml

Risk & Rollback
- Low risk (syntax only). Rollback = revert this PR.

Notes
- No secrets/logging changes; preserves existing behavior except fixing runtime/parse errors.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix unclosed JSON payload in workflow jq command

- Correct YAML heredoc indentation for proper parsing

- Complete message body structure with proper object closure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Broken jq JSON"] --> B["Complete JSON structure"]
  C["Misaligned heredoc"] --> D["Properly indented YAML"]
  B --> E["Fixed workflow execution"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-pr-assistant-v2-reusable.yml</strong><dd><code>Fix JSON structure and YAML indentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude-pr-assistant-v2-reusable.yml

<ul><li>Complete truncated jq JSON payload with proper message structure<br> <li> Add missing closing brackets and proper diff formatting<br> <li> Fix heredoc block indentation to satisfy YAML parsing requirements<br> <li> Maintain existing functionality while resolving syntax errors</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/8/files#diff-81946c86f03e52d172e25a927fad300f0017e7e7224bb8f55d52bae6c02bbfcf">+23/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes the suggest-mode LLM request by completing the JSON and wrapping the diff in code fences; adjusts heredoc indentation for apply-mode comment.
> 
> - **Workflow `.github/workflows/claude-pr-assistant-v2-reusable.yml`**:
>   - **Suggest mode (LLM call)**:
>     - Completes JSON payload construction; injects `PR Diff` content and wraps it in triple backticks.
>   - **Apply mode (comment)**:
>     - Switches to indented, dash-escaped heredoc (`<<-'EOF'`) and aligns content/terminator for valid YAML parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f58868604c4f1688bc065b522f0ecb5d726a40c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->