### PR TITLE
fix(ci): add allow_unauthenticated param + idempotent release tagging

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -150,10 +150,18 @@ jobs:
       - name: Create Git tag
         if: steps.version.outputs.skip != 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
+          VERSION="v${{ steps.version.outputs.version }}"
+          
+          # Check if tag already exists (idempotent)
+          if git tag -l "$VERSION" | grep -q "$VERSION"; then
+            echo "Tag $VERSION already exists, skipping tag creation (idempotent)"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag -a "$VERSION" -m "Release $VERSION"
+            git push origin "$VERSION"
+            echo "Tag $VERSION created and pushed"
+          fi
       
       - name: Create GitHub Release
         if: steps.version.outputs.skip != 'true'

--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -38,6 +38,11 @@ on:
         description: 'Newline-separated SECRET_NAME=secret-id:version'
         required: false
         type: string
+      allow_unauthenticated:
+        description: 'Allow unauthenticated access (use only for services behind IAP/Load Balancer with own auth)'
+        required: false
+        type: boolean
+        default: false
     secrets:
       GCP_WIF_PROVIDER:
         required: true
@@ -116,8 +121,14 @@ jobs:
             "--memory=1Gi"
             "--cpu=1"
             "--port=8080"
-            "--no-allow-unauthenticated"
           )
+
+          # Authentication flag (default: no-allow-unauthenticated for security)
+          if [ "${{ inputs.allow_unauthenticated }}" = "true" ]; then
+            gcloud_cmd+=("--allow-unauthenticated")
+          else
+            gcloud_cmd+=("--no-allow-unauthenticated")
+          fi
 
           if [ -n "${{ inputs.env_vars }}" ]; then
             gcloud_cmd+=("--set-env-vars=${{ inputs.env_vars }}")


### PR DESCRIPTION
### **User description**
## 🔧 Fixes

### 1. Deploy Workflow - startup_failure
**Problem:** merglbot-admin deploy workflow fails with `startup_failure` because it passes `allow_unauthenticated: true` to reusable workflow, but this parameter doesn't exist.

**Solution:**
- Added `allow_unauthenticated` as optional input (default: `false`)
- Deploy step now conditionally uses `--allow-unauthenticated` or `--no-allow-unauthenticated`
- Security: Default remains `--no-allow-unauthenticated` for safety

**Use case:** Only set `allow_unauthenticated: true` for services behind IAP/Load Balancer with their own authentication (like admin platform with OAuth).

### 2. Release Workflow - Idempotent Tag Creation
**Problem:** Release workflow fails with `fatal: tag already exists` when re-running after partial failure.

**Solution:**
- Added check before creating tag: `git tag -l` to detect existing tags
- If tag exists, skip creation and continue (idempotent behavior)
- If tag doesn't exist, create and push normally

## 🎯 Impact

- **Fixes:** 3x `startup_failure` in merglbot-admin deploy workflow
- **Fixes:** 2x `tag already exists` failures in github release workflow
- **Enables:** Successful deployment of admin platform to production
- **Enables:** Safe re-run of release workflow after partial failures

## 🔒 Security

✅ Default behavior unchanged: `--no-allow-unauthenticated`
✅ Explicit opt-in required for unauthenticated access
✅ Documented use cases in parameter description

## ✅ Acceptance Criteria

- [x] AC1: `allow_unauthenticated` parameter added with default `false`
- [x] AC2: Deploy step conditionally uses correct auth flag
- [x] AC3: Release workflow checks for existing tag before creation
- [x] AC4: Security: default remains `--no-allow-unauthenticated`
- [ ] AC5: CI checks pass (will verify after PR creation)

## 📝 Related

**Blocked PRs:**
- merglbot-core/merglbot-admin: will update `deploy-admin.yml` SHA reference after this PR merges

**Failed Runs:**
- https://github.com/merglbot-core/github/actions/runs/19230995297
- https://github.com/merglbot-core/github/actions/runs/19230985382
- https://github.com/merglbot-core/merglbot-admin/actions/runs/19228866107
- https://github.com/merglbot-core/merglbot-admin/actions/runs/19228863467
- https://github.com/merglbot-core/merglbot-admin/actions/runs/19228860283

## 🔄 Next Steps

1. ✅ Merge this PR
2. ⏭️ Update merglbot-admin `deploy-admin.yml` to use new commit SHA
3. ⏭️ Verify deploy workflow passes in merglbot-admin


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `allow_unauthenticated` optional input parameter to Cloud Run deployment workflow
  - Defaults to `false` for security
  - Conditionally applies `--allow-unauthenticated` or `--no-allow-unauthenticated` flag

- Make release workflow tag creation idempotent
  - Checks if tag already exists before creating
  - Skips creation if tag present, enabling safe workflow re-runs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Deploy Workflow"] -->|"allow_unauthenticated input"| B["Conditional Auth Flag"]
  B -->|"true"| C["--allow-unauthenticated"]
  B -->|"false"| D["--no-allow-unauthenticated"]
  E["Release Workflow"] -->|"Check tag exists"| F["Tag Creation Logic"]
  F -->|"exists"| G["Skip creation"]
  F -->|"not exists"| H["Create & push tag"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reusable-deploy-cloud-run.yml</strong><dd><code>Add conditional authentication flag parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-deploy-cloud-run.yml

<ul><li>Added <code>allow_unauthenticated</code> as optional boolean input parameter <br>(default: <code>false</code>)<br> <li> Moved authentication flag from hardcoded <code>--no-allow-unauthenticated</code> to <br>conditional logic<br> <li> Deploy step now dynamically selects auth flag based on input parameter <br>value<br> <li> Maintains security by defaulting to <code>--no-allow-unauthenticated</code></ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/54/files#diff-fea78e61de176c6d05db9c342fb74dd2c611f80c81dd7e0739fff70d31fa1423">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>automated-release.yml</strong><dd><code>Make tag creation idempotent with existence check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/automated-release.yml

<ul><li>Added idempotent tag creation check using <code>git tag -l</code> before tag <br>creation<br> <li> Skips tag creation and push if tag already exists<br> <li> Adds informative logging for both skip and creation scenarios<br> <li> Enables safe re-runs of release workflow after partial failures</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/54/files#diff-c22c638874a55e79b484b69854297da43d12af91dbc6f3e5db8e7188d9544f68">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes release tagging idempotent and adds an `allow_unauthenticated` input to the Cloud Run reusable deploy workflow.
> 
> - **CI Workflows**
>   - **Release** (`.github/workflows/automated-release.yml`):
>     - Create tag step now idempotent: checks for existing `v<version>` tag before tagging/pushing; sets `VERSION` var and configures bot identity only when creating.
>   - **Cloud Run Deploy** (`.github/workflows/reusable-deploy-cloud-run.yml`):
>     - Adds `inputs.allow_unauthenticated` (boolean, default `false`).
>     - Deploy step conditionally passes `--allow-unauthenticated` or `--no-allow-unauthenticated` instead of always denying unauthenticated access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cf37df34bf8bd0ff65a90e510bfc895099845b4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->