### PR TITLE
fix: Cloud Run cross-project secrets annotation format

### DIFF
--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -315,13 +315,13 @@ jobs:
                   printf '%s\n' 'k = "run.googleapis.com/secrets"' >> /tmp/inject_xproj_secret.py
                   printf '%s\n' 'raw = str(ann.get(k, "") or "")' >> /tmp/inject_xproj_secret.py
                   printf '%s\n' 'mp = {}' >> /tmp/inject_xproj_secret.py
-                  printf '%s\n' 'for ln in raw.splitlines():' >> /tmp/inject_xproj_secret.py
+                  printf '%s\n' 'for ln in raw.replace("\n", ",").split(","):' >> /tmp/inject_xproj_secret.py
                   printf '%s\n' '    ln = ln.strip()' >> /tmp/inject_xproj_secret.py
                   printf '%s\n' '    if not ln or ":" not in ln: continue' >> /tmp/inject_xproj_secret.py
                   printf '%s\n' '    a, b = ln.split(":", 1)' >> /tmp/inject_xproj_secret.py
                   printf '%s\n' '    mp[a.strip()] = b.strip()' >> /tmp/inject_xproj_secret.py
                   printf '%s\n' 'mp[env_var] = secret_resource' >> /tmp/inject_xproj_secret.py
-                  printf '%s\n' 'ann[k] = "\n".join([f"{a}:{b}" for a,b in mp.items()])' >> /tmp/inject_xproj_secret.py
+                  printf '%s\n' 'ann[k] = ",".join([f"{a}:{b}" for a,b in mp.items()])' >> /tmp/inject_xproj_secret.py
                   printf '%s\n' 'containers = svc["spec"]["template"]["spec"]["containers"]' >> /tmp/inject_xproj_secret.py
                   printf '%s\n' 'env_list = containers[0].get("env", [])' >> /tmp/inject_xproj_secret.py
                   printf '%s\n' 'env_list = [e for e in env_list if e.get("name") != env_var]' >> /tmp/inject_xproj_secret.py
@@ -379,13 +379,13 @@ jobs:
               printf '%s\n' 'k = "run.googleapis.com/secrets"' >> /tmp/inject_xproj_secret.py
               printf '%s\n' 'raw = str(ann.get(k, "") or "")' >> /tmp/inject_xproj_secret.py
               printf '%s\n' 'mp = {}' >> /tmp/inject_xproj_secret.py
-              printf '%s\n' 'for ln in raw.splitlines():' >> /tmp/inject_xproj_secret.py
+              printf '%s\n' 'for ln in raw.replace("\n", ",").split(","):' >> /tmp/inject_xproj_secret.py
               printf '%s\n' '    ln = ln.strip()' >> /tmp/inject_xproj_secret.py
               printf '%s\n' '    if not ln or ":" not in ln: continue' >> /tmp/inject_xproj_secret.py
               printf '%s\n' '    a, b = ln.split(":", 1)' >> /tmp/inject_xproj_secret.py
               printf '%s\n' '    mp[a.strip()] = b.strip()' >> /tmp/inject_xproj_secret.py
               printf '%s\n' 'mp[env_var] = secret_resource' >> /tmp/inject_xproj_secret.py
-              printf '%s\n' 'ann[k] = "\n".join([f"{a}:{b}" for a,b in mp.items()])' >> /tmp/inject_xproj_secret.py
+              printf '%s\n' 'ann[k] = ",".join([f"{a}:{b}" for a,b in mp.items()])' >> /tmp/inject_xproj_secret.py
               printf '%s\n' 'containers = svc["spec"]["template"]["spec"]["containers"]' >> /tmp/inject_xproj_secret.py
               printf '%s\n' 'env_list = containers[0].get("env", [])' >> /tmp/inject_xproj_secret.py
               printf '%s\n' 'env_list = [e for e in env_list if e.get("name") != env_var]' >> /tmp/inject_xproj_secret.py


### PR DESCRIPTION
Fixes Cloud Run deploy failures when using cross-project secrets: the `run.googleapis.com/secrets` annotation must be a single comma-separated string (not newline-separated).

Unblocks:
- https://github.com/merglbot-core/merglbot-admin/actions/runs/20676154648
- https://github.com/merglbot-core/merglbot-admin/actions/runs/20676159809

Ref: merglbot-public/docs/MERGLBOT_CROSS_PROJECT_SECRETS_SSOT.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Cloud Run cross-project secrets handling in the reusable deploy workflow.
> 
> - In `reusable-deploy-cloud-run.yml`, the Python patcher now parses `run.googleapis.com/secrets` by splitting on commas (after normalizing newlines) and writes it as a single comma-separated string
> - Applied in both the pre-patch (existing service) and post-deploy patch steps to prevent format drift and deploy failures
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 665881c5274e51bddbc863bf5b6a0b945f9b3126. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->