### PR TITLE
fix: allow automated release without lockfile

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Detect dependency lockfile
         id: lockfile
         run: |
-          set -euo pipefail
+          set -eo pipefail
           if [ -f package-lock.json ]; then
             echo "manager=npm" >> $GITHUB_OUTPUT
             echo "path=package-lock.json" >> $GITHUB_OUTPUT

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -38,11 +38,37 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Setup Node
+      - name: Detect dependency lockfile
+        id: lockfile
+        run: |
+          set -euo pipefail
+          if [ -f package-lock.json ]; then
+            echo "manager=npm" >> $GITHUB_OUTPUT
+            echo "path=package-lock.json" >> $GITHUB_OUTPUT
+          elif [ -f npm-shrinkwrap.json ]; then
+            echo "manager=npm" >> $GITHUB_OUTPUT
+            echo "path=npm-shrinkwrap.json" >> $GITHUB_OUTPUT
+          elif [ -f yarn.lock ]; then
+            echo "manager=yarn" >> $GITHUB_OUTPUT
+            echo "path=yarn.lock" >> $GITHUB_OUTPUT
+          else
+            echo "manager=" >> $GITHUB_OUTPUT
+            echo "path=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Node (with cache)
+        if: steps.lockfile.outputs.manager != ''
         uses: actions/setup-node@v6
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: ${{ steps.lockfile.outputs.manager }}
+          cache-dependency-path: ${{ steps.lockfile.outputs.path }}
+
+      - name: Setup Node (no cache)
+        if: steps.lockfile.outputs.manager == ''
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/reusable-codeql-analysis.yml
+++ b/.github/workflows/reusable-codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: '["javascript"]'
+    secrets:
+      CODEQL_TOKEN:
+        description: 'Run-scoped token forwarded by the caller (typically GITHUB_TOKEN)'
+        required: true
 
 jobs:
   analyze:
@@ -17,6 +21,8 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.CODEQL_TOKEN }}
 
     # Pre-matrix step to split the languages string into an array
     strategy:

--- a/.github/workflows/reusable-codeql-analysis.yml
+++ b/.github/workflows/reusable-codeql-analysis.yml
@@ -10,19 +10,15 @@ on:
         default: '["javascript"]'
     secrets:
       CODEQL_TOKEN:
-        description: 'Run-scoped token forwarded by the caller (typically GITHUB_TOKEN)'
-        required: true
+        description: 'Optional run-scoped token forwarded by the caller (defaults to auto GITHUB_TOKEN)'
+        required: false
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
     env:
-      GITHUB_TOKEN: ${{ secrets.CODEQL_TOKEN }}
+      CODEQL_AUTH_TOKEN: ${{ secrets.CODEQL_TOKEN || github.token }}
 
     # Pre-matrix step to split the languages string into an array
     strategy:
@@ -38,9 +34,12 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        token: ${{ env.CODEQL_AUTH_TOKEN }}
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
+      with:
+        token: ${{ env.CODEQL_AUTH_TOKEN }}

--- a/.github/workflows/reusable-codeql-analysis.yml
+++ b/.github/workflows/reusable-codeql-analysis.yml
@@ -17,6 +17,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     env:
       CODEQL_AUTH_TOKEN: ${{ secrets.CODEQL_TOKEN || github.token }}
 


### PR DESCRIPTION
### **User description**
## Summary
- detect whether a dependency lockfile exists before enabling npm/yarn caching
- fall back to a cacheless node-setup path so the automated release workflow no longer fails when no lockfile is committed

## Testing
- workflow linted via


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Detect dependency lockfile presence before enabling npm/yarn caching

- Split Node setup into conditional cached and cacheless paths

- Make CodeQL token optional with fallback to GITHUB_TOKEN

- Add token parameter to CodeQL analysis workflow steps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Detect lockfile<br/>npm/yarn/shrinkwrap"] --> B{Lockfile<br/>exists?}
  B -->|Yes| C["Setup Node<br/>with cache"]
  B -->|No| D["Setup Node<br/>no cache"]
  C --> E["Install dependencies"]
  D --> E
  F["CodeQL Token"] --> G{Token<br/>provided?}
  G -->|Yes| H["Use provided token"]
  G -->|No| I["Use GITHUB_TOKEN"]
  H --> J["CodeQL Analysis"]
  I --> J
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>automated-release.yml</strong><dd><code>Conditional Node setup with lockfile detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/automated-release.yml

<ul><li>Added lockfile detection step that checks for package-lock.json, <br>npm-shrinkwrap.json, or yarn.lock<br> <li> Split Node setup into two conditional steps: one with cache when <br>lockfile exists, one without cache when missing<br> <li> Removed hardcoded npm cache configuration to support multiple package <br>managers</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/50/files#diff-c22c638874a55e79b484b69854297da43d12af91dbc6f3e5db8e7188d9544f68">+28/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reusable-codeql-analysis.yml</strong><dd><code>Make CodeQL token optional with fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-codeql-analysis.yml

<ul><li>Added optional CODEQL_TOKEN secret input to workflow_call <br>configuration<br> <li> Replaced explicit permissions block with environment variable using <br>token fallback logic<br> <li> Added token parameter to CodeQL init and analyze action steps<br> <li> Implemented fallback to github.token when CODEQL_TOKEN is not provided</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/50/files#diff-ce51e01ea431aa15b53587a6c5523fad07b46bf66146ee9cbc2434b3102f673a">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects dependency lockfiles to conditionally enable Node cache in automated release and adds explicit permissions with token fallback to the reusable CodeQL workflow.
> 
> - **CI Workflows**:
>   - **Automated Release (`.github/workflows/automated-release.yml`)**:
>     - Add lockfile detection to choose package manager and cache path (`npm`, `npm-shrinkwrap`, `yarn`).
>     - Split Node setup into cached vs. no-cache paths based on lockfile presence.
>   - **CodeQL Analysis (`.github/workflows/reusable-codeql-analysis.yml`)**:
>     - Add explicit `permissions` (contents, actions read; security-events write).
>     - Introduce `CODEQL_AUTH_TOKEN` env with fallback to `github.token`; pass token to init/analyze steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a21aa05c4280618c4606690aa55da21283417ecd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->