### PR TITLE
fix: reduce workflow_dispatch inputs to 9 (GitHub limit)

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
+++ b/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
@@ -117,16 +117,6 @@ on:
         required: false
         type: number
         default: 0.2
-      openai_temperature:
-        description: 'Teplota pro OpenAI (0.0-1.0)'
-        required: false
-        type: number
-        default: 0.2
-      openai_max_tokens:
-        description: 'OpenAI max_tokens'
-        required: false
-        type: number
-        default: 4096
       enable_openai:
         description: 'Povolit OpenAI review/patch'
         required: false
@@ -141,16 +131,6 @@ on:
           - suggest
           - apply-suggestions
           - apply
-      allowed_paths:
-        description: 'Povolené cesty (globs oddělené čárkou)'
-        required: false
-        type: string
-        default: '**'
-      max_changed_lines:
-        description: 'Maximální počet změněných řádků pro apply režimy'
-        required: false
-        type: number
-        default: 800
       patch_provider:
         description: 'Zdroj patchů (claude|openai)'
         required: false


### PR DESCRIPTION
### **User description**
## Problem
GitHub Actions has a limit of 10 inputs for `workflow_dispatch` events.
The canonical PR Assistant workflow had 13 inputs, causing validation errors.

## Solution
Reduced `workflow_dispatch` inputs from 13 to 9 by removing 4 less critical parameters:
- `openai_temperature` (defaults to 0.2)
- `openai_max_tokens` (defaults to 4096)  
- `allowed_paths` (defaults to `**`)
- `max_changed_lines` (defaults to 800)

## Impact
- ✅ `workflow_call` inputs unchanged (all 13 inputs still available for programmatic use)
- ✅ `workflow_dispatch` now has 9 inputs (within GitHub limit)
- ✅ Manual workflow runs will use sensible defaults for removed inputs

## Testing
- [ ] Workflow file validates successfully
- [ ] Manual workflow_dispatch works
- [ ] Programmatic workflow_call works

## References
- GitHub limit: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
- Error: https://github.com/merglbot-core/github/actions/runs/19636232790


___

### **PR Type**
Bug fix


___

### **Description**
- Removed 4 duplicate/redundant workflow_dispatch inputs

- Reduced workflow_dispatch inputs from 13 to 9

- Complies with GitHub's 10-input limit for workflow_dispatch

- Removed inputs: openai_temperature, openai_max_tokens, allowed_paths, max_changed_lines

- All inputs remain available in workflow_call for programmatic use


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["13 workflow_dispatch inputs"] -->|Remove 4 redundant inputs| B["9 workflow_dispatch inputs"]
  B -->|Within GitHub limit| C["Valid workflow file"]
  D["13 workflow_call inputs"] -->|Unchanged| E["Full programmatic access"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v1-reusable.yml</strong><dd><code>Remove 4 redundant workflow_dispatch inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v1-reusable.yml

<ul><li>Removed <code>openai_temperature</code> input (duplicate of <code>temperature</code>)<br> <li> Removed <code>openai_max_tokens</code> input (less critical parameter)<br> <li> Removed <code>allowed_paths</code> input (defaults to <code>**</code>)<br> <li> Removed <code>max_changed_lines</code> input (defaults to 800)<br> <li> Reduced workflow_dispatch inputs from 13 to 9 to comply with GitHub <br>limit<br> <li> All removed inputs remain available in workflow_call section</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/76/files#diff-59551c1918a84cc9a2ba1896c4eccc3fa9039a3183aff9899c858eb2310cd723">+0/-20</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes four less-critical workflow_dispatch inputs while leaving workflow_call inputs intact to comply with GitHub’s 10-input limit.
> 
> - **GitHub Actions workflow (`.github/workflows/merglbot-pr-assistant-v1-reusable.yml`)**
>   - **workflow_dispatch**: Removed inputs `openai_temperature`, `openai_max_tokens`, `allowed_paths`, and `max_changed_lines` to stay under the input limit.
>   - **workflow_call**: Input set unchanged (retains all parameters for programmatic use).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11f8d62173599b02c01a2196a860e2b4ee32e0b1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->