### PR TITLE
ci: enforce SSOT WIF provider

### DIFF
--- a/.github/workflows/reusable-build-attest.yml
+++ b/.github/workflows/reusable-build-attest.yml
@@ -104,6 +104,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
+      - name: Validate WIF provider (SSOT)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SSOT_WIF_PROVIDER="projects/671585034644/locations/global/workloadIdentityPools/github-actions/providers/github-oidc"
+
+          if [ "${{ secrets.wif_provider }}" != "${SSOT_WIF_PROVIDER}" ]; then
+            echo "::error::wif_provider must point to the SSOT provider in merglbot-seed (${SSOT_WIF_PROVIDER})."
+            exit 1
+          fi
+
+          if [[ "${{ secrets.wif_service_account }}" == *@merglbot.iam.gserviceaccount.com ]]; then
+            echo "::error::wif_service_account points to a legacy service account in the DELETE_REQUESTED 'merglbot' project."
+            exit 1
+          fi
+
       - name: Authenticate to GCP
         id: auth
         uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
@@ -248,6 +265,23 @@ jobs:
       attestation_id: ${{ steps.attest.outputs.attestation_id }}
     
     steps:
+      - name: Validate WIF provider (SSOT)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SSOT_WIF_PROVIDER="projects/671585034644/locations/global/workloadIdentityPools/github-actions/providers/github-oidc"
+
+          if [ "${{ secrets.wif_provider }}" != "${SSOT_WIF_PROVIDER}" ]; then
+            echo "::error::wif_provider must point to the SSOT provider in merglbot-seed (${SSOT_WIF_PROVIDER})."
+            exit 1
+          fi
+
+          if [[ "${{ secrets.wif_service_account }}" == *@merglbot.iam.gserviceaccount.com ]]; then
+            echo "::error::wif_service_account points to a legacy service account in the DELETE_REQUESTED 'merglbot' project."
+            exit 1
+          fi
+
       - name: Authenticate to GCP
         uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
         with:

--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -75,6 +75,25 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v5.0.0
+
+      - name: Validate WIF provider (SSOT)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SSOT_WIF_PROVIDER="projects/671585034644/locations/global/workloadIdentityPools/github-actions/providers/github-oidc"
+
+          if [ "${{ secrets.GCP_WIF_PROVIDER }}" != "${SSOT_WIF_PROVIDER}" ]; then
+            echo "::error::GCP_WIF_PROVIDER must point to the SSOT provider in merglbot-seed (${SSOT_WIF_PROVIDER})."
+            echo "::error::Fix by updating the caller repo/org variable passed into this reusable workflow."
+            exit 1
+          fi
+
+          if [[ "${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}" == *@merglbot.iam.gserviceaccount.com ]]; then
+            echo "::error::GCP_WIF_SERVICE_ACCOUNT points to a legacy service account in the DELETE_REQUESTED 'merglbot' project."
+            echo "::error::Create a dedicated deploy SA in an active target project and update the repo variable."
+            exit 1
+          fi
      
       - name: Authenticate to Google Cloud (WIF)
         id: auth

--- a/.github/workflows/reusable-terraform-wif.yml
+++ b/.github/workflows/reusable-terraform-wif.yml
@@ -43,6 +43,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
+      - name: Validate WIF provider (SSOT)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SSOT_WIF_PROVIDER="projects/671585034644/locations/global/workloadIdentityPools/github-actions/providers/github-oidc"
+
+          if [ "${{ secrets.WIF_PROVIDER }}" != "${SSOT_WIF_PROVIDER}" ]; then
+            echo "::error::WIF_PROVIDER must point to the SSOT provider in merglbot-seed (${SSOT_WIF_PROVIDER})."
+            exit 1
+          fi
+
+          if [[ "${{ secrets.WIF_SERVICE_ACCOUNT }}" == *@merglbot.iam.gserviceaccount.com ]]; then
+            echo "::error::WIF_SERVICE_ACCOUNT points to a legacy service account in the DELETE_REQUESTED 'merglbot' project."
+            exit 1
+          fi
+
       - name: Authenticate to GCP (WIF)
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2
         with:


### PR DESCRIPTION
Adds drift-prevention checks to reusable workflows:
- Validates the WIF provider equals the SSOT provider in `merglbot-seed` (github-actions/github-oidc).
- Blocks legacy service accounts from the DELETE_REQUESTED `merglbot` project.

This prevents future regressions to invalid/legacy providers that cause `google-github-actions/auth` `invalid_target` failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add SSOT WIF provider and non-legacy service account validation steps to build/attest, Cloud Run deploy, and Terraform WIF reusable workflows, failing runs on mismatch.
> 
> - **Workflows: SSOT WIF enforcement**
>   - `reusable-build-attest.yml`:
>     - Add "Validate WIF provider (SSOT)" step to both `build` and `attest` jobs to require the canonical WIF provider and reject legacy `merglbot.iam.gserviceaccount.com` service accounts.
>   - `reusable-deploy-cloud-run.yml`:
>     - Add SSOT validation step ensuring `GCP_WIF_PROVIDER` matches the canonical provider and blocking legacy `merglbot` SAs; includes guidance messages for callers.
>   - `reusable-terraform-wif.yml`:
>     - Add SSOT validation step enforcing `WIF_PROVIDER` and disallowing legacy `merglbot` service accounts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d9194780164f76356d8260eed0fe1e3dbea43e2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->