### PR TITLE
debug: show Anthropic API response in logs

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
+++ b/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
@@ -350,6 +350,22 @@ jobs:
             -d @/tmp/payload.json)
     
           printf "%s" "$RESP" > claude_api_suggest.json
+          
+          # DEBUG: Show API response
+          echo "=== API Response Debug ==="
+          echo "Response length: $(echo "$RESP" | wc -c)"
+          echo "First 500 chars:"
+          echo "$RESP" | head -c 500
+          echo ""
+          echo "=== Checking for errors ==="
+          if echo "$RESP" | jq -e ".error" > /dev/null 2>&1; then
+            echo "ERROR FOUND:"
+            echo "$RESP" | jq ".error"
+          else
+            echo "No error field in response"
+          fi
+          echo "======================="
+          
           echo "$RESP" | jq -r '.content[0].text // ""' > claude_response.txt
 
       - name: Post comment (suggest mode)


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
Adds debug logging to see exact API response.

This will help identify why responses are empty.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds debug logging to Anthropic API response handling

- Shows response length and first 500 characters

- Detects and displays API error fields when present

- Helps diagnose empty or failed LLM responses


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Anthropic API Call"] --> B["Save Response to File"]
  B --> C["DEBUG: Log Response Details"]
  C --> D["Check for Error Field"]
  D --> E["Process Response Text"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v1-reusable.yml</strong><dd><code>Add API response debug logging and error detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v1-reusable.yml

<ul><li>Added debug logging block after API response capture<br> <li> Logs response length and first 500 characters for inspection<br> <li> Checks for error field in JSON response using jq<br> <li> Displays error details if present, otherwise confirms no error</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/83/files#diff-59551c1918a84cc9a2ba1896c4eccc3fa9039a3183aff9899c858eb2310cd723">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add debug logs to the reusable PR assistant workflow to print Anthropic API response details and surface errors in suggest mode.
> 
> - **Workflows**:
>   - **Debug logging added** in `/.github/workflows/merglbot-pr-assistant-v1-reusable.yml` (suggest mode):
>     - Print API response length and first 500 chars after Anthropic `/v1/messages` call.
>     - Detect and print `.error` via `jq` if present.
>     - Response still saved to `claude_api_suggest.json` and text extracted to `claude_response.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94aac9a94ed1260359f52ac3d192e2187b7b58e0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->