### PR TITLE
ci(deploy): grant actions read in reusable workflow

### DIFF
--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -71,6 +71,7 @@ jobs:
       contents: write          # needed for release asset upload on tags
       id-token: write          # needed for WIF to GCP
       security-events: write   # needed for SARIF upload
+      actions: read            # needed for SARIF upload telemetry (avoids "Resource not accessible by integration")
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Context
`github/codeql-action/upload-sarif` can emit noisy annotations during deploy workflows:

- `Caught an exception while gathering information for telemetry: HttpError: Resource not accessible by integration ... get-a-workflow-run`
- `Resource not accessible by integration ... get-a-workflow-run`

This was observed in `merglbot-core/merglbot-admin` deploy runs, but the root cause is here: `reusable-deploy-cloud-run.yml` sets job-level `permissions` without `actions: read`.

## Change
- Add `actions: read` to the `deploy` job permissions in `.github/workflows/reusable-deploy-cloud-run.yml`.

## Verification
- After merge, the next caller repo deploy run should no longer show the telemetry warning/error (SARIF upload should remain successful).

## Risk
Low: adds read-only permission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing permission required by SARIF upload telemetry.
> 
> - Grants `actions: read` in `deploy` job `permissions` within `.github/workflows/reusable-deploy-cloud-run.yml`, addressing telemetry access errors from `github/codeql-action/upload-sarif`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e345a3d1a64bc6a47e5fbef546652cd36ef4c8f7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->