### PR TITLE
ci: stop org-settings-watch from creating issues

### DIFF
--- a/.github/workflows/org-settings-watch.yml
+++ b/.github/workflows/org-settings-watch.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: org-settings-watch
@@ -102,47 +101,8 @@ jobs:
             echo "drift_found=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create alert issue
+      - name: Drift detected (no issue creation)
         if: steps.drift.outputs.drift_found == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRIFT_COUNT: ${{ steps.drift.outputs.drift_count }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          DRIFT_DETAILS=$(cat /tmp/drift_details.txt || echo "See workflow run for details")
-          
-          BODY=$(cat << 'EOF'
-          ## Organization Settings Drift Detected
-
-          **DRIFT_COUNT_PLACEHOLDER** configuration settings differ from the expected baseline.
-
-          ### Drift Details
-          DRIFT_DETAILS_PLACEHOLDER
-
-          ### Expected Baseline
-
-          | Setting | Expected Value |
-          |---------|----------------|
-          | allowed_actions | selected |
-          | workflow_permissions | read |
-          | public_repos | false |
-
-          ### Action Required
-
-          1. Review the [workflow run](RUN_URL_PLACEHOLDER)
-          2. Determine if the change was intentional
-          3. Either fix the settings or update the baseline
-
-          ---
-          *This issue was created automatically by the Org Settings Watch workflow.*
-          EOF
-          )
-          BODY="${BODY//DRIFT_COUNT_PLACEHOLDER/$DRIFT_COUNT}"
-          BODY="${BODY//DRIFT_DETAILS_PLACEHOLDER/$DRIFT_DETAILS}"
-          BODY="${BODY//RUN_URL_PLACEHOLDER/$RUN_URL}"
-          
-          gh issue create \
-            --repo "${{ github.repository }}" \
-            --title "🚨 Org Settings Drift Alert - $(date -u +%Y-%m-%d)" \
-            --body "$BODY" \
-            --label "security-alert,automated,config-drift"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> Note: issue creation is disabled for this workflow to avoid daily noise." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why
Daily Org Settings Watch runs were creating a new drift-alert issue every day, generating noise (e.g. #197 + many closed duplicates).

## What
- Disable issue creation in `.github/workflows/org-settings-watch.yml`.
- Remove `issues: write` permission from the workflow to prevent future drift-alert issue spam.
- Keep drift details in the workflow run summary (Actions tab).

## Test Plan
- Run workflow manually via `workflow_dispatch` and confirm no GitHub issue is created, while drift details still appear in the job summary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents automated issue spam from the org settings watch workflow while preserving visibility of drift.
> 
> - Removes `issues: write` from `permissions` in `org-settings-watch.yml`
> - Replaces the "Create alert issue" step with a non-issue path that appends a note to the job summary
> - Drift details continue to be written to the workflow run summary (`$GITHUB_STEP_SUMMARY`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 286a8f8c4052c0487fb958e51c36c01d38fea610. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->