### PR TITLE
fix(ci): reusable deploy secret list

### DIFF
--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -292,7 +292,7 @@ jobs:
 
             # Apply same-project secrets via gcloud deploy
             if [ "${#SAME_PROJECT_SECRET_LINES[@]}" -gt 0 ]; then
-              (IFS=,; SECRET_LIST="${SAME_PROJECT_SECRET_LINES[*]}")
+              { IFS=,; SECRET_LIST="${SAME_PROJECT_SECRET_LINES[*]}"; }
               gcloud_cmd+=("--set-secrets=${SECRET_LIST}")
             fi
 


### PR DESCRIPTION
Fixes a bash subshell bug in `reusable-deploy-cloud-run.yml` that caused `SECRET_LIST` to be undefined under `set -u`.

Observed failure example (consumer repo): https://github.com/merglbot-core/merglbot-admin/actions/runs/20180826116 (`SECRET_LIST: unbound variable`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes bash scoping so `SECRET_LIST` is properly built for same-project secrets in the Cloud Run deploy step.
> 
> - **CI/CD (GitHub Actions)**
>   - In `/.github/workflows/reusable-deploy-cloud-run.yml`, replace subshell with a grouped command when setting `IFS` to build `SECRET_LIST`, ensuring `--set-secrets` receives same-project secrets during `gcloud run deploy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e10984dc8b437590f0900f78a6bfa9f799f2aa0a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->