### PR TITLE
fix(ci): PR Assistant v3 large prompts

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1023,7 +1023,6 @@ jobs:
           printf '%s\n' "Now synthesize into FINAL review."
           
           } > /tmp/synthesis_prompt.txt
-          SYNTHESIS_PROMPT=$(< /tmp/synthesis_prompt.txt)
           
           OPENAI_SYSTEM_ROLE="system"
           if echo "$OPENAI_MODEL_FINAL" | grep -Eqi '^o[13]'; then


### PR DESCRIPTION
Fixes PR Assistant v3 failing with `jq: Argument list too long` on large PR diffs by loading prompts via `jq --rawfile` instead of passing them as CLI args.\n\nThis keeps payload content identical, but avoids Linux per-argument length limits (~128KB).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes prompt construction in the PR Assistant v3 workflow to load large prompts from files instead of CLI args, preventing shell arg-length failures.
> 
> - Use `jq --rawfile` to read `prompt` from `/tmp/full_prompt.txt` for Anthropic and all OpenAI request payload branches
> - Use `jq --rawfile` to read synthesis `prompt` from `/tmp/synthesis_prompt.txt` for final OpenAI synthesis payload branches
> - Payload schemas and message structures remain unchanged; only prompt ingestion switches from `--arg` to file-based
> 
> **Risk/Impact**: Low – functional behavior is unchanged; reduces failures on large diffs. Minor risk if temp files are missing or unreadable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd08c1e76ef86980d689bfe1df5c82aa5d33bb12. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->