### PR TITLE
fix(ci): feedback collector comment parsing

### DIFF
--- a/.github/workflows/merglbot-feedback-collector.yml
+++ b/.github/workflows/merglbot-feedback-collector.yml
@@ -69,20 +69,22 @@ jobs:
           echo "🔍 Searching for Merglbot review comments..."
           
           # Search for issue comments containing Merglbot review signature
-          gh api "repos/${{ github.repository }}/issues/comments" \
+          if ! gh api "repos/${{ github.repository }}/issues/comments" \
             --paginate \
             -f since="$SINCE_DATE" \
             -q '.[] | select(.body | contains("Merglbot PR Assistant")) | {id: .id, issue_url: .issue_url, created_at: .created_at, user: .user.login}' \
-            > /tmp/merglbot_comments.json 2>/dev/null || echo "[]" > /tmp/merglbot_comments.json
+            2>/dev/null | jq -s '.' > /tmp/merglbot_comments.json; then
+            echo "[]" > /tmp/merglbot_comments.json
+          fi
           
-          COMMENT_COUNT=$(cat /tmp/merglbot_comments.json | jq -s 'length')
+          COMMENT_COUNT=$(jq 'length' /tmp/merglbot_comments.json)
           echo "Found $COMMENT_COUNT Merglbot review comments"
           echo ""
           
           # Process each comment
           echo "📈 Collecting reactions..."
           
-          cat /tmp/merglbot_comments.json | jq -c '.' | while read -r comment; do
+          jq -c '.[]' /tmp/merglbot_comments.json | while read -r comment; do
             COMMENT_ID=$(echo "$comment" | jq -r '.id')
             CREATED_AT=$(echo "$comment" | jq -r '.created_at')
             


### PR DESCRIPTION
## Purpose
Fix post-merge regression in `Merglbot Feedback Collector` where the workflow fails parsing `/tmp/merglbot_comments.json`.

## Context
Workflow dispatch run failed on main:
- https://github.com/merglbot-core/github/actions/runs/20864845313

## Changes
- Normalize `gh api ... --paginate` output into a single JSON array (`jq -s '.'`) and iterate elements with `jq -c '.[]'`.

## Risk
- Low (CI-only workflow logic).

## Test Plan
- [ ] Run workflow dispatch: `Merglbot Feedback Collector` with `days_back=7` and confirm it completes successfully.

**STOP BEFORE MERGE**: prepared for manual merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes JSON parsing in feedback collection**
> 
> - Aggregate paginated `gh api` issue comments into one array via `jq -s '.'`, with fallback to `[]` on failure
> - Iterate comments with `jq -c '.[]'` and compute counts via `jq 'length'` for consistent processing
> - Redirect errors from `gh api` to avoid workflow failure and ensure robust defaults
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63f9b68221ac8a6ac633a7da0bb0d13b8cc97675. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->