### PR TITLE
fix: Remove problematic heredoc in Claude PR Assistant workflow

### DIFF
--- a/.github/workflows/claude-pr-assistant-v2-reusable.yml
+++ b/.github/workflows/claude-pr-assistant-v2-reusable.yml
@@ -299,40 +299,9 @@ jobs:
             exit 0
           fi
     
-          read -r -d '' PAYLOAD_TEMPLATE <<EOF
-          {
-            "model": "%s",
-            "max_tokens": 4096,
-            "temperature": %s,
-            "messages": [
-              {
-                "role": "user",
-                "content": [
-                  {
-                    "type": "text",
-                    "text": "You are a helpful code reviewer.\\nRules: no secrets in logs, least-privilege IAM, safe shell patterns, no destructive infra changes.\\n\\nUser request:\\n"
-                  },
-                  {
-                    "type": "text",
-                    "text": %s
-                  },
-                  {
-                    "type": "text",
-                    "text": "\\n\\nPR Diff:\\n\`\`\`\\n"
-                  },
-                  {
-                    "type": "text",
-                    "text": %s
-                  },
-                  {
-                    "type": "text",
-                    "text": "\\n\`\`\`"
-                  }
-                ]
-              }
-            ]
-          }
-          EOF
+          # Note: The read -r -d '' heredoc always returns exit code 1, which causes failure with set -e
+          # Since the PAYLOAD_TEMPLATE is not actually used (the real payload is built with jq below),
+          # we can safely remove this heredoc
 
           PAYLOAD=$(jq -n \
             --arg model "$MODEL" \


### PR DESCRIPTION
### **User description**
## Summary

This PR fixes the critical issue in the Claude PR Assistant v2 workflow that was causing failures with 'Process completed with exit code 1' in the 'Call LLM (suggest mode)' step.

## Problem

The workflow was using this pattern:
```bash
read -r -d '' PAYLOAD_TEMPLATE <<EOF
...
EOF
```

This bash idiom **always returns exit code 1** when it reaches EOF (even though it successfully reads the content). Combined with `set -euo pipefail`, this causes immediate script failure.

## Solution

Removed the problematic heredoc entirely. The `PAYLOAD_TEMPLATE` variable wasn't actually being used - the real payload is constructed with `jq` a few lines below.

## Testing

- ✅ YAML syntax validation passes
- ✅ The workflow should now run without exit code 1 errors

## Related Issues

- Fixes workflow run failure: https://github.com/merglbot-core/github/actions/runs/18416667355/job/52481835832

## Technical Background

The `read -r -d ''` command is designed to read until it encounters a delimiter (in this case, an empty delimiter). When it reaches EOF, it returns exit code 1 as a signal that EOF was reached rather than the delimiter. This is expected behavior but incompatible with `set -e`.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove problematic heredoc causing workflow exit code 1 failures

- Fix Claude PR Assistant v2 workflow script execution

- Clean up unused PAYLOAD_TEMPLATE variable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Heredoc with read -r -d ''"] -- "Always returns exit code 1" --> B["Script failure with set -e"]
  C["Remove unused heredoc"] -- "Fixes workflow" --> D["Successful execution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-pr-assistant-v2-reusable.yml</strong><dd><code>Remove problematic heredoc causing workflow failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude-pr-assistant-v2-reusable.yml

<ul><li>Removed problematic heredoc using <code>read -r -d ''</code> command<br> <li> Added explanatory comment about exit code 1 issue<br> <li> Cleaned up unused <code>PAYLOAD_TEMPLATE</code> variable<br> <li> Maintained existing <code>jq</code> payload construction logic</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/10/files#diff-81946c86f03e52d172e25a927fad300f0017e7e7224bb8f55d52bae6c02bbfcf">+3/-34</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the unused heredoc payload template from the Claude PR Assistant workflow to prevent set -e exit 1 failures, relying solely on the jq-built payload.
> 
> - **Workflows**:
>   - **Claude PR Assistant v2** (`.github/workflows/claude-pr-assistant-v2-reusable.yml`):
>     - Remove unused `read -r -d '' PAYLOAD_TEMPLATE <<EOF` heredoc in "Call LLM (suggest mode)" to avoid exit 1 under `set -e`.
>     - Keep payload construction via `jq`; add explanatory comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c27ce702789b750c94fd82dcea6a7fdd89c1b466. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->