### PR TITLE
🧠 feat: GPT-5.1-thinking + HIGH reasoning

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
+++ b/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
@@ -22,7 +22,7 @@ on:
         description: "OpenAI model"
         required: false
         type: string  
-        default: "gpt-5.1-pro"
+        default: "gpt-5.1-thinking"
       temperature:
         description: "Temperature"
         required: false
@@ -55,9 +55,10 @@ on:
         description: "OpenAI model"
         required: false
         type: choice
-        default: "gpt-5.1-pro"
+        default: "gpt-5.1-thinking"
         options:
-          - gpt-5.1-pro
+          - gpt-5.1-thinking
+          - gpt-5.1
           - gpt-4-turbo
           - o1-preview
           - o1-mini
@@ -133,7 +134,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_MODEL: ${{ inputs.anthropic_model || 'claude-sonnet-4-5-20250929' }}
-          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-5.1-pro' }}
+          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-5.1-thinking' }}
           TEMPERATURE: ${{ inputs.temperature || '0.2' }}
           PROMPT: ${{ inputs.prompt }}
         run: |
@@ -198,6 +199,7 @@ jobs:
           # === OPENAI CALL ===
           echo "🟢 Calling OpenAI ($OPENAI_MODEL)..."
           echo "   Temperature: $TEMPERATURE"
+          echo "   Reasoning Effort: HIGH"
           echo ""
           
           jq -n \
@@ -210,7 +212,8 @@ jobs:
                 {role: "user", content: $prompt}
               ],
               temperature: ($temp | tonumber),
-              max_tokens: 4000
+              max_tokens: 4000,
+              reasoning_effort: "high"
             }' > /tmp/openai_payload.json
           
           OPENAI_RESP=$(curl -s https://api.openai.com/v1/chat/completions \
@@ -239,7 +242,7 @@ jobs:
       - name: Step 2 - Synthesize Final Review (OpenAI)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-5.1-pro' }}
+          OPENAI_MODEL: ${{ inputs.openai_model || 'gpt-5.1-thinking' }}
           ANTHROPIC_MODEL: ${{ inputs.anthropic_model || 'claude-sonnet-4-5-20250929' }}
         run: |
           set -euo pipefail
@@ -279,8 +282,8 @@ jobs:
             echo "---"
             echo "**🤖 Review Models:**"
             echo "- Primary: Anthropic $ANTHROPIC_MODEL"
-            echo "- Secondary: OpenAI $OPENAI_MODEL"
-            echo "- Synthesis: OpenAI $OPENAI_MODEL"
+            echo "- Secondary: OpenAI $OPENAI_MODEL (reasoning_effort: HIGH 🧠)"
+            echo "- Synthesis: OpenAI $OPENAI_MODEL (reasoning_effort: HIGH 🧠)"
           } > /tmp/synthesis_prompt.txt
           
           SYNTHESIS_PROMPT=$(cat /tmp/synthesis_prompt.txt)
@@ -295,10 +298,13 @@ jobs:
                 {role: "user", content: $prompt}
               ],
               temperature: 0.3,
-              max_tokens: 6000
+              max_tokens: 6000,
+              reasoning_effort: "high"
             }' > /tmp/synthesis_payload.json
           
-          echo "🟢 Calling OpenAI for synthesis..."
+          echo "🟢 Calling OpenAI for synthesis ($OPENAI_MODEL)..."
+          echo "   Reasoning Effort: HIGH"
+          echo ""
           
           SYNTHESIS_RESP=$(curl -s https://api.openai.com/v1/chat/completions \
             -H "Content-Type: application/json" \
@@ -365,7 +371,8 @@ jobs:
             echo ""
             echo "- **PR**: #${{ steps.parse.outputs.pr_number }}"
             echo "- **Anthropic Model**: ${{ inputs.anthropic_model || 'claude-sonnet-4-5-20250929' }}"
-            echo "- **OpenAI Model**: ${{ inputs.openai_model || 'gpt-4.1-mini' }}"
+            echo "- **OpenAI Model**: ${{ inputs.openai_model || 'gpt-5.1-thinking' }}"
+            echo "- **Reasoning Effort**: HIGH 🧠"
             echo "- **Status**: $([ -s final_review.txt ] && echo "✅ Success" || echo "❌ Failed")"
             echo ""
             echo "### Review Sizes"


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
## 🧠 GPT-5.1-thinking + HIGH reasoning effort

**Deep thinking mode**: Maximum intelligence!

### Features
- ✅ Correct model: `gpt-5.1-thinking`
- ✅ `reasoning_effort: high`
- ✅ Visible in logs & summary
- ✅ Attribution in PR comments

### Configuration
```json
{
  "model": "gpt-5.1-thinking",
  "reasoning_effort": "high",
  "max_tokens": 4000
}
```

Ready for ULTIMATE code review! 🚀


___

### **PR Type**
Enhancement


___

### **Description**
- Update OpenAI model from `gpt-5.1-pro` to `gpt-5.1-thinking`

- Add `reasoning_effort: "high"` parameter to OpenAI API calls

- Display reasoning effort status in logs and PR summary

- Update model options and defaults across workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OpenAI Model Config"] -->|Update default| B["gpt-5.1-thinking"]
  C["API Payloads"] -->|Add parameter| D["reasoning_effort: high"]
  E["Logs & Summary"] -->|Display| F["Reasoning Effort: HIGH 🧠"]
  B --> D
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v2-multi-model.yml</strong><dd><code>Configure GPT-5.1-thinking with high reasoning effort</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v2-multi-model.yml

<ul><li>Replace default OpenAI model from <code>gpt-5.1-pro</code> to <code>gpt-5.1-thinking</code> in <br>input defaults and environment variables<br> <li> Add <code>reasoning_effort: "high"</code> parameter to both Step 1 (parallel API <br>call) and Step 2 (synthesis) OpenAI API payloads<br> <li> Update model selection options to include <code>gpt-5.1-thinking</code> and <code>gpt-5.1</code><br> <li> Add reasoning effort status messages in logs for both API calls and <br>update PR summary to display <code>reasoning_effort: HIGH 🧠</code></ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/91/files#diff-5404cd0d65811e9002fd2863f66a02303398f7ca5bda4f6353f6e7f61b89a879">+18/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches OpenAI to `gpt-5.1-thinking` by default and adds `reasoning_effort: "high"` to OpenAI calls, with corresponding logs and summary updates.
> 
> - **Workflow (.github/workflows/merglbot-pr-assistant-v2-multi-model.yml)**
>   - **Model defaults/options**:
>     - Change OpenAI default to `gpt-5.1-thinking` (was `gpt-5.1-pro`).
>     - Update dispatch options to include `gpt-5.1-thinking` and `gpt-5.1`.
>   - **OpenAI requests**:
>     - Add `reasoning_effort: "high"` to review and synthesis payloads.
>     - Keep `max_tokens` at 4000 (review) and 6000 (synthesis).
>   - **Logging/summary**:
>     - Echo “Reasoning Effort: HIGH” during calls and synthesis.
>     - Workflow summary shows selected OpenAI model and reasoning effort.
>     - Attribution in synthesis prompt notes secondary/synthesis model with high reasoning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1be10310a528021f8c9aee8284391436980ba867. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->