### PR TITLE
feat: update PR Assistant to use thinking models by default

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
+++ b/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
@@ -17,12 +17,12 @@ on:
         description: 'AI model'
         required: false
         type: string
-        default: 'Sonnet 4.5 (doporučeno)'
+        default: 'Sonnet 4.5 Thinking (doporučeno)'
       openai_model:
-        description: 'OpenAI model (default: gpt-4.1-mini)'
+        description: 'OpenAI model (default: gpt-5.1 high thinking)'
         required: false
         type: string
-        default: 'gpt-4.1-mini'
+        default: 'gpt-5.1'
       temperature:
         description: 'Sampling temperature (0.0-1.0)'
         required: false
@@ -88,12 +88,13 @@ on:
         default: |
           Proveď profesionální code review tohoto PR. Zaměř se na: (1) bezpečnost (secrets, OIDC/WIF), (2) architekturní konzistenci s WARP rules, (3) potenciální bugy a edge cases, (4) kvalitu kódu a idiomatičnost. Odpověz česky, kód komentuj anglicky. Výstup: krátký sumář (3-5 řádků), seznam konkrétních findings (každý s vysvětlením a doporučením), závěr (schválit/changes needed).
       model:
-        description: 'AI model - doporučeno: Sonnet 4.5 (vyvážený), Opus 4.1 (komplexní), Haiku 3.5 (rychlý)'
+        description: 'AI model - doporučeno: Sonnet 4.5 Thinking (max thinking), Opus 4.1 (komplexní), Haiku 3.5 (rychlý)'
         required: false
         type: choice
-        default: 'Sonnet 4.5 (doporučeno)'
+        default: 'Sonnet 4.5 Thinking (doporučeno)'
         options:
-          - Sonnet 4.5 (doporučeno)
+          - Sonnet 4.5 Thinking (doporučeno)
+          - Sonnet 4.5 (standard)
           - Opus 4.1 (komplexní)
           - Haiku 3.5 (rychlý)
           - Opus 4.0
@@ -106,12 +107,13 @@ on:
         description: 'OpenAI model'
         required: false
         type: choice
-        default: 'gpt-4.1-mini'
+        default: 'gpt-5.1'
         options:
-          - 'gpt-4.1-mini'
+          - 'gpt-5.1'
           - 'gpt-4.1'
-          - 'o4-mini'
+          - 'gpt-4.1-mini'
           - 'o4'
+          - 'o4-mini'
       temperature:
         description: 'Teplota vzorkování (0.0-1.0, nižší = konzervativnější odpovědi)'
         required: false
@@ -333,7 +335,8 @@ jobs:
           
           # Map human-readable names to Anthropic API identifiers
           case "${MODEL_INPUT:-}" in
-            "Sonnet 4.5 (doporučeno)") MODEL='claude-sonnet-4-5-20250929' ;;
+            "Sonnet 4.5 Thinking (doporučeno)") MODEL='claude-sonnet-4-5-thinking-20250929' ;;
+            "Sonnet 4.5 (standard)")    MODEL='claude-sonnet-4-5-20250929' ;;
             "Opus 4.1 (komplexní)")     MODEL='claude-opus-4-1-20250805' ;;
             "Haiku 3.5 (rychlý)")       MODEL='claude-3-5-haiku-20241022' ;;
             "Opus 4.0")                 MODEL='claude-opus-4-20250514' ;;
@@ -342,14 +345,16 @@ jobs:
             "Sonnet 3.5 (stable)")      MODEL='claude-3-5-sonnet-20241022' ;;
             "Sonnet 3.5 (legacy)")      MODEL='claude-3-5-sonnet-20240620' ;;
             "Haiku 3.0")                MODEL='claude-3-haiku-20240307' ;;
-            *)                          MODEL='claude-sonnet-4-5-20250929' ;;  # safe fallback
+            *)                          MODEL='claude-sonnet-4-5-thinking-20250929' ;;  # safe fallback
           esac
 
           case "${OPENAI_MODEL_INPUT:-}" in
+            "gpt-5.1")       OPENAI_MODEL='gpt-5.1' ;;
             "gpt-4.1")       OPENAI_MODEL='gpt-4.1' ;;
+            "gpt-4.1-mini")  OPENAI_MODEL='gpt-4.1-mini' ;;
             "o4")            OPENAI_MODEL='o4' ;;
             "o4-mini")       OPENAI_MODEL='o4-mini' ;;
-            *)               OPENAI_MODEL='gpt-4.1-mini' ;;
+            *)               OPENAI_MODEL='gpt-5.1' ;;
           esac
           
           [ -z "${TEMP:-}" ] && TEMP='0.2'


### PR DESCRIPTION
### **User description**
## Changes
- **Claude default**: `claude-sonnet-4-5-thinking-20250929` (max thinking)
- **OpenAI default**: `gpt-5.1` (high thinking)
- Added 'Sonnet 4.5 Thinking' as recommended option
- Kept standard 'Sonnet 4.5' as fallback

## Rationale
Thinking models provide deeper reasoning for code reviews, catching more subtle issues.

## Testing
Will test across all 12 repos after merge.


___

### **PR Type**
Enhancement


___

### **Description**
- Updated Claude default model to thinking variant for deeper reasoning

- Changed OpenAI default from gpt-4.1-mini to gpt-5.1 with high thinking

- Added 'Sonnet 4.5 Thinking' as recommended option in UI

- Kept standard 'Sonnet 4.5' as fallback for compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Model Selection"] -->|Claude| B["claude-sonnet-4-5-thinking-20250929"]
  A -->|OpenAI| C["gpt-5.1"]
  B -->|Recommended| D["Sonnet 4.5 Thinking"]
  C -->|High Thinking| E["Enhanced Reasoning"]
  D -->|Fallback| F["Sonnet 4.5 Standard"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v1-reusable.yml</strong><dd><code>Update workflow defaults to thinking models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v1-reusable.yml

<ul><li>Updated workflow_call model default from 'Sonnet 4.5 (doporučeno)' to <br>'Sonnet 4.5 Thinking (doporučeno)'<br> <li> Changed OpenAI model default from 'gpt-4.1-mini' to 'gpt-5.1' with <br>updated description<br> <li> Updated workflow_dispatch model description to highlight thinking <br>capability as recommended option<br> <li> Added 'Sonnet 4.5 (standard)' as new option in model choices dropdown<br> <li> Reordered OpenAI model options with gpt-5.1 as first choice<br> <li> Updated model mapping logic to use <code>claude-sonnet-4-5-thinking-20250929</code> <br>for thinking variant and fallback<br> <li> Added gpt-5.1 case mapping and reordered OpenAI model switch statement</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/77/files#diff-59551c1918a84cc9a2ba1896c4eccc3fa9039a3183aff9899c858eb2310cd723">+17/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set thinking models (`Sonnet 4.5 Thinking`, `gpt-5.1`) as defaults and update model options/mappings and fallbacks accordingly.
> 
> - **Workflow inputs**:
>   - Defaults switched to `Sonnet 4.5 Thinking (doporučeno)` and OpenAI `gpt-5.1`.
>   - Updated descriptions and choices; added `Sonnet 4.5 (standard)` alongside thinking option.
> - **Model mapping and fallbacks**:
>   - Updated Anthropic name→API mappings; safe fallback now `claude-sonnet-4-5-thinking-20250929`.
>   - OpenAI mappings updated to include `gpt-5.1`; default/fallback set to `gpt-5.1`.
> - **Behavior**:
>   - No other logic changes to review/apply flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71b1b19d56c37e622811a652acb284b80bfa1572. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->