### PR TITLE
fix: declare codeql workflow token alias

### DIFF
--- a/.github/workflows/reusable-codeql-analysis.yml
+++ b/.github/workflows/reusable-codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: '["javascript"]'
+    secrets:
+      CODEQL_TOKEN:
+        description: 'Run-scoped token forwarded by the caller (typically GITHUB_TOKEN)'
+        required: true
 
 jobs:
   analyze:
@@ -17,6 +21,8 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.CODEQL_TOKEN }}
 
     # Pre-matrix step to split the languages string into an array
     strategy:

--- a/.github/workflows/reusable-codeql-analysis.yml
+++ b/.github/workflows/reusable-codeql-analysis.yml
@@ -10,19 +10,15 @@ on:
         default: '["javascript"]'
     secrets:
       CODEQL_TOKEN:
-        description: 'Run-scoped token forwarded by the caller (typically GITHUB_TOKEN)'
-        required: true
+        description: 'Optional run-scoped token forwarded by the caller (defaults to auto GITHUB_TOKEN)'
+        required: false
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
     env:
-      GITHUB_TOKEN: ${{ secrets.CODEQL_TOKEN }}
+      CODEQL_AUTH_TOKEN: ${{ secrets.CODEQL_TOKEN || github.token }}
 
     # Pre-matrix step to split the languages string into an array
     strategy:
@@ -38,9 +34,12 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        token: ${{ env.CODEQL_AUTH_TOKEN }}
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
+      with:
+        token: ${{ env.CODEQL_AUTH_TOKEN }}


### PR DESCRIPTION
### **User description**
## Summary
- add a  secret to the reusable workflow_call contract
- export it to  env so downstream steps still work while callers can scope which token is provided

## Testing
-


___

### **PR Type**
Enhancement


___

### **Description**
- Add `CODEQL_TOKEN` secret to reusable workflow contract

- Export token to `GITHUB_TOKEN` environment variable

- Allow callers to scope token permissions independently


___

### Diagram Walkthrough


```mermaid
flowchart LR
  caller["Caller provides<br/>CODEQL_TOKEN secret"]
  workflow["Reusable workflow<br/>declares secret"]
  env["Maps to GITHUB_TOKEN<br/>environment variable"]
  steps["Downstream steps<br/>use GITHUB_TOKEN"]
  caller -- "passes secret" --> workflow
  workflow -- "exports as env" --> env
  env -- "available to" --> steps
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reusable-codeql-analysis.yml</strong><dd><code>Add CODEQL_TOKEN secret and environment mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-codeql-analysis.yml

<ul><li>Added <code>secrets</code> section to <code>workflow_call</code> with <code>CODEQL_TOKEN</code> parameter<br> <li> Declared <code>CODEQL_TOKEN</code> as required secret with descriptive <br>documentation<br> <li> Added <code>env</code> section to job that maps <code>GITHUB_TOKEN</code> to <br><code>secrets.CODEQL_TOKEN</code><br> <li> Enables downstream steps to use token while allowing callers to <br>control which token is provided</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/49/files#diff-ce51e01ea431aa15b53587a6c5523fad07b46bf66146ee9cbc2434b3102f673a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add optional CODEQL_TOKEN secret to the reusable CodeQL workflow and pass it to init/analyze via CODEQL_AUTH_TOKEN with fallback to GITHUB_TOKEN; remove explicit permissions.
> 
> - **CI/Workflows** (`.github/workflows/reusable-codeql-analysis.yml`):
>   - Add `workflow_call.secrets.CODEQL_TOKEN` (optional) and map to `env` as `CODEQL_AUTH_TOKEN` with fallback to `github.token`.
>   - Pass `CODEQL_AUTH_TOKEN` to `github/codeql-action` `init` and `analyze` steps via `with.token`.
>   - Remove job `permissions` block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba10535b881693ccd27361b233410c5fa08bcda2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->