### PR TITLE
ci: add reusable accessibility test workflow

### DIFF
--- a/.github/workflows/reusable-a11y-test.yml
+++ b/.github/workflows/reusable-a11y-test.yml
@@ -46,6 +46,7 @@ jobs:
   axe-core:
     name: axe-core Accessibility Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     
     steps:
       - name: Checkout repository
@@ -130,6 +131,7 @@ jobs:
   pa11y:
     name: Pa11y Accessibility Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     
     steps:
       - name: Checkout repository
@@ -179,6 +181,7 @@ jobs:
   summary:
     name: Accessibility Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [axe-core, pa11y]
     if: always()
     


### PR DESCRIPTION
## Summary
Adds reusable workflow for automated accessibility testing using Pa11y and axe-core.

## Changes
- **Pa11y Integration**: WCAG 2.2 AA compliance checks
- **axe-core Integration**: Fast accessibility validation
- **Report Generation**: HTML and JSON artifacts
- **Configurable Standards**: WCAG2A, WCAG2AA, Section508

## Usage
```yaml
jobs:
  a11y:
    uses: merglbot-core/github/.github/workflows/reusable-a11y-test.yml@main
    with:
      target_url: 'https://staging.merglbot.ai'
      axe_ruleset: 'WCAG2AA'
      pa11y_standard: 'WCAG2AA'
```

## Related
- Deep Research Phase 3.3
- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a reusable workflow that runs axe-core and Pa11y WCAG checks against configurable pages, uploads reports, and summarizes/fails on violations.
> 
> - **CI Workflow**: Adds reusable workflow `/.github/workflows/reusable-a11y-test.yml` for automated accessibility testing.
>   - **Jobs**:
>     - `axe-core`: Installs `@axe-core/cli`, tests pages with `--tags` per `standard`, writes per-page JSON reports, aggregates violations, optional fail via `fail_on_violations`.
>     - `pa11y`: Installs `pa11y` and HTML reporter, runs JSON reports per page, aggregates issue count.
>     - `summary`: Generates combined status summary and WCAG 2.2 notes in `$GITHUB_STEP_SUMMARY`.
>   - **Inputs**: `url` (required), `standard` (default `WCAG2AA`), `fail_on_violations` (default `true`), `pages` (JSON array, default `["/"]`).
>   - **Artifacts**: Uploads `a11y-report-*.json` and `pa11y-*.json` with 30-day retention.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a3fa2cfc4fcd039152ca65b7ba846973039f2fa. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->