### PR TITLE
🚀 feat: Upgrade to Codex 5.1 (GPT-5.1-codex)

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
+++ b/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
@@ -22,7 +22,7 @@ on:
         description: "OpenAI model"
         required: false
         type: string  
-        default: "gpt-4-turbo"
+        default: "gpt-5.1-codex"
       temperature:
         description: "Temperature"
         required: false
@@ -55,13 +55,13 @@ on:
         description: "OpenAI model"
         required: false
         type: choice
-        default: "gpt-4-turbo"
+        default: "gpt-5.1-codex"
         options:
+          - gpt-5.1-codex
+          - gpt-5.1-codex-mini
           - gpt-4-turbo
-          - gpt-4
           - o1-preview
-          - o1-mini
-          - gpt-4.1-mini
+          - gpt-4
 
 permissions:
   contents: write
@@ -133,7 +133,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_MODEL: ${{ inputs.anthropic_model || 'claude-sonnet-4-5-20250929' }}
-          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-4-turbo' }}
+          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-5.1-codex' }}
           TEMPERATURE: ${{ inputs.temperature || '0.2' }}
           PROMPT: ${{ inputs.prompt }}
         run: |
@@ -239,7 +239,7 @@ jobs:
       - name: Step 2 - Synthesize Final Review (OpenAI)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-4-turbo' }}
+          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-5.1-codex' }}
           ANTHROPIC_MODEL: ${{ inputs.anthropic_model || 'claude-sonnet-4-5-20250929' }}
         run: |
           set -euo pipefail


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
## 🚀 Codex 5.1 Integration

**NEW**: OpenAI Codex 5.1 (`gpt-5.1-codex`)

### Why Codex 5.1?
- ✅ **Latest OpenAI model**
- ✅ Optimized for **code analysis**
- ✅ Agentní programovací úlohy
- ✅ Superior reasoning

### Multi-Model Flow
```
Step 1: Parallel Analysis
├─> Anthropic Sonnet 4.5 → Code Review A
└─> Codex 5.1          → Code Review B

Step 2: Synthesis
└─> Codex 5.1 → Final Comprehensive Review
```

### Model Options
1. **gpt-5.1-codex** ⭐ (default)
2. gpt-5.1-codex-mini
3. gpt-4-turbo
4. o1-preview
5. gpt-4

### References
- [Codex Changelog](https://developers.openai.com/codex/changelog)

**Ready to test!** 🎯


___

### **PR Type**
Enhancement


___

### **Description**
- Upgrade default OpenAI model from gpt-4-turbo to gpt-5.1-codex

- Add gpt-5.1-codex-mini as new model option

- Update model selection options in workflow inputs

- Apply new default model to both parallel analysis and synthesis steps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gpt-4-turbo<br/>Previous Default"] -->|"Upgrade"| B["gpt-5.1-codex<br/>New Default"]
  C["Model Options"] -->|"Add"| D["gpt-5.1-codex-mini"]
  B -->|"Used in"| E["Step 1: Parallel Analysis"]
  B -->|"Used in"| F["Step 2: Synthesis"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v2-multi-model.yml</strong><dd><code>Update default OpenAI model to Codex 5.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v2-multi-model.yml

<ul><li>Changed default OpenAI model from <code>gpt-4-turbo</code> to <code>gpt-5.1-codex</code> in <br>workflow inputs<br> <li> Added <code>gpt-5.1-codex</code> and <code>gpt-5.1-codex-mini</code> to model selection options<br> <li> Removed <code>gpt-4.1-mini</code> and <code>o1-mini</code> from available model choices<br> <li> Updated environment variable defaults in Step 1 and Step 2 job steps <br>to use new model</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/89/files#diff-5404cd0d65811e9002fd2863f66a02303398f7ca5bda4f6353f6e7f61b89a879">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update PR assistant workflow to use `gpt-5.1-codex` by default and refresh the selectable OpenAI model list.
> 
> - **CI Workflow (`.github/workflows/merglbot-pr-assistant-v2-multi-model.yml`)**
>   - **Default OpenAI model updated**: switch from `gpt-4-turbo` to `gpt-5.1-codex` in `workflow_call`/`workflow_dispatch` inputs and in env for Step 1 and Step 2.
>   - **Model choices refreshed**:
>     - Added `gpt-5.1-codex`, `gpt-5.1-codex-mini`.
>     - Retained `gpt-4-turbo`, `o1-preview`, `gpt-4`.
>     - Removed older entries (`o1-mini`, `gpt-4.1-mini`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 094148bec987cc09046f36f1bc8650fd3fecebc8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->