### PR TITLE
ci: add OSSF Scorecard reusable workflow

### DIFF
--- a/.github/workflows/reusable-security-scorecard.yml
+++ b/.github/workflows/reusable-security-scorecard.yml
@@ -51,6 +51,7 @@ jobs:
   scorecard:
     name: Scorecard Analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     
     steps:
       - name: Checkout repository
@@ -129,6 +130,7 @@ jobs:
   sha-pinning-check:
     name: SHA Pinning Verification
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
Adds reusable workflow for OSSF Scorecard security checks across all repositories.

## Changes
- **Scorecard Workflow**: Automated security posture assessment
- **Threshold**: Minimum score of 7.0 required for passing
- **SHA Pinning**: All actions use SHA-based references
- **Integration**: Results uploaded to GitHub Security tab

## Workflow Features
| Check | Weight | Description |
|-------|--------|-------------|
| Binary Artifacts | High | No binaries in repo |
| Branch Protection | High | Required reviews, status checks |
| Code Review | High | All changes reviewed |
| Dangerous Workflow | High | No dangerous patterns |
| Dependency Update Tool | Medium | Dependabot enabled |
| Pinned Dependencies | High | SHA-pinned actions |
| Token Permissions | Medium | Least privilege |

## Acceptance Criteria
- [x] Scorecard threshold: 7.0 minimum
- [x] SHA pinning enforced
- [x] Results uploaded to Security tab

## Related
- Deep Research Phase 1.6
- [OSSF Scorecard](https://github.com/ossf/scorecard)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a reusable GitHub Actions workflow that runs OSSF Scorecard with a configurable pass threshold, publishes results, and verifies SHA pinning in workflows.
> 
> - **Workflows**:
>   - New reusable workflow: `.github/workflows/reusable-security-scorecard.yml`.
> - **Jobs**:
>   - **`scorecard`**: Runs `ossf/scorecard-action`, parses and summarizes results, uploads JSON artifact, optionally uploads SARIF to Code Scanning, and fails if score < `inputs.minimum_score`.
>   - **`sha-pinning-check`**: Audits `.github/workflows` for non–SHA-pinned `uses:` references, summarizes findings, and optionally fails on issues.
> - **Inputs & Permissions**:
>   - Inputs: `minimum_score` (default `7.0`), `fail_on_low_score`, `publish_results`; optional `secrets.scorecard_token`.
>   - Permissions: `security-events: write`, `contents: read`, `actions: read`.
> - **Hardening**:
>   - All referenced actions pinned to commit SHAs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd459ef10d0501d9496cfc98ce529d6e5473a32d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->