### PR TITLE
revert: restore PR Assistant to working version (e481574)

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
+++ b/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
@@ -17,32 +17,12 @@ on:
         description: 'AI model'
         required: false
         type: string
-        default: 'Sonnet 4.5 Thinking (doporučeno)'
-      openai_model:
-        description: 'OpenAI model (default: gpt-5.1 high thinking)'
-        required: false
-        type: string
-        default: 'gpt-5.1'
+        default: 'Sonnet 4.5 (doporučeno)'
       temperature:
         description: 'Sampling temperature (0.0-1.0)'
         required: false
         type: string
         default: '0.2'
-      openai_temperature:
-        description: 'OpenAI sampling temperature (0.0-1.0)'
-        required: false
-        type: string
-        default: '0.2'
-      openai_max_tokens:
-        description: 'OpenAI max_tokens for responses'
-        required: false
-        type: string
-        default: '4096'
-      enable_openai:
-        description: 'Enable OpenAI review/patch calls'
-        required: false
-        type: string
-        default: 'true'
       run_mode:
         description: 'Run mode: suggest (comments), apply-suggestions (review suggestions), apply (commit & push)'
         required: false
@@ -58,11 +38,6 @@ on:
         required: false
         type: string
         default: '800'
-      patch_provider:
-        description: 'Which model generates patches (claude|openai)'
-        required: false
-        type: string
-        default: 'claude'
       confirm:
         description: 'For apply mode: type "apply" to confirm'
         required: false
@@ -71,8 +46,6 @@ on:
       ANTHROPIC_API_KEY:
         required: true
       GH_TOKEN:
-        required: false
-      OPENAI_API_KEY:
         required: false
 
   workflow_dispatch:
@@ -88,13 +61,12 @@ on:
         default: |
           Proveď profesionální code review tohoto PR. Zaměř se na: (1) bezpečnost (secrets, OIDC/WIF), (2) architekturní konzistenci s WARP rules, (3) potenciální bugy a edge cases, (4) kvalitu kódu a idiomatičnost. Odpověz česky, kód komentuj anglicky. Výstup: krátký sumář (3-5 řádků), seznam konkrétních findings (každý s vysvětlením a doporučením), závěr (schválit/changes needed).
       model:
-        description: 'AI model - doporučeno: Sonnet 4.5 Thinking (max thinking), Opus 4.1 (komplexní), Haiku 3.5 (rychlý)'
+        description: 'AI model - doporučeno: Sonnet 4.5 (vyvážený), Opus 4.1 (komplexní), Haiku 3.5 (rychlý)'
         required: false
         type: choice
-        default: 'Sonnet 4.5 Thinking (doporučeno)'
+        default: 'Sonnet 4.5 (doporučeno)'
         options:
-          - Sonnet 4.5 Thinking (doporučeno)
-          - Sonnet 4.5 (standard)
+          - Sonnet 4.5 (doporučeno)
           - Opus 4.1 (komplexní)
           - Haiku 3.5 (rychlý)
           - Opus 4.0
@@ -103,27 +75,11 @@ on:
           - Sonnet 3.5 (stable)
           - Sonnet 3.5 (legacy)
           - Haiku 3.0
-      openai_model:
-        description: 'OpenAI model'
-        required: false
-        type: choice
-        default: 'gpt-5.1'
-        options:
-          - 'gpt-5.1'
-          - 'gpt-4.1'
-          - 'gpt-4.1-mini'
-          - 'o4'
-          - 'o4-mini'
       temperature:
         description: 'Teplota vzorkování (0.0-1.0, nižší = konzervativnější odpovědi)'
         required: false
         type: number
         default: 0.2
-      enable_openai:
-        description: 'Povolit OpenAI review/patch'
-        required: false
-        type: boolean
-        default: true
       run_mode:
         description: 'Režim běhu: suggest (komentáře), apply-suggestions (review návrhy), apply (commit & push)'
         required: true
@@ -133,14 +89,16 @@ on:
           - suggest
           - apply-suggestions
           - apply
-      patch_provider:
-        description: 'Zdroj patchů (claude|openai)'
+      allowed_paths:
+        description: 'Povolené cesty (globs oddělené čárkou)'
         required: false
-        type: choice
-        default: claude
-        options:
-          - claude
-          - openai
+        type: string
+        default: '**'
+      max_changed_lines:
+        description: 'Maximální počet změněných řádků pro apply režimy'
+        required: false
+        type: number
+        default: 800
       confirm:
         description: 'Pouze pro apply režim: napiš "apply" pro povolení commit & push'
         required: false
@@ -270,64 +228,11 @@ jobs:
           json.dump(comments, sys.stdout)
           PY
 
-      - name: Build review context (PR body, bugbots, files)
-        id: context
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-          
-          # Fetch metadata
-          gh pr view "$PR_NUMBER" --json title,body,url,headRefName,baseRefName,author > pr_meta.json
-          gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > files.txt || true
-          gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.author.login | contains("bot")) | "- " + (.author.login) + ": " + (.body | gsub("\\r"; "") | gsub("\\n"; " ") | .[0:500])' > bugbot.txt || true
-          
-          PR_TITLE=$(jq -r '.title // ""' pr_meta.json)
-          PR_BODY=$(jq -r '.body // ""' pr_meta.json | head -c 12000)
-          PR_URL=$(jq -r '.url // ""' pr_meta.json)
-          HEAD=$(jq -r '.headRefName // ""' pr_meta.json)
-          BASE=$(jq -r '.baseRefName // ""' pr_meta.json)
-          AUTHOR=$(jq -r '.author.login // ""' pr_meta.json)
-          
-          {
-            echo "# PR Kontext"
-            echo "Title: $PR_TITLE"
-            echo "URL: $PR_URL"
-            echo "Author: $AUTHOR"
-            echo "Head: $HEAD -> Base: $BASE"
-            echo
-            echo "## PR Body"
-            printf "%s\n" "$PR_BODY"
-            echo
-            echo "## Bugbot komentáře"
-            if [ -s bugbot.txt ]; then
-              head -n 200 bugbot.txt
-            else
-              echo "(žádné bot komentáře)"
-            fi
-            echo
-            echo "## Seznam souborů"
-            if [ -s files.txt ]; then
-              head -n 200 files.txt
-            else
-              echo "(neznámé)"
-            fi
-          } > context.txt
-
-          # Trim context file for safety
-          head -c 120000 context.txt > context.txt.trim && mv context.txt.trim context.txt
-          echo "context_file=$PWD/context.txt" >> "$GITHUB_OUTPUT"
-
       - name: Map model name to API identifier
         id: cfg
         env:
           MODEL_INPUT: ${{ inputs.model }}
           TEMP: ${{ inputs.temperature }}
-          OPENAI_MODEL_INPUT: ${{ inputs.openai_model }}
-          OPENAI_TEMP: ${{ inputs.openai_temperature }}
-          OPENAI_MAX: ${{ inputs.openai_max_tokens }}
-          PATCH_PROVIDER_INPUT: ${{ inputs.patch_provider }}
           ALLOWED: ${{ inputs.allowed_paths }}
           MAX: ${{ inputs.max_changed_lines }}
         run: |
@@ -335,8 +240,7 @@ jobs:
           
           # Map human-readable names to Anthropic API identifiers
           case "${MODEL_INPUT:-}" in
-            "Sonnet 4.5 Thinking (doporučeno)") MODEL='claude-sonnet-4-5-thinking-20250929' ;;
-            "Sonnet 4.5 (standard)")    MODEL='claude-sonnet-4-5-20250929' ;;
+            "Sonnet 4.5 (doporučeno)") MODEL='claude-sonnet-4-5-20250929' ;;
             "Opus 4.1 (komplexní)")     MODEL='claude-opus-4-1-20250805' ;;
             "Haiku 3.5 (rychlý)")       MODEL='claude-3-5-haiku-20241022' ;;
             "Opus 4.0")                 MODEL='claude-opus-4-20250514' ;;
@@ -345,35 +249,15 @@ jobs:
             "Sonnet 3.5 (stable)")      MODEL='claude-3-5-sonnet-20241022' ;;
             "Sonnet 3.5 (legacy)")      MODEL='claude-3-5-sonnet-20240620' ;;
             "Haiku 3.0")                MODEL='claude-3-haiku-20240307' ;;
-            *)                          MODEL='claude-sonnet-4-5-thinking-20250929' ;;  # safe fallback
-          esac
-
-          case "${OPENAI_MODEL_INPUT:-}" in
-            "gpt-5.1")       OPENAI_MODEL='gpt-5.1' ;;
-            "gpt-4.1")       OPENAI_MODEL='gpt-4.1' ;;
-            "gpt-4.1-mini")  OPENAI_MODEL='gpt-4.1-mini' ;;
-            "o4")            OPENAI_MODEL='o4' ;;
-            "o4-mini")       OPENAI_MODEL='o4-mini' ;;
-            *)               OPENAI_MODEL='gpt-5.1' ;;
+            *)                          MODEL='claude-sonnet-4-5-20250929' ;;  # safe fallback
           esac
           
           [ -z "${TEMP:-}" ] && TEMP='0.2'
-          [ -z "${OPENAI_TEMP:-}" ] && OPENAI_TEMP='0.2'
-          [ -z "${OPENAI_MAX:-}" ] && OPENAI_MAX='4096'
           [ -z "${ALLOWED:-}" ] && ALLOWED='**'
           [ -z "${MAX:-}" ] && MAX='800'
-
-          PATCH_PROVIDER=$(printf "%s" "${PATCH_PROVIDER_INPUT:-claude}" | tr '[:upper:]' '[:lower:]')
-          if [ "$PATCH_PROVIDER" != "openai" ]; then
-            PATCH_PROVIDER="claude"
-          fi
           
           echo "model=$MODEL" >> "$GITHUB_OUTPUT"
           echo "temperature=$TEMP" >> "$GITHUB_OUTPUT"
-          echo "openai_model=$OPENAI_MODEL" >> "$GITHUB_OUTPUT"
-          echo "openai_temperature=$OPENAI_TEMP" >> "$GITHUB_OUTPUT"
-          echo "openai_max_tokens=$OPENAI_MAX" >> "$GITHUB_OUTPUT"
-          echo "patch_provider=$PATCH_PROVIDER" >> "$GITHUB_OUTPUT"
           echo "$ALLOWED" > allowed.txt
           echo "$MAX" > max.txt
 
@@ -399,10 +283,8 @@ jobs:
           # Named constants for input size limits
           MAX_COMMENT_CHARS=20000
           MAX_DIFF_LINES=8000
-          MAX_CONTEXT_CHARS=120000
           
           COMMENT=$(cat '${{ steps.parse.outputs.prompt_file }}')
-          CONTEXT=$(cat '${{ steps.context.outputs.context_file }}' | head -c "$MAX_CONTEXT_CHARS")
           MODEL='${{ steps.cfg.outputs.model }}'
           TEMP='${{ steps.cfg.outputs.temperature }}'
     
@@ -424,7 +306,6 @@ jobs:
             --arg model "$MODEL" \
             --arg temp "$TEMP" \
             --rawfile comment /tmp/comment.txt \
-            --rawfile context "${{ steps.context.outputs.context_file }}" \
             --rawfile diff /tmp/diff.txt \
             '{
               "model": $model,
@@ -441,18 +322,6 @@ jobs:
                     {
                       "type": "text",
                       "text": $comment
-                    },
-                    {
-                      "type": "text",
-                      "text": "\n\nPR Context:\n```\n"
-                    },
-                    {
-                      "type": "text",
-                      "text": $context
-                    },
-                    {
-                      "type": "text",
-                      "text": "\n```"
                     },
                     {
                       "type": "text",
@@ -483,68 +352,6 @@ jobs:
           printf "%s" "$RESP" > claude_api_suggest.json
           echo "$RESP" | jq -r '.content[0].text // ""' > claude_response.txt
 
-      - name: Call OpenAI (suggest mode)
-        if: steps.parse.outputs.run_mode == 'suggest' && inputs.enable_openai != 'false' && inputs.enable_openai != '0'
-        id: call_openai_suggest
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          set -euo pipefail
-          MAX_COMMENT_CHARS=20000
-          MAX_DIFF_LINES=8000
-          MAX_CONTEXT_CHARS=120000
-          
-          if [ -z "${OPENAI_API_KEY:-}" ]; then
-            echo "OpenAI API key missing; skipping OpenAI review."
-            : > openai_response.txt
-            exit 0
-          fi
-
-          COMMENT=$(cat '${{ steps.parse.outputs.prompt_file }}')
-          CONTEXT=$(cat '${{ steps.context.outputs.context_file }}' | head -c "$MAX_CONTEXT_CHARS")
-          MODEL='${{ steps.cfg.outputs.openai_model }}'
-          TEMP='${{ steps.cfg.outputs.openai_temperature }}'
-          MAXTOK='${{ steps.cfg.outputs.openai_max_tokens }}'
-    
-          COMMENT_SAFE=$(printf "%s" "$COMMENT" | head -c "$MAX_COMMENT_CHARS")
-          DIFF_CONTENT=$(head -n "$MAX_DIFF_LINES" pr_diff.txt)
-
-          printf "%s" "$COMMENT_SAFE" > /tmp/comment.txt
-          printf "%s" "$CONTEXT" > /tmp/context.txt
-          printf "%s" "$DIFF_CONTENT" > /tmp/diff.txt
-
-          PAYLOAD=$(jq -n \
-            --arg model "$MODEL" \
-            --arg temp "$TEMP" \
-            --arg max_tok "$MAXTOK" \
-            --rawfile comment /tmp/comment.txt \
-            --rawfile context /tmp/context.txt \
-            --rawfile diff /tmp/diff.txt \
-            '{
-              "model": $model,
-              "temperature": ($temp | tonumber),
-              "max_tokens": ($max_tok | tonumber),
-              "messages": [
-                {
-                  "role": "system",
-                  "content": "You are a helpful code reviewer. Rules: no secrets in logs, least-privilege IAM, safe shell patterns, no destructive infra changes."
-                },
-                {
-                  "role": "user",
-                  "content": ("User request:\n" + $comment + "\n\nPR Context:\n" + $context + "\n\nPR Diff:\n```\n" + $diff + "\n```")
-                }
-              ]
-            }')
-
-          printf "%s" "$PAYLOAD" > /tmp/openai_payload.json
-
-          RESP=$(curl -s https://api.openai.com/v1/chat/completions \
-            -H "content-type: application/json" \
-            -H "authorization: Bearer $OPENAI_API_KEY" \
-            -d @/tmp/openai_payload.json)
-          
-          printf "%s" "$RESP" | jq -r '.choices[0].message.content // ""' > openai_response.txt
-
       - name: Post comment (suggest mode)
         if: steps.parse.outputs.run_mode == 'suggest'
         env:
@@ -553,12 +360,7 @@ jobs:
           set -euo pipefail
           PR_NUMBER="${{ steps.parse.outputs.pr_number }}"
           
-          CLAUDE_BODY=""
-          OPENAI_BODY=""
-          [ -s claude_response.txt ] && CLAUDE_BODY=$(cat claude_response.txt)
-          [ -s openai_response.txt ] && OPENAI_BODY=$(cat openai_response.txt)
-
-          if [ -z "$CLAUDE_BODY" ] && [ -z "$OPENAI_BODY" ]; then
+          if [ ! -s claude_response.txt ]; then
             {
               echo "## 🤖 Merglbot PR Assistant"
               echo
@@ -568,18 +370,8 @@ jobs:
             {
               echo "## 🤖 Merglbot PR Assistant"
               echo
-              if [ -n "$CLAUDE_BODY" ]; then
-                echo "### Claude"
-                echo
-                echo "$CLAUDE_BODY"
-                echo
-              fi
-              if [ -n "$OPENAI_BODY" ]; then
-                echo "### OpenAI"
-                echo
-                echo "$OPENAI_BODY"
-                echo
-              fi
+              cat claude_response.txt
+              echo
               echo "---"
               echo "*AI-generated suggestions. Please review before applying.*"
             } > comment_body.md
@@ -627,8 +419,8 @@ jobs:
           echo "${{ inputs.allowed_paths }}" > allowed.txt
           echo "${{ inputs.max_changed_lines }}" > max.txt
 
-      - name: Ask LLM for unified patch (Claude)
-        if: steps.parse.outputs.run_mode != 'suggest' && steps.cfg.outputs.patch_provider == 'claude'
+      - name: Ask LLM for unified patch
+        if: steps.parse.outputs.run_mode != 'suggest'
         id: ask
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -713,89 +505,6 @@ jobs:
           echo "$RESP" | jq -r '.content[0].text // .content // empty' > patch_raw.txt
   
           # Strip markdown code fences if present
-          awk 'BEGIN{in=1} /^```/{in=!in; next} {if(in) print}' patch_raw.txt > patch.diff || true
-
-      - name: Ask OpenAI for unified patch
-        if: steps.parse.outputs.run_mode != 'suggest' && steps.cfg.outputs.patch_provider == 'openai' && inputs.enable_openai != 'false' && inputs.enable_openai != '0'
-        id: ask_openai
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          set -euo pipefail
-          MAX_DIFF_LINES=8000
-          MAX_DIFF_CHARS=350000
-          MODEL='${{ steps.cfg.outputs.openai_model }}'
-          TEMP='${{ steps.cfg.outputs.openai_temperature }}'
-          MAXTOK='${{ steps.cfg.outputs.openai_max_tokens }}'
-          PROMPT=$(cat '${{ steps.parse.outputs.prompt_file }}')
-          
-          escape_for_prompt() { sed -e 's/[`$\\]/\\&/g'; }
-          DIFF=$(head -n "$MAX_DIFF_LINES" pr_diff.txt | escape_for_prompt | head -c "$MAX_DIFF_CHARS")
-          ALLOWED=$(cat allowed.txt)
-          MAX=$(cat max.txt)
-          
-          read -r -d '' SYS <<'EOS' || true
-          You are a cautious code editor that outputs a single valid unified diff patch.
-          Rules:
-          - Touch ONLY files under the allowlist globs provided.
-          - Never modify .github/workflows, secrets, lock files, or binary assets.
-          - Keep total added+removed lines <= MAX_LINES.
-          - The patch must apply cleanly with `git apply` from repo root.
-          - Prefer minimal edits; maintain existing code style.
-          - If nothing needs changing, return an empty patch.
-          EOS
-          
-          read -r -d '' REQ <<EOF || true
-          TASK:
-          $PROMPT
-          
-          PR diff (context):
-          ```diff
-          $DIFF
-          ```
-          
-          CONSTRAINTS:
-          - ALLOWLIST: $ALLOWED
-          - MAX_LINES: $MAX
-          
-          Output ONLY the unified diff. No explanatory text.
-          EOF
-          
-          if [ -z "${OPENAI_API_KEY:-}" ]; then
-            : > patch.diff
-            exit 0
-          fi
-          
-          PAYLOAD=$(jq -n \
-            --arg model "$MODEL" \
-            --arg temp "$TEMP" \
-            --arg max_tok "$MAXTOK" \
-            --arg sys "$SYS" \
-            --arg req "$REQ" \
-            '{
-              "model": $model,
-              "temperature": ($temp | tonumber),
-              "max_tokens": ($max_tok | tonumber),
-              "messages": [
-                {
-                  "role": "system",
-                  "content": $sys
-                },
-                {
-                  "role": "user",
-                  "content": $req
-                }
-              ]
-            }')
-
-          printf "%s" "$PAYLOAD" > /tmp/openai_patch_payload.json
-
-          RESP=$(curl -s https://api.openai.com/v1/chat/completions \
-            -H "content-type: application/json" \
-            -H "authorization: Bearer $OPENAI_API_KEY" \
-            -d @/tmp/openai_patch_payload.json)
-          
-          echo "$RESP" | jq -r '.choices[0].message.content // ""' > patch_raw.txt
           awk 'BEGIN{in=1} /^```/{in=!in; next} {if(in) print}' patch_raw.txt > patch.diff || true
 
       - name: Validate allowlist and limits
@@ -1049,8 +758,6 @@ jobs:
             echo "- **Mode**: ${{ steps.parse.outputs.run_mode }}"
             echo "- **Model**: ${{ steps.cfg.outputs.model }}"
             echo "- **Temperature**: ${{ steps.cfg.outputs.temperature }}"
-            echo "- **OpenAI model**: ${{ steps.cfg.outputs.openai_model }} (enabled: ${{ inputs.enable_openai }})"
-            echo "- **Patch provider**: ${{ steps.cfg.outputs.patch_provider }}"
             echo "- **Status**: ${{ job.status }}"
             
             if [ "${{ steps.validate.outputs.total_lines }}" != "" ]; then


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
## Summary
Reverting PR Assistant workflow to last known good state before today's changes.

## Reverted Commits
- 8664a0e feat: update PR Assistant to use thinking models
- 6c326b6 fix: reduce workflow_dispatch inputs to 9  
- 37231f6 ci: add openai dual review and context

## Reason
Today's changes caused functionality issues. Restoring to commit e481574 (2025-11-23) which was working correctly.

## Testing
- [ ] Verify workflow syntax is valid
- [ ] Test on sample PR

## References
- Last good commit: e481574


___

### **PR Type**
Bug fix


___

### **Description**
- Removed OpenAI dual-review integration and model selection

- Removed PR context building step that fetched metadata

- Simplified workflow to single Claude-based review path

- Removed "Thinking" model variant, reverted to standard Sonnet 4.5


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v1-reusable.yml</strong><dd><code>Revert to single Claude-only PR review workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v1-reusable.yml

<ul><li>Removed <code>openai_model</code>, <code>openai_temperature</code>, <code>openai_max_tokens</code>, <br><code>enable_openai</code>, and <code>patch_provider</code> input parameters<br> <li> Removed <code>OPENAI_API_KEY</code> secret requirement<br> <li> Removed "Build review context" step that fetched PR metadata, bugbot <br>comments, and file lists<br> <li> Removed "Call OpenAI (suggest mode)" and "Ask OpenAI for unified <br>patch" steps<br> <li> Simplified model mapping to remove OpenAI model cases and "Sonnet 4.5 <br>Thinking" variant<br> <li> Removed PR context from Claude API payload construction<br> <li> Simplified comment posting logic to remove dual-model output <br>formatting<br> <li> Updated model descriptions to reference "vyvážený" (balanced) instead <br>of "max thinking"</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/78/files#diff-59551c1918a84cc9a2ba1896c4eccc3fa9039a3183aff9899c858eb2310cd723">+20/-313</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts PR Assistant workflow to an Anthropic-only version, removing OpenAI paths/options and simplifying inputs, model mapping, and patch generation steps.
> 
> - **Workflow inputs/config**:
>   - Remove OpenAI-related inputs (`openai_*`, `enable_openai`, `patch_provider`) and "Thinking" model variants; default to `Sonnet 4.5 (doporučeno)`.
>   - Add/standardize `allowed_paths` and `max_changed_lines` to both triggers; simplify temperature types.
> - **Suggest mode**:
>   - Drop PR context aggregation and OpenAI call; keep single Anthropic call with trimmed diff and prompt.
>   - Simplify comment posting to a single body from `claude_response.txt`.
> - **Apply/apply-suggestions**:
>   - Consolidate to one "Ask LLM for unified patch" (Anthropic) step; remove OpenAI patch flow and `patch_provider` branching.
>   - Keep allowlist/limits validation and suggestion generation; minor hardening of checks and outputs.
> - **Model mapping**:
>   - Update mapping to non-thinking IDs; safe fallback to `claude-sonnet-4-5-20250929`.
> - **Summary output**:
>   - Step summary trimmed to exclude OpenAI/patch-provider details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37a3e7f58f1a85da369fdf51cae70125d9b79b48. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->