### PR TITLE
fix: avoid 'Argument list too long' error in jq payload build

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
+++ b/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
@@ -288,26 +288,25 @@ jobs:
           MODEL='${{ steps.cfg.outputs.model }}'
           TEMP='${{ steps.cfg.outputs.temperature }}'
     
-          # Escape for JSON
+          # Truncate inputs to avoid "Argument list too long" error
           COMMENT_SAFE=$(printf "%s" "$COMMENT" | head -c "$MAX_COMMENT_CHARS")
-          COMMENT_JSON=$(printf "%s" "$COMMENT_SAFE" | jq -R -s '.')
           DIFF_CONTENT=$(head -n "$MAX_DIFF_LINES" pr_diff.txt)
-          DIFF_JSON=$(printf "%s" "$DIFF_CONTENT" | jq -R -s '.')
 
           if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
             printf "LLM not configured; posting diff summary only." > claude_response.txt
             exit 0
           fi
     
-          # Note: The read -r -d '' heredoc always returns exit code 1, which causes failure with set -e
-          # Since the PAYLOAD_TEMPLATE is not actually used (the real payload is built with jq below),
-          # we can safely remove this heredoc
-
+          # Write inputs to temp files to avoid command line length limits
+          printf "%s" "$COMMENT_SAFE" > /tmp/comment.txt
+          printf "%s" "$DIFF_CONTENT" > /tmp/diff.txt
+          
+          # Build payload using file inputs (avoids "Argument list too long")
           PAYLOAD=$(jq -n \
             --arg model "$MODEL" \
             --arg temp "$TEMP" \
-            --arg comment "$COMMENT_JSON" \
-            --arg diff "$DIFF_JSON" \
+            --rawfile comment /tmp/comment.txt \
+            --rawfile diff /tmp/diff.txt \
             '{
               "model": $model,
               "max_tokens": 4096,


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
## 🐛 Critical Bug Fix

**Failing run**: https://github.com/merglbot-public/docs/actions/runs/19614871810

**Error**:
```
/usr/bin/jq: Argument list too long
Error: Process completed with exit code 126.
```

---

## 🎯 Root Cause

**Issue**: Large PR diffs cause command line argument length to exceed system limits

**Technical details**:
- `jq -n --arg` passes values as command line arguments
- Linux has `ARG_MAX` limit (~2MB on most systems, but varies)
- Large diffs (e.g., PR #68: consolidation with deletions) exceed this limit
- Error: `/usr/bin/jq: Argument list too long`

**Before** (BROKEN):
```bash
COMMENT_JSON=$(printf "%s" "$COMMENT_SAFE" | jq -R -s '.')
DIFF_JSON=$(printf "%s" "$DIFF_CONTENT" | jq -R -s '.')
PAYLOAD=$(jq -n --arg comment "$COMMENT_JSON" --arg diff "$DIFF_JSON" ...)
# ❌ Error when diff > ~100KB
```

---

## ✅ Solution

**Use file-based input** instead of command line arguments

**After** (FIXED):
```bash
printf "%s" "$COMMENT_SAFE" > /tmp/comment.txt
printf "%s" "$DIFF_CONTENT" > /tmp/diff.txt
PAYLOAD=$(jq -n --rawfile comment /tmp/comment.txt --rawfile diff /tmp/diff.txt ...)
# ✅ Works with any size diff (up to MAX_DIFF_LINES limit)
```

**Why this works**:
- `--rawfile` reads from file (no command line limit)
- File I/O has no ARG_MAX constraint
- Simpler (no double JSON escaping)
- More reliable for large PRs

---

## 📊 Impact

**Before**:
- ❌ Large PRs fail with "Argument list too long"
- ❌ Consolidation PRs (deletions) always fail
- ❌ No workaround available

**After**:
- ✅ Works with any size PR
- ✅ Only limited by MAX_DIFF_LINES (8000 lines)
- ✅ Simpler code (no double escaping)

---

## 🧪 Testing

**Test case**: PR #68 in merglbot-public/docs
- Large consolidation PR (deletions)
- Previously failed with "Argument list too long"
- Will re-run workflow after this fix is merged

**Verification**:
```bash
# After merge, update SHA in docs repo
cd merglbot-public/docs
# Update .github/workflows/merglbot-pr-review.yml
# Change SHA to this commit
# Re-run workflow on PR #68
```

---

## 🎓 Technical Details

### ARG_MAX Limits

**Linux**:
- Typical: 2MB (`getconf ARG_MAX`)
- Includes environment variables
- Shared across all args

**GitHub Actions**:
- Ubuntu runners: ~2MB
- Large diffs easily exceed this

### jq --rawfile vs --arg

**`--arg`** (command line):
- Passes value as command line argument
- Subject to ARG_MAX limit
- Double escaping (if value is already JSON)

**`--rawfile`** (file input):
- Reads from file
- No command line limit
- No escaping issues
- Recommended for large inputs

---

## 🔗 Related

**Triggered by**: merglbot-public/docs PR #68  
**Error run**: https://github.com/merglbot-public/docs/actions/runs/19614871810  
**Affects**: All repos using merglbot-pr-assistant-v1-reusable.yml

---

**Priority**: CRITICAL - Blocks large PR reviews


___

### **PR Type**
Bug fix


___

### **Description**
- Replace command-line argument passing with file-based input to jq

- Eliminates "Argument list too long" error for large PR diffs

- Uses `--rawfile` instead of `--arg` to bypass ARG_MAX limits

- Removes unnecessary double JSON escaping of diff content


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Large PR Diff"] -->|"Previously: --arg"| B["Command Line Args"]
  B -->|"Exceeds ARG_MAX"| C["❌ Argument list too long"]
  A -->|"Now: --rawfile"| D["Temp Files"]
  D -->|"No limit"| E["✅ Payload built successfully"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v1-reusable.yml</strong><dd><code>Replace jq --arg with --rawfile for large inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v1-reusable.yml

<ul><li>Replaced <code>--arg</code> with <code>--rawfile</code> for jq payload construction<br> <li> Write <code>COMMENT_SAFE</code> and <code>DIFF_CONTENT</code> to temporary files instead of <br>passing as command-line arguments<br> <li> Removed intermediate JSON escaping steps (<code>COMMENT_JSON</code> and <code>DIFF_JSON</code> <br>variables)<br> <li> Removed unused heredoc template comment that caused exit code issues</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/65/files#diff-59551c1918a84cc9a2ba1896c4eccc3fa9039a3183aff9899c858eb2310cd723">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the suggest-mode LLM call to build the jq payload from temp files with --rawfile (and input truncation), preventing "Argument list too long" failures.
> 
> - **Workflow** (`.github/workflows/merglbot-pr-assistant-v1-reusable.yml`):
>   - **LLM call (suggest mode)**:
>     - Truncates inputs (`MAX_COMMENT_CHARS`, `MAX_DIFF_LINES`) and writes to `/tmp/comment.txt` and `/tmp/diff.txt`.
>     - Builds JSON payload with `jq --rawfile` for `comment` and `diff` instead of `--arg`.
>     - Removes JSON-escaping intermediates (`COMMENT_JSON`, `DIFF_JSON`) and unused heredoc remnants.
>     - Mitigates command line length limits that caused "Argument list too long" errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbe43365cafbe667713e3944e755a1455df3c057. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->