### PR TITLE
ci: update pr assistant to dual openai/claude

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
+++ b/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
@@ -18,11 +18,31 @@ on:
         required: false
         type: string
         default: 'Sonnet 4.5 (doporučeno)'
+      openai_model:
+        description: 'OpenAI model (default: gpt-4.1-mini)'
+        required: false
+        type: string
+        default: 'gpt-4.1-mini'
       temperature:
         description: 'Sampling temperature (0.0-1.0)'
         required: false
         type: string
         default: '0.2'
+      openai_temperature:
+        description: 'OpenAI sampling temperature (0.0-1.0)'
+        required: false
+        type: string
+        default: '0.2'
+      openai_max_tokens:
+        description: 'OpenAI max_tokens for responses'
+        required: false
+        type: string
+        default: '4096'
+      enable_openai:
+        description: 'Enable OpenAI review/patch calls'
+        required: false
+        type: string
+        default: 'true'
       run_mode:
         description: 'Run mode: suggest (comments), apply-suggestions (review suggestions), apply (commit & push)'
         required: false
@@ -38,6 +58,11 @@ on:
         required: false
         type: string
         default: '800'
+      patch_provider:
+        description: 'Which model generates patches (claude|openai)'
+        required: false
+        type: string
+        default: 'claude'
       confirm:
         description: 'For apply mode: type "apply" to confirm'
         required: false
@@ -46,6 +71,8 @@ on:
       ANTHROPIC_API_KEY:
         required: true
       GH_TOKEN:
+        required: false
+      OPENAI_API_KEY:
         required: false
 
   workflow_dispatch:
@@ -75,11 +102,36 @@ on:
           - Sonnet 3.5 (stable)
           - Sonnet 3.5 (legacy)
           - Haiku 3.0
+      openai_model:
+        description: 'OpenAI model'
+        required: false
+        type: choice
+        default: 'gpt-4.1-mini'
+        options:
+          - 'gpt-4.1-mini'
+          - 'gpt-4.1'
+          - 'o4-mini'
+          - 'o4'
       temperature:
         description: 'Teplota vzorkování (0.0-1.0, nižší = konzervativnější odpovědi)'
         required: false
         type: number
         default: 0.2
+      openai_temperature:
+        description: 'Teplota pro OpenAI (0.0-1.0)'
+        required: false
+        type: number
+        default: 0.2
+      openai_max_tokens:
+        description: 'OpenAI max_tokens'
+        required: false
+        type: number
+        default: 4096
+      enable_openai:
+        description: 'Povolit OpenAI review/patch'
+        required: false
+        type: boolean
+        default: true
       run_mode:
         description: 'Režim běhu: suggest (komentáře), apply-suggestions (review návrhy), apply (commit & push)'
         required: true
@@ -99,6 +151,14 @@ on:
         required: false
         type: number
         default: 800
+      patch_provider:
+        description: 'Zdroj patchů (claude|openai)'
+        required: false
+        type: choice
+        default: claude
+        options:
+          - claude
+          - openai
       confirm:
         description: 'Pouze pro apply režim: napiš "apply" pro povolení commit & push'
         required: false
@@ -228,11 +288,64 @@ jobs:
           json.dump(comments, sys.stdout)
           PY
 
+      - name: Build review context (PR body, bugbots, files)
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          
+          # Fetch metadata
+          gh pr view "$PR_NUMBER" --json title,body,url,headRefName,baseRefName,author > pr_meta.json
+          gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > files.txt || true
+          gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.author.login | contains("bot")) | "- " + (.author.login) + ": " + (.body | gsub("\\r"; "") | gsub("\\n"; " ") | .[0:500])' > bugbot.txt || true
+          
+          PR_TITLE=$(jq -r '.title // ""' pr_meta.json)
+          PR_BODY=$(jq -r '.body // ""' pr_meta.json | head -c 12000)
+          PR_URL=$(jq -r '.url // ""' pr_meta.json)
+          HEAD=$(jq -r '.headRefName // ""' pr_meta.json)
+          BASE=$(jq -r '.baseRefName // ""' pr_meta.json)
+          AUTHOR=$(jq -r '.author.login // ""' pr_meta.json)
+          
+          {
+            echo "# PR Kontext"
+            echo "Title: $PR_TITLE"
+            echo "URL: $PR_URL"
+            echo "Author: $AUTHOR"
+            echo "Head: $HEAD -> Base: $BASE"
+            echo
+            echo "## PR Body"
+            printf "%s\n" "$PR_BODY"
+            echo
+            echo "## Bugbot komentáře"
+            if [ -s bugbot.txt ]; then
+              head -n 200 bugbot.txt
+            else
+              echo "(žádné bot komentáře)"
+            fi
+            echo
+            echo "## Seznam souborů"
+            if [ -s files.txt ]; then
+              head -n 200 files.txt
+            else
+              echo "(neznámé)"
+            fi
+          } > context.txt
+
+          # Trim context file for safety
+          head -c 120000 context.txt > context.txt.trim && mv context.txt.trim context.txt
+          echo "context_file=$PWD/context.txt" >> "$GITHUB_OUTPUT"
+
       - name: Map model name to API identifier
         id: cfg
         env:
           MODEL_INPUT: ${{ inputs.model }}
           TEMP: ${{ inputs.temperature }}
+          OPENAI_MODEL_INPUT: ${{ inputs.openai_model }}
+          OPENAI_TEMP: ${{ inputs.openai_temperature }}
+          OPENAI_MAX: ${{ inputs.openai_max_tokens }}
+          PATCH_PROVIDER_INPUT: ${{ inputs.patch_provider }}
           ALLOWED: ${{ inputs.allowed_paths }}
           MAX: ${{ inputs.max_changed_lines }}
         run: |
@@ -251,13 +364,31 @@ jobs:
             "Haiku 3.0")                MODEL='claude-3-haiku-20240307' ;;
             *)                          MODEL='claude-sonnet-4-5-20250929' ;;  # safe fallback
           esac
+
+          case "${OPENAI_MODEL_INPUT:-}" in
+            "gpt-4.1")       OPENAI_MODEL='gpt-4.1' ;;
+            "o4")            OPENAI_MODEL='o4' ;;
+            "o4-mini")       OPENAI_MODEL='o4-mini' ;;
+            *)               OPENAI_MODEL='gpt-4.1-mini' ;;
+          esac
           
           [ -z "${TEMP:-}" ] && TEMP='0.2'
+          [ -z "${OPENAI_TEMP:-}" ] && OPENAI_TEMP='0.2'
+          [ -z "${OPENAI_MAX:-}" ] && OPENAI_MAX='4096'
           [ -z "${ALLOWED:-}" ] && ALLOWED='**'
           [ -z "${MAX:-}" ] && MAX='800'
+
+          PATCH_PROVIDER=$(printf "%s" "${PATCH_PROVIDER_INPUT:-claude}" | tr '[:upper:]' '[:lower:]')
+          if [ "$PATCH_PROVIDER" != "openai" ]; then
+            PATCH_PROVIDER="claude"
+          fi
           
           echo "model=$MODEL" >> "$GITHUB_OUTPUT"
           echo "temperature=$TEMP" >> "$GITHUB_OUTPUT"
+          echo "openai_model=$OPENAI_MODEL" >> "$GITHUB_OUTPUT"
+          echo "openai_temperature=$OPENAI_TEMP" >> "$GITHUB_OUTPUT"
+          echo "openai_max_tokens=$OPENAI_MAX" >> "$GITHUB_OUTPUT"
+          echo "patch_provider=$PATCH_PROVIDER" >> "$GITHUB_OUTPUT"
           echo "$ALLOWED" > allowed.txt
           echo "$MAX" > max.txt
 
@@ -283,8 +414,10 @@ jobs:
           # Named constants for input size limits
           MAX_COMMENT_CHARS=20000
           MAX_DIFF_LINES=8000
+          MAX_CONTEXT_CHARS=120000
           
           COMMENT=$(cat '${{ steps.parse.outputs.prompt_file }}')
+          CONTEXT=$(cat '${{ steps.context.outputs.context_file }}' | head -c "$MAX_CONTEXT_CHARS")
           MODEL='${{ steps.cfg.outputs.model }}'
           TEMP='${{ steps.cfg.outputs.temperature }}'
     
@@ -306,6 +439,7 @@ jobs:
             --arg model "$MODEL" \
             --arg temp "$TEMP" \
             --rawfile comment /tmp/comment.txt \
+            --rawfile context "${{ steps.context.outputs.context_file }}" \
             --rawfile diff /tmp/diff.txt \
             '{
               "model": $model,
@@ -322,6 +456,18 @@ jobs:
                     {
                       "type": "text",
                       "text": $comment
+                    },
+                    {
+                      "type": "text",
+                      "text": "\n\nPR Context:\n```\n"
+                    },
+                    {
+                      "type": "text",
+                      "text": $context
+                    },
+                    {
+                      "type": "text",
+                      "text": "\n```"
                     },
                     {
                       "type": "text",
@@ -352,6 +498,68 @@ jobs:
           printf "%s" "$RESP" > claude_api_suggest.json
           echo "$RESP" | jq -r '.content[0].text // ""' > claude_response.txt
 
+      - name: Call OpenAI (suggest mode)
+        if: steps.parse.outputs.run_mode == 'suggest' && inputs.enable_openai != 'false' && inputs.enable_openai != '0'
+        id: call_openai_suggest
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          MAX_COMMENT_CHARS=20000
+          MAX_DIFF_LINES=8000
+          MAX_CONTEXT_CHARS=120000
+          
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "OpenAI API key missing; skipping OpenAI review."
+            : > openai_response.txt
+            exit 0
+          fi
+
+          COMMENT=$(cat '${{ steps.parse.outputs.prompt_file }}')
+          CONTEXT=$(cat '${{ steps.context.outputs.context_file }}' | head -c "$MAX_CONTEXT_CHARS")
+          MODEL='${{ steps.cfg.outputs.openai_model }}'
+          TEMP='${{ steps.cfg.outputs.openai_temperature }}'
+          MAXTOK='${{ steps.cfg.outputs.openai_max_tokens }}'
+    
+          COMMENT_SAFE=$(printf "%s" "$COMMENT" | head -c "$MAX_COMMENT_CHARS")
+          DIFF_CONTENT=$(head -n "$MAX_DIFF_LINES" pr_diff.txt)
+
+          printf "%s" "$COMMENT_SAFE" > /tmp/comment.txt
+          printf "%s" "$CONTEXT" > /tmp/context.txt
+          printf "%s" "$DIFF_CONTENT" > /tmp/diff.txt
+
+          PAYLOAD=$(jq -n \
+            --arg model "$MODEL" \
+            --arg temp "$TEMP" \
+            --arg max_tok "$MAXTOK" \
+            --rawfile comment /tmp/comment.txt \
+            --rawfile context /tmp/context.txt \
+            --rawfile diff /tmp/diff.txt \
+            '{
+              "model": $model,
+              "temperature": ($temp | tonumber),
+              "max_tokens": ($max_tok | tonumber),
+              "messages": [
+                {
+                  "role": "system",
+                  "content": "You are a helpful code reviewer. Rules: no secrets in logs, least-privilege IAM, safe shell patterns, no destructive infra changes."
+                },
+                {
+                  "role": "user",
+                  "content": ("User request:\n" + $comment + "\n\nPR Context:\n" + $context + "\n\nPR Diff:\n```\n" + $diff + "\n```")
+                }
+              ]
+            }')
+
+          printf "%s" "$PAYLOAD" > /tmp/openai_payload.json
+
+          RESP=$(curl -s https://api.openai.com/v1/chat/completions \
+            -H "content-type: application/json" \
+            -H "authorization: Bearer $OPENAI_API_KEY" \
+            -d @/tmp/openai_payload.json)
+          
+          printf "%s" "$RESP" | jq -r '.choices[0].message.content // ""' > openai_response.txt
+
       - name: Post comment (suggest mode)
         if: steps.parse.outputs.run_mode == 'suggest'
         env:
@@ -360,7 +568,12 @@ jobs:
           set -euo pipefail
           PR_NUMBER="${{ steps.parse.outputs.pr_number }}"
           
-          if [ ! -s claude_response.txt ]; then
+          CLAUDE_BODY=""
+          OPENAI_BODY=""
+          [ -s claude_response.txt ] && CLAUDE_BODY=$(cat claude_response.txt)
+          [ -s openai_response.txt ] && OPENAI_BODY=$(cat openai_response.txt)
+
+          if [ -z "$CLAUDE_BODY" ] && [ -z "$OPENAI_BODY" ]; then
             {
               echo "## 🤖 Merglbot PR Assistant"
               echo
@@ -370,8 +583,18 @@ jobs:
             {
               echo "## 🤖 Merglbot PR Assistant"
               echo
-              cat claude_response.txt
-              echo
+              if [ -n "$CLAUDE_BODY" ]; then
+                echo "### Claude"
+                echo
+                echo "$CLAUDE_BODY"
+                echo
+              fi
+              if [ -n "$OPENAI_BODY" ]; then
+                echo "### OpenAI"
+                echo
+                echo "$OPENAI_BODY"
+                echo
+              fi
               echo "---"
               echo "*AI-generated suggestions. Please review before applying.*"
             } > comment_body.md
@@ -419,8 +642,8 @@ jobs:
           echo "${{ inputs.allowed_paths }}" > allowed.txt
           echo "${{ inputs.max_changed_lines }}" > max.txt
 
-      - name: Ask LLM for unified patch
-        if: steps.parse.outputs.run_mode != 'suggest'
+      - name: Ask LLM for unified patch (Claude)
+        if: steps.parse.outputs.run_mode != 'suggest' && steps.cfg.outputs.patch_provider == 'claude'
         id: ask
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -505,6 +728,89 @@ jobs:
           echo "$RESP" | jq -r '.content[0].text // .content // empty' > patch_raw.txt
   
           # Strip markdown code fences if present
+          awk 'BEGIN{in=1} /^```/{in=!in; next} {if(in) print}' patch_raw.txt > patch.diff || true
+
+      - name: Ask OpenAI for unified patch
+        if: steps.parse.outputs.run_mode != 'suggest' && steps.cfg.outputs.patch_provider == 'openai' && inputs.enable_openai != 'false' && inputs.enable_openai != '0'
+        id: ask_openai
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          MAX_DIFF_LINES=8000
+          MAX_DIFF_CHARS=350000
+          MODEL='${{ steps.cfg.outputs.openai_model }}'
+          TEMP='${{ steps.cfg.outputs.openai_temperature }}'
+          MAXTOK='${{ steps.cfg.outputs.openai_max_tokens }}'
+          PROMPT=$(cat '${{ steps.parse.outputs.prompt_file }}')
+          
+          escape_for_prompt() { sed -e 's/[`$\\]/\\&/g'; }
+          DIFF=$(head -n "$MAX_DIFF_LINES" pr_diff.txt | escape_for_prompt | head -c "$MAX_DIFF_CHARS")
+          ALLOWED=$(cat allowed.txt)
+          MAX=$(cat max.txt)
+          
+          read -r -d '' SYS <<'EOS' || true
+          You are a cautious code editor that outputs a single valid unified diff patch.
+          Rules:
+          - Touch ONLY files under the allowlist globs provided.
+          - Never modify .github/workflows, secrets, lock files, or binary assets.
+          - Keep total added+removed lines <= MAX_LINES.
+          - The patch must apply cleanly with `git apply` from repo root.
+          - Prefer minimal edits; maintain existing code style.
+          - If nothing needs changing, return an empty patch.
+          EOS
+          
+          read -r -d '' REQ <<EOF || true
+          TASK:
+          $PROMPT
+          
+          PR diff (context):
+          ```diff
+          $DIFF
+          ```
+          
+          CONSTRAINTS:
+          - ALLOWLIST: $ALLOWED
+          - MAX_LINES: $MAX
+          
+          Output ONLY the unified diff. No explanatory text.
+          EOF
+          
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            : > patch.diff
+            exit 0
+          fi
+          
+          PAYLOAD=$(jq -n \
+            --arg model "$MODEL" \
+            --arg temp "$TEMP" \
+            --arg max_tok "$MAXTOK" \
+            --arg sys "$SYS" \
+            --arg req "$REQ" \
+            '{
+              "model": $model,
+              "temperature": ($temp | tonumber),
+              "max_tokens": ($max_tok | tonumber),
+              "messages": [
+                {
+                  "role": "system",
+                  "content": $sys
+                },
+                {
+                  "role": "user",
+                  "content": $req
+                }
+              ]
+            }')
+
+          printf "%s" "$PAYLOAD" > /tmp/openai_patch_payload.json
+
+          RESP=$(curl -s https://api.openai.com/v1/chat/completions \
+            -H "content-type: application/json" \
+            -H "authorization: Bearer $OPENAI_API_KEY" \
+            -d @/tmp/openai_patch_payload.json)
+          
+          echo "$RESP" | jq -r '.choices[0].message.content // ""' > patch_raw.txt
           awk 'BEGIN{in=1} /^```/{in=!in; next} {if(in) print}' patch_raw.txt > patch.diff || true
 
       - name: Validate allowlist and limits
@@ -758,6 +1064,8 @@ jobs:
             echo "- **Mode**: ${{ steps.parse.outputs.run_mode }}"
             echo "- **Model**: ${{ steps.cfg.outputs.model }}"
             echo "- **Temperature**: ${{ steps.cfg.outputs.temperature }}"
+            echo "- **OpenAI model**: ${{ steps.cfg.outputs.openai_model }} (enabled: ${{ inputs.enable_openai }})"
+            echo "- **Patch provider**: ${{ steps.cfg.outputs.patch_provider }}"
             echo "- **Status**: ${{ job.status }}"
             
             if [ "${{ steps.validate.outputs.total_lines }}" != "" ]; then


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
## Summary
Upgrades PR Assistant workflow to support dual OpenAI/Claude providers with context builder.

## Changes
- ✅ Pin to commit `9e8d3c0330bd00f40b23d685b865e40ab10c6784`
- ✅ Add OpenAI inputs: `openai_model`, `openai_temperature`, `openai_max_tokens`
- ✅ Add `enable_openai` flag (default: true)
- ✅ Add `patch_provider` option (claude|openai)
- ✅ Add `OPENAI_API_KEY` secret propagation
- ✅ Context builder integration

## Testing
- [ ] CI checks pass
- [ ] Workflow validates successfully

## References
- Canonical workflow implementation
- WARP_GITHUB_ACTIONS_REUSABLE_WORKFLOWS.md


___

### **PR Type**
Enhancement


___

### **Description**
- Add OpenAI dual-provider support alongside Claude for PR reviews

- Implement PR context builder collecting metadata, bugbot comments, files

- Add configurable patch provider selection (Claude or OpenAI)

- Integrate OpenAI API calls for suggest and patch generation modes

- Expose new OpenAI model, temperature, and max_tokens configuration inputs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Assistant Workflow"] --> B["Parse & Config"]
  B --> C["Build PR Context"]
  C --> D{Run Mode}
  D -->|suggest| E["Claude Review"]
  D -->|suggest| F["OpenAI Review"]
  E --> G["Post Combined Comment"]
  F --> G
  D -->|apply| H{Patch Provider}
  H -->|claude| I["Claude Patch"]
  H -->|openai| J["OpenAI Patch"]
  I --> K["Validate & Apply"]
  J --> K
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v1-reusable.yml</strong><dd><code>Dual OpenAI/Claude provider with context builder integration</code></dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v1-reusable.yml

<ul><li>Added OpenAI model selection inputs (<code>openai_model</code>, <code>openai_temperature</code>, <br><code>openai_max_tokens</code>) with defaults<br> <li> Added <code>enable_openai</code> flag and <code>patch_provider</code> choice input to select <br>between Claude and OpenAI for patch generation<br> <li> Added <code>OPENAI_API_KEY</code> secret propagation for OpenAI API authentication<br> <li> Implemented PR context builder step that collects PR metadata, body, <br>bugbot comments, and file list<br> <li> Added OpenAI API call step for suggest mode with context integration<br> <li> Added OpenAI API call step for patch generation in apply modes with <br>allowlist/limit validation<br> <li> Updated comment posting logic to display both Claude and OpenAI <br>responses when available<br> <li> Updated workflow summary output to show OpenAI model and patch <br>provider configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/74/files#diff-59551c1918a84cc9a2ba1896c4eccc3fa9039a3183aff9899c858eb2310cd723">+313/-5</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables dual OpenAI/Claude review and patch generation with a new context builder and configurable patch provider in the PR assistant workflow.
> 
> - **GitHub Actions Workflow** (`.github/workflows/merglbot-pr-assistant-v1-reusable.yml`):
>   - **Inputs/Secrets**:
>     - Add `openai_model`, `openai_temperature`, `openai_max_tokens`, `enable_openai`, and `patch_provider` inputs.
>     - Propagate `OPENAI_API_KEY` secret; map OpenAI model identifiers.
>   - **Context Builder**:
>     - New step to assemble PR context (title/body/files/bot comments) into `context.txt` and pass to reviewers.
>   - **Suggest Mode**:
>     - Augment Anthropic call with PR context.
>     - Add parallel OpenAI review call and include both Claude/OpenAI sections in PR comment.
>   - **Apply/Apply-Suggestions Modes**:
>     - Add selectable patch generation provider (`claude` or `openai`), each with tailored prompts and API calls.
>   - **Validation/Reporting**:
>     - Keep allowlist/limits checks; summarize OpenAI model enablement and chosen patch provider in step summary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e8d3c0330bd00f40b23d685b865e40ab10c6784. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->