### PR TITLE
🔧 fix: broken pipe in logging

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
+++ b/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml
@@ -188,7 +188,8 @@ jobs:
           echo "   Length: $(echo "$ANTHROPIC_RESP" | wc -c) chars"
           echo ""
           echo "📥 Anthropic Full Response (first 2000 chars):"
-          echo "$ANTHROPIC_RESP" | jq '.' | head -c 2000
+          echo "$ANTHROPIC_RESP" | head -c 2000
+          echo ""
           echo "..."
           echo ""
           
@@ -240,7 +241,8 @@ jobs:
           echo "   Message structure: $(echo "$OPENAI_RESP" | jq -r '.choices[0].message | keys | join(", ")' 2>/dev/null || echo 'N/A')"
           echo ""
           echo "📥 OpenAI Full Response (first 2000 chars):"
-          echo "$OPENAI_RESP" | jq '.' | head -c 2000
+          echo "$OPENAI_RESP" | head -c 2000
+          echo ""
           echo "..."
           echo ""
           
@@ -359,7 +361,8 @@ jobs:
           echo "   Response keys: $(echo "$SYNTHESIS_RESP" | jq -r 'keys | join(", ")' 2>/dev/null || echo 'N/A')"
           echo ""
           echo "📥 Synthesis Full Response (first 2000 chars):"
-          echo "$SYNTHESIS_RESP" | jq '.' | head -c 2000
+          echo "$SYNTHESIS_RESP" | head -c 2000
+          echo ""
           echo "..."
           echo ""
           


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
Fix broken pipe error in logs.

**Error**: `jq '.' | head -c 2000` → Broken pipe

**Fix**: Use `head -c 2000` directly

YAML: ✅


___

### **PR Type**
Bug fix


___

### **Description**
- Remove `jq` pipe to prevent broken pipe errors

- Apply fix across three API response logging sections

- Add blank line after response output for clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Response Logging"] -->|Remove jq pipe| B["Direct head -c 2000"]
  B -->|Applied to| C["Anthropic Response"]
  B -->|Applied to| D["OpenAI Response"]
  B -->|Applied to| E["Synthesis Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merglbot-pr-assistant-v2-multi-model.yml</strong><dd><code>Remove jq pipe to fix broken pipe errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merglbot-pr-assistant-v2-multi-model.yml

<ul><li>Removed <code>jq '.'</code> pipe from three API response logging sections <br>(Anthropic, OpenAI, Synthesis)<br> <li> Changed from <code>echo "$RESPONSE" | jq '.' | head -c 2000</code> to <code>echo </code><br><code>"$RESPONSE" | head -c 2000</code><br> <li> Added blank line (<code>echo ""</code>) after each response output for improved log <br>readability<br> <li> Prevents broken pipe errors when piping through <code>jq</code> before truncating <br>output</ul>


</details>


  </td>
  <td><a href="https://github.com/merglbot-core/github/pull/99/files#diff-5404cd0d65811e9002fd2863f66a02303398f7ca5bda4f6353f6e7f61b89a879">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop piping API responses through jq before truncation; directly use head -c 2000 in workflow logs.
> 
> - **Workflows**:
>   - Update `/.github/workflows/merglbot-pr-assistant-v2-multi-model.yml` to avoid piping responses through `jq` before truncation:
>     - Anthropic, OpenAI, and Synthesis sections now use `echo "$RESP" | head -c 2000` (removed `| jq '.'`).
>     - Add a newline `echo ""` after truncated output for readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d055d9d84263ad88d03a10c5fd0d09fff2a204c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->