### PR TITLE
fix(deploy): add missing SECRETS_INPUT env var

### DIFF
--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -192,6 +192,8 @@ jobs:
       
       - name: Deploy to Cloud Run
         id: deploy
+        env:
+          SECRETS_INPUT: ${{ inputs.secrets }}
         run: |
           set -euo pipefail
           


### PR DESCRIPTION
Quick fix for missing env var definition

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defines SECRETS_INPUT from inputs.secrets in the deploy step to enable secret handling during Cloud Run deployment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61772b121aba52104322b924e10ae70569bc1d0c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->