### PR TITLE
🔧 fix: remove temperature for GPT-5.1

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
+++ b/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
@@ -205,13 +205,11 @@ jobs:
           jq -n \
             --arg model "$OPENAI_MODEL" \
             --arg prompt "$FULL_PROMPT" \
-            --arg temp "$TEMPERATURE" \
             '{
               model: $model,
               messages: [
                 {role: "user", content: $prompt}
               ],
-              temperature: ($temp | tonumber),
               max_completion_tokens: 4000,
               reasoning_effort: "high"
             }' > /tmp/openai_payload.json
@@ -294,7 +292,6 @@ jobs:
                 {role: "system", content: "You are an expert code reviewer that synthesizes multiple AI reviews into a single comprehensive review."},
                 {role: "user", content: $prompt}
               ],
-              temperature: 0.3,
               max_completion_tokens: 6000,
               reasoning_effort: "high"
             }' > /tmp/synthesis_payload.json


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
GPT-5.1 doesn't support custom temperature.

**Error**: Only default (1) value is supported.

**Fix**: Removed temperature from OpenAI calls.

YAML: ✅ Valid


___

### **PR Type**
Bug fix


___

### **Description**
- Remove temperature parameter from GPT-5.1 API calls

- Temperature not supported by GPT-5.1 model

- Removed from OpenAI Step 1 and Synthesis API payloads

- Anthropic calls remain unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OpenAI API Calls"] -->|"Remove temperature"| B["GPT-5.1 Compatible"]
  C["Step 1 Call"] -->|"Delete temp param"| B
  D["Synthesis Call"] -->|"Delete temp param"| B
  E["Anthropic Calls"] -->|"Unchanged"| F["Still Supported"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v2-multi-model.yml</strong><dd><code>Remove temperature from GPT-5.1 API payloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v2-multi-model.yml

<ul><li>Removed <code>--arg temp "$TEMPERATURE"</code> from OpenAI Step 1 jq payload<br> <li> Removed <code>temperature: ($temp | tonumber)</code> field from Step 1 API request<br> <li> Removed hardcoded <code>temperature: 0.3</code> from Synthesis API request<br> <li> Kept all other API parameters and configuration intact</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/95/files#diff-5404cd0d65811e9002fd2863f66a02303398f7ca5bda4f6353f6e7f61b89a879">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the temperature parameter from OpenAI chat and synthesis requests in the PR assistant workflow to comply with model limitations.
> 
> - **CI/Workflow (`.github/workflows/merglbot-pr-assistant-v2-multi-model.yml`)**:
>   - **OpenAI requests**:
>     - Step 1 (secondary analysis): drop `temperature` from the chat completion payload; keep `reasoning_effort: "high"` and token limits.
>     - Step 2 (final synthesis): remove fixed `temperature: 0.3` from the synthesis payload; retain `reasoning_effort: "high"` and token limits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3627be0fd44b7f2f86f4966daadc0658467a09e5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->