### PR TITLE
fix(deploy): add cross-project Secret Manager support

### DIFF
--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -219,14 +219,51 @@ jobs:
             gcloud_cmd+=("--set-env-vars=${{ inputs.env_vars }}")
           fi
           
-          if [ -n "${{ inputs.secrets }}" ]; then
-            # Convert newline-separated to comma-separated list (ignore blank lines)
-            SECRET_LIST=$(echo "${{ inputs.secrets }}" | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')
-            gcloud_cmd+=("--set-secrets=${SECRET_LIST}")
-          fi
           
-          # Execute the command
-          "${gcloud_cmd[@]}"
+          if [ -n "$SECRETS_INPUT" ]; then
+            # Check if any secret uses cross-project format (projects/...)
+            if echo "$SECRETS_INPUT" | grep -q "projects/"; then
+              echo "::notice::Cross-project secrets detected, using gcloud run services replace"
+              
+              # Deploy without secrets first
+              "${gcloud_cmd[@]}"
+              
+              # Export current service config
+              gcloud run services describe "$SERVICE" --region="$REGION" --project="$PROJECT_ID" --format=export > /tmp/service.yaml
+              
+              # Create python script for secret injection using printf
+              printf '%s\n' 'import yaml, sys' > /tmp/inject_secret.py
+              printf '%s\n' 'env_name, secret_name, secret_version = sys.argv[1:4]' >> /tmp/inject_secret.py
+              printf '%s\n' 'with open("/tmp/service.yaml") as f: svc = yaml.safe_load(f)' >> /tmp/inject_secret.py
+              printf '%s\n' 'env_list = svc["spec"]["template"]["spec"]["containers"][0].get("env", [])' >> /tmp/inject_secret.py
+              printf '%s\n' 'env_list = [e for e in env_list if e.get("name") != env_name]' >> /tmp/inject_secret.py
+              printf '%s\n' 'env_list.append({"name": env_name, "valueFrom": {"secretKeyRef": {"name": secret_name, "key": secret_version}}})' >> /tmp/inject_secret.py
+              printf '%s\n' 'svc["spec"]["template"]["spec"]["containers"][0]["env"] = env_list' >> /tmp/inject_secret.py
+              printf '%s\n' 'with open("/tmp/service.yaml", "w") as f: yaml.dump(svc, f, default_flow_style=False)' >> /tmp/inject_secret.py
+              
+              # Process each secret
+              echo "$SECRETS_INPUT" | while IFS= read -r line; do
+                [ -z "$line" ] && continue
+                ENV_NAME="${line%%=*}"
+                SECRET_REF="${line#*=}"
+                SECRET_NAME="${SECRET_REF%%:*}"
+                SECRET_VERSION="${SECRET_REF##*:}"
+                [ "$SECRET_VERSION" = "$SECRET_NAME" ] && SECRET_VERSION="latest"
+                python3 /tmp/inject_secret.py "$ENV_NAME" "$SECRET_NAME" "$SECRET_VERSION"
+              done
+              
+              # Apply updated config
+              gcloud run services replace /tmp/service.yaml --region="$REGION" --project="$PROJECT_ID"
+            else
+              # Standard secrets (same project) - use --set-secrets
+              SECRET_LIST=$(echo "$SECRETS_INPUT" | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')
+              gcloud_cmd+=("--set-secrets=${SECRET_LIST}")
+              "${gcloud_cmd[@]}"
+            fi
+          else
+            # No secrets - just deploy
+            "${gcloud_cmd[@]}"
+          fi
 
           URL=$(gcloud run services describe "$SERVICE" --region="$REGION" --project="$PROJECT_ID" --format="value(status.url)")
           echo "url=$URL" >> $GITHUB_OUTPUT
@@ -234,9 +271,7 @@ jobs:
       - name: Update deployment summary
         if: always()
         run: |
-          cat >> $GITHUB_STEP_SUMMARY << EOF
-          ## 🚀 Reusable Deployment
-          - **Service**: $SERVICE
-          - **URL**: ${{ steps.deploy.outputs.url }}
-          - **Status**: ${{ job.status }}
-          EOF
+          echo "## 🚀 Reusable Deployment" >> $GITHUB_STEP_SUMMARY
+          echo "- **Service**: $SERVICE" >> $GITHUB_STEP_SUMMARY
+          echo "- **URL**: ${{ steps.deploy.outputs.url }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- `gcloud run deploy --set-secrets` does not support cross-project secret references (`projects/PROJECT/secrets/NAME`)
- This causes deploy failures when services need SSOT secrets from a centralized project
- Solution: detect cross-project secrets and use `gcloud run services replace` with YAML manipulation instead

## Root Cause

admin-portal deploy failing with:
```
ERROR: (gcloud.run.deploy) 'projects/merglbot-website-prd/secrets/jwt-secret' is not a valid secret name.
```

## Changes

- Detect cross-project secrets by checking for "projects/" prefix in secret reference
- For cross-project: deploy first, then export YAML, inject secrets via python3 -c, apply with `gcloud run services replace`
- For same-project: use existing `--set-secrets` flow (faster)

## Test plan

- [ ] Trigger admin-portal deploy after merge
- [ ] Verify admin-portal uses cross-project jwt-secret from merglbot-website-prd
- [ ] Verify same-project secrets still work (e.g., google-client-id-secret)

## Related

- Fixes: admin-portal deploy failure (run 20149245510)
- Part of: Proteinaco 401 auth loop fix (JWT secret SSOT alignment)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cross-project Secret Manager support by detecting `projects/...` secret refs and switching to YAML-based `gcloud run services replace`, otherwise using `--set-secrets`.
> 
> - **CI/CD (Cloud Run deploy workflow)**:
>   - **Secrets handling**:
>     - Detect cross-project secret refs (`projects/...`).
>     - Deploy without secrets, export YAML, inject env with `secretKeyRef` via Python, then `gcloud run services replace`.
>     - For same-project secrets, continue using `--set-secrets`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bab4a1511432ef1fa3fc5e80b6397dad1ab0a448. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->