### PR TITLE
ci: add Terraform drift scan workflow

### DIFF
--- a/.github/workflows/terraform-drift-scan.yml
+++ b/.github/workflows/terraform-drift-scan.yml
@@ -38,6 +38,7 @@ jobs:
   scan-bootstrap:
     name: Scan Bootstrap
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: inputs.workspace == 'all' || inputs.workspace == 'bootstrap' || github.event_name == 'schedule'
     outputs:
       drift_detected: ${{ steps.plan.outputs.drift_detected }}
@@ -91,6 +92,7 @@ jobs:
   scan-core:
     name: Scan Core
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: inputs.workspace == 'all' || inputs.workspace == 'core' || github.event_name == 'schedule'
     outputs:
       drift_detected: ${{ steps.plan.outputs.drift_detected }}
@@ -144,6 +146,7 @@ jobs:
   report:
     name: Generate Report
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [scan-bootstrap, scan-core]
     if: always()
     


### PR DESCRIPTION
## Summary
Adds weekly Terraform drift detection workflow for infrastructure state verification.

## Changes
- **Weekly Scan**: Runs every Monday at midnight UTC
- **WIF Integration**: Uses Workload Identity Federation for GCP access
- **Issue Reporting**: Creates GitHub Issue on drift detection
- **Manual Trigger**: workflow_dispatch for on-demand scans

## Schedule
```yaml
on:
  schedule:
    - cron: '0 0 * * 1'  # Weekly Monday midnight
```

## Related
- Deep Research Phase 2.4
- merglbot-core/infra#81 - OPA policies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a scheduled/on-demand Terraform drift scan for bootstrap and core workspaces with artifact reports and automatic issue creation.
> 
> - **CI/CD (GitHub Actions)**:
>   - **New Workflow**: `/.github/workflows/terraform-drift-scan.yml`
>     - Schedule: `cron: '0 8 * * 1'` (weekly, 08:00 UTC) + `workflow_dispatch` with `workspace` choice (`all|bootstrap|core|public|clients`).
>     - Permissions: `contents: read`, `id-token: write`, `issues: write`.
>     - Env: `TF_VERSION=1.6.0`, `WORKING_DIR=merglbot-core/infra/terraform/v2`.
>   - **Drift Scans**:
>     - `scan-bootstrap` and `scan-core`: checkout, GCP auth via WIF, Terraform setup/init, `terraform plan -detailed-exitcode` for drift, summary output, and upload `plan-output.txt` artifacts.
>   - **Reporting**:
>     - `report` job aggregates drift results, writes a summary table, and when drift found, creates/updates a labeled GitHub Issue with run link and next steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca0e2f027cc2d3188a1dc8c07a9e5d92ac0a2d63. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->