### PR TITLE
feat: add reusable build attestation workflow (SLSA)

### DIFF
--- a/.github/workflows/reusable-build-attest.yml
+++ b/.github/workflows/reusable-build-attest.yml
@@ -87,6 +87,7 @@ jobs:
   build:
     name: Build & Push Image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       digest: ${{ steps.build.outputs.digest }}
       tag: ${{ steps.meta.outputs.version }}
@@ -217,6 +218,7 @@ jobs:
     needs: build
     if: inputs.scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     
     steps:
       - name: Authenticate to GCP
@@ -249,6 +251,7 @@ jobs:
     needs: [build, scan]
     if: inputs.attest && inputs.push
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       attestation_id: ${{ steps.attest.outputs.attestation_id }}
     
@@ -311,6 +314,7 @@ jobs:
     needs: [build, scan, attest]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     
     steps:
       - name: Generate Summary


### PR DESCRIPTION
## Summary
Adds reusable workflow for SLSA provenance attestation and Binary Authorization integration.

## Changes
- **Build Attestation**: Generate SLSA provenance for container images
- **Cosign Integration**: Sign images with KMS-backed key
- **Binary Authorization**: Attest to build origin
- **WIF Support**: Use Workload Identity Federation

## Workflow Inputs
| Input | Required | Description |
|-------|----------|-------------|
| image_ref | ✅ | Container image reference |
| project_id | ✅ | GCP project ID |
| attestor_name | ✅ | Binary Auth attestor |
| service_account | ✅ | WIF service account |

## Usage Example
```yaml
jobs:
  build:
    # ... build job
  attest:
    needs: build
    uses: merglbot-core/github/.github/workflows/reusable-build-attest.yml@main
    with:
      image_ref: gcr.io/project/image:tag
      project_id: merglbot-artifacts
      attestor_name: merglbot-build-attestor
      service_account: ci-runner@merglbot-artifacts.iam.gserviceaccount.com
```

## Related
- Deep Research Phase 2.1
- [SLSA Framework](https://slsa.dev/)
- merglbot-core/infra PR #80 (Binary Auth terraform)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add reusable GitHub Actions workflow to build/push container images with SLSA provenance, run Trivy scan, and create Binary Authorization attestations using GCP WIF.
> 
> - **CI/CD**: Add reusable workflow `/.github/workflows/reusable-build-attest.yml`.
>   - **Build**:
>     - Auth via GCP WIF; configure Artifact Registry Docker auth.
>     - Generate image metadata/tags; build and push with Buildx (`provenance`, `sbom`, cache).
>     - Generate and upload SLSA provenance artifact; expose `digest`, `tag`, `provenance` outputs.
>   - **Scan** (optional): Run Trivy on built digest; upload SARIF to GitHub.
>   - **Attest** (optional): Create and verify Binary Authorization attestation via `gcloud`; output `attestation_id` and step summary.
>   - **Summary**: Job summarization with statuses and image details.
> - **Interface**:
>   - Inputs: `image_name`, `dockerfile`, `context`, `registry`, `push`, `attest`, `scan`.
>   - Secrets: `wif_provider`, `wif_service_account`.
>   - Outputs: `image_digest`, `image_tag`, `attestation_id`, `slsa_provenance`.
> - **Permissions**: `contents`, `packages`, `id-token`, `security-events` set for workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ae73430413c5a64c2a2c0e448a81901585ce866. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->