### PR TITLE
feat: Use GPT-4 Turbo for multi-model review

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
+++ b/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
@@ -22,7 +22,7 @@ on:
         description: "OpenAI model"
         required: false
         type: string  
-        default: "o1-preview"
+        default: "gpt-4-turbo"
       temperature:
         description: "Temperature"
         required: false
@@ -55,13 +55,13 @@ on:
         description: "OpenAI model"
         required: false
         type: choice
-        default: "o1-preview"
+        default: "gpt-4-turbo"
         options:
+          - gpt-4-turbo
+          - gpt-4
           - o1-preview
           - o1-mini
-          - gpt-4-turbo
           - gpt-4.1-mini
-          - gpt-4
 
 permissions:
   contents: write
@@ -133,7 +133,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_MODEL: ${{ inputs.anthropic_model || 'claude-sonnet-4-5-20250929' }}
-          OPENAI_MODEL: ${{ inputs.openai_model || 'o1-preview' }}
+          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-4-turbo' }}
           TEMPERATURE: ${{ inputs.temperature || '0.2' }}
           PROMPT: ${{ inputs.prompt }}
         run: |
@@ -239,7 +239,7 @@ jobs:
       - name: Step 2 - Synthesize Final Review (OpenAI)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: ${{ inputs.openai_model || 'o1-preview' }}
+          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-4-turbo' }}
           ANTHROPIC_MODEL: ${{ inputs.anthropic_model || 'claude-sonnet-4-5-20250929' }}
         run: |
           set -euo pipefail


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
## Update to GPT-4 Turbo

**Change**: Default OpenAI model → **gpt-4-turbo**

### Why GPT-4 Turbo?
- ✅ Latest GPT-4 model
- ✅ Excellent code analysis
- ✅ Faster than reasoning models
- ✅ Cost effective

### Flow
```
Step 1: Parallel
├─> Anthropic Sonnet 4.5
└─> GPT-4 Turbo

Step 2: Synthesis
└─> GPT-4 Turbo → Final Review
```

Ready to merge and test!


___

### **PR Type**
Enhancement


___

### **Description**
- Replace default OpenAI model from o1-preview to gpt-4-turbo

- Update model selection options with gpt-4-turbo prioritized first

- Apply consistent gpt-4-turbo default across all workflow steps

- Improve cost-effectiveness and code analysis performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Configuration"] -->|"Update default model"| B["o1-preview → gpt-4-turbo"]
  B -->|"Apply to Step 1"| C["Parallel API Calls"]
  B -->|"Apply to Step 2"| D["Synthesis Review"]
  C -->|"Anthropic + OpenAI"| E["Multi-model Review"]
  D -->|"Final synthesis"| E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v2-multi-model.yml</strong><dd><code>Update default OpenAI model to GPT-4 Turbo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v2-multi-model.yml

<ul><li>Changed default OpenAI model from <code>o1-preview</code> to <code>gpt-4-turbo</code> in <br>workflow inputs (line 24)<br> <li> Reordered model options list to prioritize <code>gpt-4-turbo</code> and <code>gpt-4</code> at <br>the top (lines 59-60)<br> <li> Updated environment variable defaults in Step 1 parallel API calls <br>(line 137)<br> <li> Updated environment variable defaults in Step 2 synthesis step (line <br>243)</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/88/files#diff-5404cd0d65811e9002fd2863f66a02303398f7ca5bda4f6353f6e7f61b89a879">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the workflow’s OpenAI model default and step fallbacks to `gpt-4-turbo` and updates selectable options.
> 
> - **CI Workflow (`.github/workflows/merglbot-pr-assistant-v2-multi-model.yml`)**
>   - **Defaults**: Set OpenAI model default to `gpt-4-turbo` in `workflow_call` and `workflow_dispatch` inputs, and as the fallback in Step 1 and Step 2 `OPENAI_MODEL` env.
>   - **Model Options**: Update `openai_model` choices to include `gpt-4-turbo` and `gpt-4`, and reorder the list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d14c146afb6e209e3030517bdfa34e2860221818. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->