### PR TITLE
fix: revert to valid API version 2023-06-01

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
+++ b/.github/workflows/merglbot-pr-assistant-v1-reusable.yml
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      ANTHROPIC_API_VERSION: "2024-06-01"  # Updated for Sonnet 4.5 support
+      ANTHROPIC_API_VERSION: "2023-06-01"  # Latest valid API version per https://docs.anthropic.com/en/api/versioning
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
## 🔥 ROOT CAUSE FOUND!

**Error from API**:
```
{"type":"invalid_request_error","message":"anthropic-version: \"2024-06-01\" is not a valid version"}
```

**Problem**: I changed API version to `2024-06-01` which DOES NOT EXIST

**Valid versions** (per [docs](https://platform.claude.com/docs/en/api/versioning)):
- ✅ `2023-06-01` (latest)
- `2023-01-01` (initial)

**Fix**: Revert to `2023-06-01`

This WILL work!


___

### **PR Type**
Bug fix


___

### **Description**
- Revert invalid API version 2024-06-01 to valid 2023-06-01

- Fix Anthropic API versioning error in GitHub workflow

- Update documentation reference to official API versioning docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Invalid version<br/>2024-06-01"] -- "Revert to" --> B["Valid version<br/>2023-06-01"]
  B -- "References" --> C["Anthropic docs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v1-reusable.yml</strong><dd><code>Correct Anthropic API version in workflow environment</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v1-reusable.yml

<ul><li>Changed <code>ANTHROPIC_API_VERSION</code> environment variable from non-existent <br><code>2024-06-01</code> to valid <code>2023-06-01</code><br> <li> Updated inline comment to reference official Anthropic API versioning <br>documentation<br> <li> Resolves API error: "anthropic-version: \"2024-06-01\" is not a valid <br>version"</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/84/files#diff-59551c1918a84cc9a2ba1896c4eccc3fa9039a3183aff9899c858eb2310cd723">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts `ANTHROPIC_API_VERSION` in `.github/workflows/merglbot-pr-assistant-v1-reusable.yml` to `2023-06-01` to use a valid API version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e0c1ec34ce5b7037858b883215c6457c9162798. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->