### PR TITLE
ci: add code acceptance rate metric

### DIFF
--- a/.github/workflows/merglbot-feedback-collector.yml
+++ b/.github/workflows/merglbot-feedback-collector.yml
@@ -192,9 +192,10 @@ jobs:
           echo ""
 
           # NOTE: --paginate is required; Search API returns max 100 items per page.
-          SEARCH_NUMBERS="$(gh api "search/issues" --paginate -f q="repo:$REPO is:pr is:merged merged:>=$SINCE_DAY \"$SIGNATURE\" in:comments" -F per_page=100 --jq '.items[].number // empty' 2>/dev/null || echo "")"
-          if [ -z "$SEARCH_NUMBERS" ]; then
-            echo "Search API returned no results (or request failed); proceeding with 0 PRs."
+          SEARCH_NUMBERS=""
+          if ! SEARCH_NUMBERS="$(gh api "search/issues" --paginate -f q="repo:$REPO is:pr is:merged merged:>=$SINCE_DAY \"$SIGNATURE\" in:comments" -F per_page=100 --jq '.items[].number // empty' 2>/dev/null)"; then
+            echo "⚠️  Search API failed; proceeding with 0 PRs." >&2
+            SEARCH_NUMBERS=""
           fi
           mapfile -t PR_NUMBERS < <(printf '%s\n' "$SEARCH_NUMBERS" | sed '/^$/d' | sort -n | uniq)
           if [ ${#PR_NUMBERS[@]} -eq 0 ] || [ -z "${PR_NUMBERS[0]:-}" ]; then
@@ -210,12 +211,22 @@ jobs:
 
           for PR_NUMBER in "${PR_NUMBERS[@]}"; do
             [ -z "$PR_NUMBER" ] && continue
+            if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+              continue
+            fi
 
             # Rate limit protection (avoid bursty loops on large PR sets)
+            if [ $((TOTAL % 50)) -eq 0 ] && [ "$TOTAL" -gt 0 ]; then
+              REMAINING="$(gh api rate_limit --jq '.rate.remaining' 2>/dev/null || echo '')"
+              if [ -n "$REMAINING" ] && [ "$REMAINING" -lt 100 ]; then
+                echo "⚠️  Rate limit low ($REMAINING remaining), sleeping 60s..." >&2
+                sleep 60
+              fi
+            fi
             sleep 0.5
 
             # Fetch PR comments and find the earliest Merglbot review comment timestamp
-            COMMENTS_JSON=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate | jq -s 'add')
+            COMMENTS_JSON="$({ gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate 2>/dev/null || echo '[]'; } | jq -s 'add // []' 2>/dev/null || echo '[]')"
             REVIEW_AT=$(echo "$COMMENTS_JSON" | jq -r --arg sig "$SIGNATURE" 'map(select(.body | contains($sig))) | min_by(.created_at) | .created_at // empty')
             if [ -z "$REVIEW_AT" ]; then
               continue
@@ -223,7 +234,7 @@ jobs:
 
             TOTAL=$((TOTAL + 1))
 
-            COMMITS_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate | jq -s 'add')
+            COMMITS_JSON="$({ gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate 2>/dev/null || echo '[]'; } | jq -s 'add // []' 2>/dev/null || echo '[]')"
             COMMITS_AFTER=$(echo "$COMMITS_JSON" | jq -r --arg review_at "$REVIEW_AT" '[.[] | select((.commit.committer.date // .commit.author.date) > $review_at)] | length')
 
             CLASSIFICATION="accepted_as_is"


### PR DESCRIPTION
## Purpose
Track Code Acceptance Rate (heuristic) as part of the AI workflow improvement plan.

## Changes
- Extend `merglbot-feedback-collector.yml` to compute Code Acceptance Rate (commits-after-review heuristic) and include it in the markdown report + step summary.

## Risk
- Medium (scheduled workflow change).

## Test Plan
- [x] YAML parses (local).
- [ ] CI workflow run (GitHub Actions) should succeed on PR and produce artifacts.

## Notes
- Part of MERGLBOT "Beyond Code" workflow improvements (PR-4).

**STOP BEFORE MERGE**: This PR is prepared for manual merge once CI + bot reviews are green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a heuristic acceptance metric and integrates it into existing feedback reporting, while tightening the workflow’s robustness.
> 
> - Adds `Collect Code Acceptance Rate` step: searches merged PRs with `"Merglbot PR Assistant"` comments, classifies by commits after first review (accepted/minor/significant), handles rate limits, and writes `feedback/acceptance-metrics.json` with counts and percentages
> - Updates report generation to include a "Code Acceptance Rate" section in `FEEDBACK_REPORT.md` and the step summary when metrics exist
> - Validates `DAYS_BACK` as integer; filters issue comments with `since` to bound queries; switches satisfaction calc to `awk` for fixed precision
> - Replaces heredoc JSON with `jq`-built `feedback/summary.json`; tweaks heredocs to control variable expansion
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c158e1dec8fd2893e886bcc8eef2d008a252a27. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Validation Notes (Auto-Generated)

- CI: ✅ green
- Cursor Bugbot: ✅ pass
- Code Acceptance Rate search: uses `gh api "search/issues" --paginate` (not limited to first 100 results)
- Failure mode: Search/PR API errors degrade gracefully to `0` metrics (no crash)
- JSON output: validated via `jq empty` for `feedback/acceptance-metrics.json`

