### PR TITLE
fix(ci): acceptance metrics search uses GET

### DIFF
--- a/.github/workflows/merglbot-feedback-collector.yml
+++ b/.github/workflows/merglbot-feedback-collector.yml
@@ -195,7 +195,7 @@ jobs:
 
           # NOTE: --paginate is required; Search API returns max 100 items per page.
           SEARCH_NUMBERS=""
-          if ! SEARCH_NUMBERS="$(gh api "search/issues" --paginate -f q="repo:$REPO is:pr is:merged merged:>=$SINCE_DAY \"$SIGNATURE\" in:comments" -F per_page=100 --jq '.items[].number // empty' 2>/dev/null)"; then
+          if ! SEARCH_NUMBERS="$(gh api -X GET "search/issues" --paginate -f q="repo:$REPO is:pr is:merged merged:>=$SINCE_DAY \"$SIGNATURE\" in:comments" -F per_page=100 --jq '.items[].number // empty' 2>/dev/null)"; then
             echo "⚠️  Search API failed; proceeding with 0 PRs." >&2
             SEARCH_NUMBERS=""
           fi


### PR DESCRIPTION
Problem
- `gh api /search/issues` defaults to POST when using `-f`/`-F` unless `-X GET` is specified.
- Search endpoints require GET, so the call returns HTTP 404 and the workflow falls back to 0 PRs.
- Result: `feedback/acceptance-metrics.json.total_reviews` stays `0` even when reviews exist.

Fix
- Force `-X GET` for the Search API call used to discover merged PRs with Merglbot review comments.

Why this matters
- Unblocks Code Acceptance Rate tracking (Beyond Code / workflow improvements).

Validation
- Local sanity: `gh api -X GET /search/issues ...` returns non-zero results for the repo (e.g. total_count=33 for last 30d).
- After merge: run workflow_dispatch `Merglbot Feedback Collector` on `main` (days_back=30) and verify `feedback/acceptance-metrics.json.total_reviews` is non-zero.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the acceptance metrics step can retrieve merged PRs with Merglbot comments instead of returning zero due to a 404 from an implicit POST.
> 
> - In `merglbot-feedback-collector.yml`, adds `-X GET` to `gh api "search/issues"` while retaining pagination and filters
> - Scope: only the Code Acceptance Rate collection; no other logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1579a006caae5dbf8c5a757fe45bd2eade8fa8a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->