### PR TITLE
ci: add reusable OpenAPI lint workflow

### DIFF
--- a/.github/workflows/reusable-openapi-lint.yml
+++ b/.github/workflows/reusable-openapi-lint.yml
@@ -36,6 +36,7 @@ jobs:
   lint:
     name: Lint OpenAPI Specification
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
Adds reusable workflow for OpenAPI specification validation using Redocly CLI.

## Changes
- **OpenAPI Linting**: Validate OpenAPI 3.x specifications
- **Redocly Integration**: Professional-grade validation
- **CI Integration**: Reusable across repositories

## Usage
```yaml
jobs:
  lint:
    uses: merglbot-core/github/.github/workflows/reusable-openapi-lint.yml@main
    with:
      openapi_spec_path: './api/openapi.yml'
```

## Related
- Deep Research Phase 2.3
- merglbot-public/docs#148 - API Governance docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a reusable GitHub Actions workflow to lint OpenAPI specs with Spectral, validate syntax, detect breaking changes, and optionally fail on warnings.
> 
> - **Workflow**: Adds `/.github/workflows/reusable-openapi-lint.yml` reusable job for OpenAPI validation.
>   - Inputs: `spec_path` (default `openapi.yml`), `fail_on_warning` (default `false`).
>   - Permissions: `contents: read`, `pull-requests: write`.
> - **Linting**: Uses Spectral with a custom Merglbot ruleset.
>   - Enforces/flags: RFC7807 error schema, rate limiting headers, path versioning, security schemes and per-operation security, operation `description` and `operationId`, naming conventions (camelCase properties, snake_case query params).
>   - Writes severity counts and details to job summary; fails on errors, optionally on warnings.
> - **Validation**: Performs YAML syntax check (via Python) and installs `ajv-cli` for JSON Schema validation scaffolding.
> - **Breaking Changes**: On PRs, compares base vs current spec with `oasdiff` and reports potential breaking changes in job summary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d7fc0b4ed27a24a93d77470bbeea6f99d4389be. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->