### PR TITLE
docs: link cross-project secrets SSOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ This repository follows the [Merglbot Rulebook v2](https://github.com/merglbot-p
 **README_MERGLBOT_IMPLEMENTATION.md** (264 lines) - WARP implementation guide
 
 **Related WARP Docs:**
-- [MERGLBOT_GITHUB_ACTIONS_REUSABLE_WORKFLOWS.md](https://github.com/merglbot-public/docs/blob/main/MERGLBOT_GITHUB_ACTIONS_REUSABLE_WORKFLOWS.md) - 491 lines
-- [MERGLBOT_GITHUB_ACTIONS_GLOBAL_RULES.md](https://github.com/merglbot-public/docs/blob/main/MERGLBOT_GITHUB_ACTIONS_GLOBAL_RULES.md) - Global rules
 - [MERGLBOT_CROSS_PROJECT_SECRETS_SSOT.md](https://github.com/merglbot-public/docs/blob/main/MERGLBOT_CROSS_PROJECT_SECRETS_SSOT.md) - Cloud Run cross-project secrets SSOT (alias mapping)
+- [MERGLBOT_GITHUB_ACTIONS_GLOBAL_RULES.md](https://github.com/merglbot-public/docs/blob/main/MERGLBOT_GITHUB_ACTIONS_GLOBAL_RULES.md) - Global rules
+- [MERGLBOT_GITHUB_ACTIONS_REUSABLE_WORKFLOWS.md](https://github.com/merglbot-public/docs/blob/main/MERGLBOT_GITHUB_ACTIONS_REUSABLE_WORKFLOWS.md) - 491 lines
 - [MERGLBOT_GLOBAL_RULES.txt](https://github.com/merglbot-public/docs/blob/main/MERGLBOT_GLOBAL_RULES.txt) § GitHub Actions - Security best practices
 - [MERGLBOT_QUICK_REFERENCE.md](https://github.com/merglbot-public/docs/blob/main/MERGLBOT_QUICK_REFERENCE.md) §1, §9 - GitHub Actions rules
 


### PR DESCRIPTION
## Summary
- Add a pointer to the canonical Cloud Run cross-project secrets SSOT documentation.

## Test plan
- N/A (documentation-only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a link in README to the Cloud Run cross-project secrets SSOT (alias mapping) documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4355112992e7abed8baa363ad79a6af3baf7d14. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->