### PR TITLE
feat: Use o1-preview (best reasoning model) as default

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
+++ b/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
@@ -22,7 +22,7 @@ on:
         description: "OpenAI model"
         required: false
         type: string  
-        default: "gpt-4.1-mini"
+        default: "o1-preview"
       temperature:
         description: "Temperature"
         required: false
@@ -55,13 +55,13 @@ on:
         description: "OpenAI model"
         required: false
         type: choice
-        default: "gpt-4.1-mini"
+        default: "o1-preview"
         options:
-          - gpt-4.1-mini
-          - gpt-4-turbo
-          - gpt-4
           - o1-preview
           - o1-mini
+          - gpt-4-turbo
+          - gpt-4.1-mini
+          - gpt-4
 
 permissions:
   contents: write
@@ -133,7 +133,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_MODEL: ${{ inputs.anthropic_model || 'claude-sonnet-4-5-20250929' }}
-          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-4.1-mini' }}
+          OPENAI_MODEL: ${{ inputs.openai_model || 'o1-preview' }}
           TEMPERATURE: ${{ inputs.temperature || '0.2' }}
           PROMPT: ${{ inputs.prompt }}
         run: |
@@ -239,7 +239,7 @@ jobs:
       - name: Step 2 - Synthesize Final Review (OpenAI)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-4.1-mini' }}
+          OPENAI_MODEL: ${{ inputs.openai_model || 'o1-preview' }}
           ANTHROPIC_MODEL: ${{ inputs.anthropic_model || 'claude-sonnet-4-5-20250929' }}
         run: |
           set -euo pipefail


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
## 🚀 Upgrade to Best OpenAI Model

**Change**: Default OpenAI model → **o1-preview**

### Why o1-preview?
- ✅ Best reasoning/thinking capabilities
- ✅ Superior code analysis
- ✅ Better synthesis quality
- ✅ Recommended for complex tasks

### Model Hierarchy (Priority Order)
1. **o1-preview** ⭐ (default - best reasoning)
2. o1-mini (smaller reasoning)
3. gpt-4-turbo
4. gpt-4.1-mini
5. gpt-4

### Multi-Model Flow
```
Anthropic Sonnet 4.5 → Review A
OpenAI o1-preview   → Review B
                    ↓
OpenAI o1-preview   → Synthesis → Final Review
```

### Testing
Will test immediately after merge on fresh PR.

**Validated**: YAML syntax ✅


___

### **PR Type**
Enhancement


___

### **Description**
- Changes default OpenAI model from gpt-4.1-mini to o1-preview

- Reorders model options with o1-preview prioritized first

- Updates all workflow environment variable defaults consistently

- Leverages superior reasoning capabilities of o1-preview model


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gpt-4.1-mini<br/>old default"] -->|replaced by| B["o1-preview<br/>new default"]
  C["Model Priority<br/>Reordered"] -->|o1-preview first| D["o1-preview<br/>o1-mini<br/>gpt-4-turbo<br/>gpt-4.1-mini<br/>gpt-4"]
  B -->|used in| E["Step 1: Parallel<br/>API Calls"]
  B -->|used in| F["Step 2: Synthesis<br/>Final Review"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v2-multi-model.yml</strong><dd><code>Update default OpenAI model to o1-preview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v2-multi-model.yml

<ul><li>Updated default OpenAI model from <code>gpt-4.1-mini</code> to <code>o1-preview</code> in <br>workflow inputs<br> <li> Reordered OpenAI model options list with <code>o1-preview</code> as first choice<br> <li> Updated environment variable defaults in Step 1 and Step 2 job steps<br> <li> Maintains consistency across all workflow configuration sections</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/87/files#diff-5404cd0d65811e9002fd2863f66a02303398f7ca5bda4f6353f6e7f61b89a879">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the PR assistant workflow to default to OpenAI `o1-preview` and updates step envs and selectable options accordingly.
> 
> - **CI/GitHub Actions (`.github/workflows/merglbot-pr-assistant-v2-multi-model.yml`)**:
>   - **Defaults**:
>     - Set `openai_model` default to `o1-preview` in both `workflow_call` and `workflow_dispatch` inputs.
>   - **Runtime env**:
>     - Update `OPENAI_MODEL` in Step 1 (parallel calls) and Step 2 (synthesis) to use `inputs.openai_model || 'o1-preview'`.
>   - **Model choices**:
>     - Reorder/update `openai_model` options to prioritize `o1-preview`, add `gpt-4-turbo`, and include `gpt-4.1-mini` and `gpt-4` after `o1-*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a2f8c57bbbbaa707a6440d2a973bbc5f96709bf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->