### PR TITLE
ci: harden PR Assistant v3.4

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -67,6 +67,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  checks: read
 
 concurrency:
   group: merglbot-review-${{ github.event.issue.number || github.event.inputs.pr_number }}
@@ -499,7 +500,7 @@ jobs:
           
           if [ "${{ env.REVIEW_MODE }}" == "light" ]; then
             echo "Skipping Codex stage (light mode)."
-            echo "SKIPPED" > codex_review.txt
+            printf '%s' "SKIPPED" > codex_review.txt
             exit 0
           fi
 
@@ -664,12 +665,12 @@ jobs:
               printf '%s' "$resp" > "$resp_file"
 
               if [ "$exit_code" -ne 0 ] || ! echo "$resp" | jq -e . > /dev/null 2>&1; then
-                echo "  ERROR: Responses API returned non-JSON (exit=$exit_code)"
+                echo "  ERROR: Responses API returned non-JSON (exit=$exit_code)" >&2
                 sleep 1
                 continue
               fi
               if echo "$resp" | jq -e ".error" > /dev/null 2>&1; then
-                echo "  ERROR: $(echo "$resp" | jq -r '.error.message')"
+                echo "  ERROR: $(echo "$resp" | jq -r '.error.message')" >&2
                 sleep 1
                 continue
               fi
@@ -677,7 +678,7 @@ jobs:
               local out
               out="$(extract_output_text "$resp")"
               if [ -z "$out" ] || [ "$out" = "null" ]; then
-                echo "  ERROR: Responses API contained no output_text"
+                echo "  ERROR: Responses API contained no output_text" >&2
                 sleep 1
                 continue
               fi
@@ -694,7 +695,7 @@ jobs:
             printf '%s' "$CONTENT" > codex_review.txt
             echo "CODEX_MODEL_USED=$CODEX_MODEL" >> "$GITHUB_ENV"
           else
-            echo "API_ERROR" > codex_review.txt
+            printf '%s' "API_ERROR" > codex_review.txt
             echo "CODEX_MODEL_USED=$CODEX_MODEL" >> "$GITHUB_ENV"
           fi
           
@@ -857,14 +858,19 @@ jobs:
           OPENAI_MODEL_FINAL="${OPENAI_MODEL_USED:-$OPENAI_MODEL}"
           ANTHROPIC_MODEL_FINAL="${ANTHROPIC_MODEL_USED:-$ANTHROPIC_MODEL}"
           
-          printf '%s\n' "## Anthropic Review ($ANTHROPIC_MODEL_FINAL)"
-          printf '%s\n' ""
-          printf '%s\n' "$ANTHROPIC_REVIEW"
-          printf '%s\n' ""
-          printf '%s\n' "## OpenAI Review ($OPENAI_MODEL_FINAL)"
-          printf '%s\n' ""
-          printf '%s\n' "$OPENAI_REVIEW"
-          printf '%s\n' ""
+          if [ "$ANTHROPIC_OK" == "true" ]; then
+            printf '%s\n' "## Anthropic Review ($ANTHROPIC_MODEL_FINAL)"
+            printf '%s\n' ""
+            printf '%s\n' "$ANTHROPIC_REVIEW"
+            printf '%s\n' ""
+          fi
+          
+          if [ "$OPENAI_OK" == "true" ]; then
+            printf '%s\n' "## OpenAI Review ($OPENAI_MODEL_FINAL)"
+            printf '%s\n' ""
+            printf '%s\n' "$OPENAI_REVIEW"
+            printf '%s\n' ""
+          fi
           
           if [ "$CODEX_OK" == "true" ]; then
             CODEX_MODEL_FINAL="${CODEX_MODEL_USED:-gpt-5.2-codex}"
@@ -943,18 +949,18 @@ jobs:
               set -e
 
               if [ "$exit_code" -ne 0 ] || ! echo "$resp" | jq -e . > /dev/null 2>&1; then
-                echo "ERROR: Responses API returned non-JSON (exit=$exit_code)"
+                echo "ERROR: Responses API returned non-JSON (exit=$exit_code)" >&2
                 continue
               fi
               if echo "$resp" | jq -e ".error" > /dev/null 2>&1; then
-                echo "ERROR: $(echo "$resp" | jq -r '.error.message')"
+                echo "ERROR: $(echo "$resp" | jq -r '.error.message')" >&2
                 continue
               fi
 
               local out
               out="$(extract_output_text_responses "$resp")"
               if [ -z "$out" ] || [ "$out" = "null" ]; then
-                echo "ERROR: Responses API contained no output_text"
+                echo "ERROR: Responses API contained no output_text" >&2
                 continue
               fi
 


### PR DESCRIPTION
## Summary
Hardens the canonical PR Assistant v3.4 workflow + Step 1 script based on Merglbot review feedback from rollout PRs.

## Changes
- Keep stdout clean for command-substitution helpers (send diagnostics/errors to stderr)
- Replace hardcoded `/tmp/*` files in Step 1 script with `mktemp -d` + cleanup `trap`
- Gate synthesis prompt to include Anthropic/OpenAI only when `*_OK == true` (avoid leaking `API_ERROR` into synthesis)
- Add `checks: read` to workflow permissions
- Use `printf '%s'` for writing LLM outputs (avoid `echo` quirks)
- Add env preflight checks for required vars
- Fix accidental indentation block in Step 1 script

## Test Plan
- Local: `actionlint` on `.github/workflows/merglbot-pr-assistant-v3-on-demand.yml`
- Local: `bash -n` + `shellcheck` on `scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens reliability and hygiene of the multi-model PR review workflow.
> 
> - **New/rewritten `scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh`**: adds env preflight checks, uses `mktemp -d` and per-run temp files, keeps stdout clean (diagnostics/token usage to stderr), switches `echo`→`printf` for file writes, clamps negative token math, and centralizes payload paths via variables.
> - **Workflow hardening**: grants `permissions.checks: read` and builds synthesis prompt to include Anthropic/OpenAI sections only if those reviews succeeded; routes API error messages to stderr; uses `printf` for writing `SKIPPED`/`API_ERROR` markers and other outputs.
> - **Codex/Synthesis steps**: consistent stderr error logging and safer file handling (payloads/prompts via variables), maintaining behavior while reducing log noise and edge-case failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45aae15a1bc59b2e802d7cafd3ef3487915fe268. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->