### PR TITLE
fix(ci): allow comments in secrets input

### DIFF
--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -256,6 +256,7 @@ jobs:
             for raw_line in "${secret_lines[@]}"; do
               line="$(trim "$raw_line")"
               [ -z "$line" ] && continue
+              [[ "$line" == \#* ]] && continue
 
               if [[ "$line" != *"="* ]]; then
                 echo "::error::Invalid secrets input line (missing '='): $line"


### PR DESCRIPTION
Fixes Deploy Cloud Run reusable workflow when caller passes a commented secrets block (lines starting with '#').

Context:
- Admin deploy failed with: "Invalid secrets input line (missing '=')" because the secrets input included a comment.
- This change skips comment lines after trimming.

SSOT: cross-project secrets mapping remains project-number enforced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In the reusable Cloud Run deploy workflow, ignore lines starting with '#' in the `secrets` input after trimming to prevent "missing '='" errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e200a6c1ca25eb5afd7626784b45441c72159cb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->