### PR TITLE
fix(ci): make GitHub Release creation idempotent

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -168,12 +168,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${{ steps.version.outputs.version }}" \
-            --title "Release v${{ steps.version.outputs.version }}" \
-            --notes "${{ steps.changelog.outputs.changelog }}" \
-            --verify-tag \
-            --latest
-          # If you want to support draft/prerelease, add --draft or --prerelease flags as needed
+          VERSION="v${{ steps.version.outputs.version }}"
+          
+          # Check if release already exists (idempotent)
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists, skipping release creation (idempotent)"
+          else
+            gh release create "$VERSION" \
+              --title "Release $VERSION" \
+              --notes "${{ steps.changelog.outputs.changelog }}" \
+              --verify-tag \
+              --latest
+            echo "Release $VERSION created"
+          fi
       
       - name: Update GITHUB_STEP_SUMMARY
         if: always()


### PR DESCRIPTION
### **User description**
## 🔧 Fix

**Problem:** Release workflow fails with `Release.tag_name already exists` when re-running after partial failure.

**Failed run:** https://github.com/merglbot-core/github/actions/runs/19232451510

**Root cause:** PR#54 made tag creation idempotent, but GitHub Release creation was not idempotent.

## 💡 Solution

Add check before creating GitHub Release:
```bash
if gh release view "$VERSION" >/dev/null 2>&1; then
  echo "Release already exists, skipping (idempotent)"
else
  gh release create "$VERSION" ...
fi
```

## 🎯 Impact

**Before:**
- Tag creation: ✅ Idempotent (fixed in PR#54)
- Release creation: ❌ Not idempotent → fails on re-run

**After:**
- Tag creation: ✅ Idempotent
- Release creation: ✅ Idempotent

## ✅ Acceptance Criteria

- [x] Check if GitHub Release exists before creating
- [x] Skip creation if exists (log message)
- [x] Create release if doesn't exist
- [ ] CI checks pass (will verify after PR creation)
- [ ] Re-run of failed workflow succeeds

## 📝 Related

- Builds on: #54 (tag idempotence)
- Fixes: https://github.com/merglbot-core/github/actions/runs/19232451510

## 🔗 SSOT References

- [WARP GitHub Actions Global Rules](https://github.com/merglbot-public/docs/blob/main/WARP_GITHUB_ACTIONS_GLOBAL_RULES.md)
- [CI/CD Standards](https://github.com/merglbot-public/docs/blob/main/WARP_GITHUB_ACTIONS_REUSABLE_WORKFLOWS.md)


___

### **PR Type**
Bug fix


___

### **Description**
- Make GitHub Release creation idempotent by checking existence first

- Prevents 'Release.tag_name already exists' error on workflow re-runs

- Complements PR#54 tag idempotence fix for complete release workflow reliability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release workflow triggered"] --> B["Check if release exists"]
  B -->|"Release exists"| C["Skip creation - idempotent"]
  B -->|"Release not found"| D["Create new release"]
  C --> E["Workflow succeeds"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>automated-release.yml</strong><dd><code>Add idempotent GitHub Release creation check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/automated-release.yml

<ul><li>Added idempotency check using <code>gh release view</code> before creating release<br> <li> Wraps release creation in conditional block to skip if already exists<br> <li> Adds informative log messages for both skip and creation scenarios<br> <li> Stores version in variable for cleaner code and reusability</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/55/files#diff-c22c638874a55e79b484b69854297da43d12af91dbc6f3e5db8e7188d9544f68">+13/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make GitHub Release creation idempotent in the automated release workflow by skipping creation if the release already exists.
> 
> - **CI/CD (GitHub Actions)**
>   - Update `./.github/workflows/automated-release.yml` to guard `gh release create` with `gh release view "$VERSION"`; skip creation if it exists, otherwise create.
>   - Standardize usage of `VERSION="v
> diff
>  steps.version.outputs.version"` and add clear status logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33c689ce45cda2eeffd77c827c3ebe70d5b99246. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->