### PR TITLE
fix(ci): feedback collector uses GET for since filter

### DIFF
--- a/.github/workflows/merglbot-feedback-collector.yml
+++ b/.github/workflows/merglbot-feedback-collector.yml
@@ -69,7 +69,7 @@ jobs:
           echo "🔍 Searching for Merglbot review comments..."
           
           # Search for issue comments containing Merglbot review signature
-          if ! gh api "repos/${{ github.repository }}/issues/comments" \
+          if ! gh api -X GET "repos/${{ github.repository }}/issues/comments" \
             --paginate \
             -f since="$SINCE_DATE" \
             -q '.[] | select(.body | contains("Merglbot PR Assistant")) | {id: .id, issue_url: .issue_url, created_at: .created_at, user: .user.login}' \


### PR DESCRIPTION
## Context
`Merglbot Feedback Collector` currently succeeds but often collects **0 reviews** on `workflow_dispatch` because `gh api` defaults to **POST** when `-f since=...` is used, which returns **404** for this endpoint; the workflow then falls back to an empty array.

## Change
- Force `gh api` to use `GET` for the `issues/comments` endpoint so `since` is applied correctly.

## Validation
- Run `workflow_dispatch` on this branch and verify `summary.json.metrics.total_reviews > 0`.

## Risk
Docs/metrics only; no production runtime impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the feedback workflow correctly retrieves Merglbot review comments within the time window.
> 
> - Updates `merglbot-feedback-collector.yml` to call `gh api -X GET repos/$REPO/issues/comments` so `-f since=...` is honored and results aren’t empty
> - Improves reliability of comment discovery for reaction aggregation and downstream metrics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67eba2fa35fa3cc2c6e8c83403aeeea38f973b5f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->