### PR TITLE
fix: avoid 'Argument list too long' error in curl command

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
+++ b/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
@@ -340,11 +340,14 @@ jobs:
               ]
             }')
 
+          # Write payload to file to avoid "Argument list too long" with curl -d
+          printf "%s" "$PAYLOAD" > /tmp/payload.json
+          
           RESP=$(curl -s https://api.anthropic.com/v1/messages \
             -H "content-type: application/json" \
             -H "x-api-key: $ANTHROPIC_API_KEY" \
             -H "anthropic-version: ${ANTHROPIC_API_VERSION:-2023-06-01}" \
-            -d "$PAYLOAD")
+            -d @/tmp/payload.json)
     
           printf "%s" "$RESP" > claude_api_suggest.json
           echo "$RESP" | jq -r '.content[0].text // ""' > claude_response.txt
@@ -489,11 +492,14 @@ jobs:
               ]
             }')
 
+          # Write payload to file to avoid "Argument list too long" with curl -d
+          printf "%s" "$PAYLOAD" > /tmp/payload_apply.json
+          
           RESP=$(curl -s https://api.anthropic.com/v1/messages \
             -H "content-type: application/json" \
             -H "x-api-key: $ANTHROPIC_API_KEY" \
             -H "anthropic-version: ${ANTHROPIC_API_VERSION:-2023-06-01}" \
-            -d "$PAYLOAD")
+            -d @/tmp/payload_apply.json)
           
           # Extract patch content from LLM response
           echo "$RESP" | jq -r '.content[0].text // .content // empty' > patch_raw.txt


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
## 🐛 Critical Bug Fix (Part 2)

**Previous fix**: PR #65 (jq --rawfile)  
**Still failing**: https://github.com/merglbot-public/docs/actions/runs/19616351209

**New error**:
```
/usr/bin/curl: Argument list too long
Error: Process completed with exit code 126.
```

---

## 🎯 Root Cause

**Issue**: Even after fixing jq, curl still hits ARG_MAX limit

**Why**:
- PR #65 fixed jq (use --rawfile instead of --arg) ✅
- But PAYLOAD is still passed to curl as command line arg ❌
- Large payloads (JSON with diff) exceed ARG_MAX
- `curl -d "$PAYLOAD"` → Argument list too long

---

## ✅ Solution

**Use file-based input for curl**

**Before** (BROKEN):
```bash
PAYLOAD=$(jq -n --rawfile comment /tmp/comment.txt --rawfile diff /tmp/diff.txt '{...}')
curl -d "$PAYLOAD" https://api.anthropic.com/v1/messages
# ❌ Error: /usr/bin/curl: Argument list too long
```

**After** (FIXED):
```bash
PAYLOAD=$(jq -n --rawfile comment /tmp/comment.txt --rawfile diff /tmp/diff.txt '{...}')
printf "%s" "$PAYLOAD" > /tmp/payload.json
curl -d @/tmp/payload.json https://api.anthropic.com/v1/messages
# ✅ Works with any size payload
```

**Why this works**:
- `curl -d @file` reads from file (no command line limit)
- File I/O has no ARG_MAX constraint
- Completes the fix from PR #65

---

## 📊 Impact

**Before** (after PR #65):
- ✅ jq works (no "Argument list too long")
- ❌ curl fails (still hits ARG_MAX)
- ❌ Large PRs still broken

**After** (this PR):
- ✅ jq works (file-based input)
- ✅ curl works (file-based input)
- ✅ Large PRs fully supported

---

## 🔧 Changes

**Two curl calls fixed**:
1. **Suggest mode**: `/tmp/payload.json`
2. **Apply mode**: `/tmp/payload_apply.json` (different file)

**Pattern**:
```bash
# Build payload with jq (already uses files from PR #65)
PAYLOAD=$(jq -n --rawfile ... '{...}')

# Write to temp file
printf "%s" "$PAYLOAD" > /tmp/payload.json

# Use file with curl
curl -d @/tmp/payload.json ...
```

---

## 🧪 Testing

**Test case**: PR #68 in merglbot-public/docs
- Large consolidation PR
- Failed with jq error (fixed in PR #65)
- Failed with curl error (will fix with this PR)

**Verification**:
```bash
# After merge, update SHA in docs repo
# Re-run workflow on PR #68
# Should succeed this time
```

---

## 🔗 Related

**Part 1**: PR #65 (jq --rawfile) ✅  
**Part 2**: THIS PR (curl -d @file) ⏳  
**Triggered by**: merglbot-public/docs PR #68  
**Error run**: https://github.com/merglbot-public/docs/actions/runs/19616351209

---

**Priority**: CRITICAL - Completes fix for large PR reviews


___

### **PR Type**
Bug fix


___

### **Description**
- Avoid "Argument list too long" error by using file-based curl input

- Write JSON payload to temporary files before passing to curl

- Use `curl -d @file` instead of `curl -d "$PAYLOAD"` syntax

- Completes fix from PR #65 for handling large PR payloads


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build PAYLOAD<br/>with jq"] --> B["Write to<br/>temp file"]
  B --> C["curl -d @file<br/>instead of<br/>curl -d PAYLOAD"]
  C --> D["No ARG_MAX<br/>limit exceeded"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v1-reusable.yml</strong><dd><code>Replace command-line payload args with file-based curl input</code></dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v1-reusable.yml

<ul><li>Added file-based payload handling in suggest mode (line ~344): write <br><code>$PAYLOAD</code> to <code>/tmp/payload.json</code> before curl<br> <li> Changed suggest mode curl command to use <code>-d @/tmp/payload.json</code> instead <br>of <code>-d "$PAYLOAD"</code><br> <li> Added file-based payload handling in apply mode (line ~496): write <br><code>$PAYLOAD</code> to <code>/tmp/payload_apply.json</code> before curl<br> <li> Changed apply mode curl command to use <code>-d @/tmp/payload_apply.json</code> <br>instead of <code>-d "$PAYLOAD"</code></ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/66/files#diff-59551c1918a84cc9a2ba1896c4eccc3fa9039a3183aff9899c858eb2310cd723">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch curl -d usage to read JSON payloads from temp files to prevent "Argument list too long" errors in suggest/apply modes.
> 
> - **GitHub Actions workflow** (`.github/workflows/merglbot-pr-assistant-v1-reusable.yml`):
>   - Use file-based payloads for Anthropic API calls to avoid command-line length limits:
>     - Suggest mode: write `PAYLOAD` to `/tmp/payload.json` and call `curl -d @/tmp/payload.json`.
>     - Apply modes: write `PAYLOAD` to `/tmp/payload_apply.json` and call `curl -d @/tmp/payload_apply.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09296aecc067bba3eb335c46d948847e921c1cc2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->