### PR TITLE
fix(deploy): use gcloud run services update for cross-project secrets

### DIFF
--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -227,35 +227,21 @@ jobs:
             if echo "$SECRETS_INPUT" | grep -q "projects/"; then
               echo "::notice::Cross-project secrets detected, using gcloud run services replace"
               
+              
               # Deploy without secrets first
               "${gcloud_cmd[@]}"
               
-              # Export current service config
-              gcloud run services describe "$SERVICE" --region="$REGION" --project="$PROJECT_ID" --format=export > /tmp/service.yaml
-              
-              # Create python script for secret injection using printf
-              printf '%s\n' 'import yaml, sys' > /tmp/inject_secret.py
-              printf '%s\n' 'env_name, secret_name, secret_version = sys.argv[1:4]' >> /tmp/inject_secret.py
-              printf '%s\n' 'with open("/tmp/service.yaml") as f: svc = yaml.safe_load(f)' >> /tmp/inject_secret.py
-              printf '%s\n' 'env_list = svc["spec"]["template"]["spec"]["containers"][0].get("env", [])' >> /tmp/inject_secret.py
-              printf '%s\n' 'env_list = [e for e in env_list if e.get("name") != env_name]' >> /tmp/inject_secret.py
-              printf '%s\n' 'env_list.append({"name": env_name, "valueFrom": {"secretKeyRef": {"name": secret_name, "key": secret_version}}})' >> /tmp/inject_secret.py
-              printf '%s\n' 'svc["spec"]["template"]["spec"]["containers"][0]["env"] = env_list' >> /tmp/inject_secret.py
-              printf '%s\n' 'with open("/tmp/service.yaml", "w") as f: yaml.dump(svc, f, default_flow_style=False)' >> /tmp/inject_secret.py
-              
-              # Process each secret
+              # Then add cross-project secrets one by one using update
               echo "$SECRETS_INPUT" | while IFS= read -r line; do
                 [ -z "$line" ] && continue
                 ENV_NAME="${line%%=*}"
                 SECRET_REF="${line#*=}"
-                SECRET_NAME="${SECRET_REF%%:*}"
-                SECRET_VERSION="${SECRET_REF##*:}"
-                [ "$SECRET_VERSION" = "$SECRET_NAME" ] && SECRET_VERSION="latest"
-                python3 /tmp/inject_secret.py "$ENV_NAME" "$SECRET_NAME" "$SECRET_VERSION"
+                echo "Adding secret: $ENV_NAME"
+                gcloud run services update "$SERVICE" \
+                  --region="$REGION" \
+                  --project="$PROJECT_ID" \
+                  --update-secrets="$ENV_NAME=$SECRET_REF"
               done
-              
-              # Apply updated config
-              gcloud run services replace /tmp/service.yaml --region="$REGION" --project="$PROJECT_ID"
             else
               # Standard secrets (same project) - use --set-secrets
               SECRET_LIST=$(echo "$SECRETS_INPUT" | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')


### PR DESCRIPTION
gcloud run services replace requires Cloud Resource Manager API which isn't enabled. Using gcloud run services update --update-secrets instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches cross-project secrets to post-deploy per-secret updates with `gcloud run services update --update-secrets`, removing the YAML export/Python injection approach.
> 
> - **CI/CD – Cloud Run deploy workflow (`.github/workflows/reusable-deploy-cloud-run.yml`)**:
>   - **Cross-project secrets handling**:
>     - Deploys service first without secrets, then iteratively adds each secret via `gcloud run services update --update-secrets`.
>     - Removes prior flow that exported service YAML and injected secrets via a temporary Python script and `gcloud run services replace`.
>   - **Standard (same-project) secrets** path via `--set-secrets` remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f20442ac4c46e1161b7118d54b47e22ecdc5595. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->