### PR TITLE
ci: harden include_retro handling

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -19,7 +19,7 @@ on:
           - full
           - light
       include_retro:
-        description: "Include SSOT-safe retro (extractable learnings + doc sync)"
+        description: "Include SSOT-safe retro section (extractable learnings)"
         required: false
         type: choice
         default: "false"
@@ -96,6 +96,13 @@ jobs:
           INPUT_DIFF_SCOPE: ${{ github.event.inputs.diff_scope }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
+          validate_bool() {
+            case "$1" in
+              true|false) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
           if [ "$IS_WORKFLOW_DISPATCH" == "true" ]; then
             # Validate PR number is numeric (security)
             if ! [[ "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
@@ -131,6 +138,11 @@ jobs:
             else
               DIFF_SCOPE_OUT="auto"
             fi
+          fi
+
+          if ! validate_bool "${INCLUDE_RETRO_OUT:-false}"; then
+            echo "⚠️ Invalid include_retro value; defaulting to false"
+            INCLUDE_RETRO_OUT="false"
           fi
           
           {


### PR DESCRIPTION
## Goal
Hardening follow-up for PR Assistant v3.3: make `include_retro` parsing more defensive and fix the input description.

## Changes
- Tighten `workflow_dispatch.include_retro` description (SSOT Sync is always included; retro is optional).
- Add defensive validation so `include_retro` can only be `true|false` (defaults to `false` otherwise).

## Risk
- Very low. Default behavior unchanged (`false`).

## Validation
- YAML parsed (`ruby -ryaml -e 'YAML.load_file(...)'`) ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens handling of the optional retro section flag in the on-demand PR Assistant workflow.
> 
> - Updates `workflow_dispatch.include_retro` description to "SSOT-safe retro section (extractable learnings)"
> - Adds `validate_bool` helper and validates `INCLUDE_RETRO_OUT`; non-`true|false` values are coerced to `false`
> - Applies validation for both manual and comment-triggered runs; default behavior remains `false`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c73b75675edeea95b4ad2780e5941aac4f6a04d7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->