### PR TITLE
fix(ci): PR Assistant uses org default Opus 20251101

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -36,11 +36,13 @@ on:
           - delta
           - full
       anthropic_model:
-        description: "Anthropic model"
+        description: "Anthropic model (org_default = use org var MERGLBOT_ANTHROPIC_MODEL)"
         required: false
         type: choice
-        default: "claude-opus-4-5-20250929"
+        default: "org_default"
         options:
+          - org_default
+          - claude-opus-4-5-20251101
           - claude-opus-4-5-20250929
           - claude-sonnet-4-5-20250929
           - claude-opus-4-1-20250805
@@ -228,7 +230,15 @@ jobs:
           echo "Review Mode: ${{ env.REVIEW_MODE }}"
           echo "Diff Scope Mode: ${{ env.DIFF_SCOPE_MODE }}"
           
-          gh pr view "$PR_NUM" --json title,body,author,baseRefName,headRefName,baseRefOid,headRefOid,labels,additions,deletions,changedFiles,statusCheckRollup > pr_metadata.json
+          PR_VIEW_FIELDS_WITH_CHECKS="title,body,author,baseRefName,headRefName,baseRefOid,headRefOid,labels,additions,deletions,changedFiles,statusCheckRollup"
+          PR_VIEW_FIELDS_NO_CHECKS="title,body,author,baseRefName,headRefName,baseRefOid,headRefOid,labels,additions,deletions,changedFiles"
+          if gh pr view "$PR_NUM" --json "$PR_VIEW_FIELDS_WITH_CHECKS" > pr_metadata.json 2>pr_view_err.txt; then
+            rm -f pr_view_err.txt
+          else
+            echo "WARN: gh pr view with statusCheckRollup failed; retrying without checks (best-effort)." >&2
+            cat pr_view_err.txt >&2 || true
+            gh pr view "$PR_NUM" --json "$PR_VIEW_FIELDS_NO_CHECKS" > pr_metadata.json
+          fi
           
           PR_TITLE=$(jq -r '.title // "No title"' pr_metadata.json)
           PR_BODY=$(jq -r '.body // "No description"' pr_metadata.json)
@@ -474,13 +484,13 @@ jobs:
             gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
               -f content="$REACTION" || true
           fi
-      
+
       - name: Step 1 - Parallel API Calls
         if: success() && steps.context.outputs.skip_review != 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_MODEL: ${{ github.event.inputs.anthropic_model || vars.MERGLBOT_ANTHROPIC_MODEL || 'claude-opus-4-5-20250929' }}
+          ANTHROPIC_MODEL: ${{ (github.event.inputs.anthropic_model != 'org_default' && github.event.inputs.anthropic_model) || vars.MERGLBOT_ANTHROPIC_MODEL || 'claude-opus-4-5-20251101' }}
           OPENAI_MODEL: ${{ github.event.inputs.openai_model || vars.MERGLBOT_OPENAI_MODEL || 'gpt-5.2' }}
         run: |
           set -euo pipefail
@@ -707,7 +717,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ github.event.inputs.openai_model || vars.MERGLBOT_OPENAI_MODEL || 'gpt-5.2' }}
-          ANTHROPIC_MODEL: ${{ github.event.inputs.anthropic_model || vars.MERGLBOT_ANTHROPIC_MODEL || 'claude-opus-4-5-20250929' }}
+          ANTHROPIC_MODEL: ${{ (github.event.inputs.anthropic_model != 'org_default' && github.event.inputs.anthropic_model) || vars.MERGLBOT_ANTHROPIC_MODEL || 'claude-opus-4-5-20251101' }}
         run: |
           set -euo pipefail
           
@@ -730,7 +740,7 @@ jobs:
           ANTHROPIC_MODEL="$(sanitize_model "${ANTHROPIC_MODEL:-}")"
           OPENAI_MODEL="$(sanitize_model "${OPENAI_MODEL:-}")"
           if [ -z "$ANTHROPIC_MODEL" ]; then
-            ANTHROPIC_MODEL="claude-opus-4-5-20250929"
+            ANTHROPIC_MODEL="claude-opus-4-5-20251101"
           fi
           if [ -z "$OPENAI_MODEL" ]; then
             OPENAI_MODEL="gpt-5.2"
@@ -1114,7 +1124,7 @@ jobs:
         if: success() && steps.context.outputs.skip_review != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_MODEL: ${{ github.event.inputs.anthropic_model || vars.MERGLBOT_ANTHROPIC_MODEL || 'claude-opus-4-5-20250929' }}
+          ANTHROPIC_MODEL: ${{ (github.event.inputs.anthropic_model != 'org_default' && github.event.inputs.anthropic_model) || vars.MERGLBOT_ANTHROPIC_MODEL || 'claude-opus-4-5-20251101' }}
           OPENAI_MODEL: ${{ github.event.inputs.openai_model || vars.MERGLBOT_OPENAI_MODEL || 'gpt-5.2' }}
           CODEX_MODEL: ${{ github.event.inputs.codex_model || vars.MERGLBOT_CODEX_MODEL || 'gpt-5.2-codex' }}
         run: |
@@ -1136,7 +1146,7 @@ jobs:
           OPENAI_MODEL="$(sanitize_model "${OPENAI_MODEL:-}")"
           CODEX_MODEL="$(sanitize_model "${CODEX_MODEL:-}")"
           if [ -z "$ANTHROPIC_MODEL" ]; then
-            ANTHROPIC_MODEL="claude-opus-4-5-20250929"
+            ANTHROPIC_MODEL="claude-opus-4-5-20251101"
           fi
           if [ -z "$OPENAI_MODEL" ]; then
             OPENAI_MODEL="gpt-5.2"
@@ -1357,7 +1367,7 @@ jobs:
       - name: Save Review Metrics (Feedback Loop)
         if: always() && steps.context.outputs.skip_review != 'true'
         env:
-          ANTHROPIC_MODEL: ${{ github.event.inputs.anthropic_model || vars.MERGLBOT_ANTHROPIC_MODEL || 'claude-opus-4-5-20250929' }}
+          ANTHROPIC_MODEL: ${{ (github.event.inputs.anthropic_model != 'org_default' && github.event.inputs.anthropic_model) || vars.MERGLBOT_ANTHROPIC_MODEL || 'claude-opus-4-5-20251101' }}
           OPENAI_MODEL: ${{ github.event.inputs.openai_model || vars.MERGLBOT_OPENAI_MODEL || 'gpt-5.2' }}
           CODEX_MODEL: ${{ github.event.inputs.codex_model || vars.MERGLBOT_CODEX_MODEL || 'gpt-5.2-codex' }}
         run: |
@@ -1378,7 +1388,7 @@ jobs:
           OPENAI_MODEL="$(sanitize_model "${OPENAI_MODEL:-}")"
           CODEX_MODEL="$(sanitize_model "${CODEX_MODEL:-}")"
           if [ -z "$ANTHROPIC_MODEL" ]; then
-            ANTHROPIC_MODEL="claude-opus-4-5-20250929"
+            ANTHROPIC_MODEL="claude-opus-4-5-20251101"
           fi
           if [ -z "$OPENAI_MODEL" ]; then
             OPENAI_MODEL="gpt-5.2"

--- a/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+++ b/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
@@ -24,8 +24,11 @@ sanitize_model() {
 
 ANTHROPIC_MODEL="$(sanitize_model "${ANTHROPIC_MODEL:-}")"
 OPENAI_MODEL="$(sanitize_model "${OPENAI_MODEL:-}")"
+if [ "$ANTHROPIC_MODEL" = "org_default" ]; then
+  ANTHROPIC_MODEL=""
+fi
 if [ -z "$ANTHROPIC_MODEL" ]; then
-  ANTHROPIC_MODEL="claude-opus-4-5-20250929"
+  ANTHROPIC_MODEL="claude-opus-4-5-20251101"
 fi
 if [ -z "$OPENAI_MODEL" ]; then
   OPENAI_MODEL="gpt-5.2"
@@ -299,7 +302,7 @@ echo "Calling Anthropic (requested: $ANTHROPIC_MODEL)..."
 
 ANTHROPIC_MODEL_USED=""
 ANTHROPIC_MODELS_TRIED="|"
-for MODEL_TO_TRY in "$ANTHROPIC_MODEL" "claude-opus-4-5-20250929" "claude-sonnet-4-5-20250929" "claude-opus-4-1-20250805" "claude-3-5-haiku-20241022"; do
+for MODEL_TO_TRY in "$ANTHROPIC_MODEL" "claude-opus-4-5-20251101" "claude-opus-4-5-20250929" "claude-sonnet-4-5-20250929" "claude-opus-4-1-20250805" "claude-3-5-haiku-20241022"; do
   if [ -z "$MODEL_TO_TRY" ] || [ "$MODEL_TO_TRY" = "null" ]; then
     continue
   fi

--- a/scripts/pr-assistant/set-org-vars.sh
+++ b/scripts/pr-assistant/set-org-vars.sh
@@ -16,12 +16,13 @@ for arg in "$@"; do
 done
 
 OPENAI_MODEL_DEFAULT="${MERGLBOT_OPENAI_MODEL_DEFAULT:-gpt-5.2}"
-ANTHROPIC_MODEL_DEFAULT="${MERGLBOT_ANTHROPIC_MODEL_DEFAULT:-claude-opus-4-5-20250929}"
+ANTHROPIC_MODEL_DEFAULT="${MERGLBOT_ANTHROPIC_MODEL_DEFAULT:-claude-opus-4-5-20251101}"
 CODEX_MODEL_DEFAULT="${MERGLBOT_CODEX_MODEL_DEFAULT:-gpt-5.2-codex}"
 
 ORGS=(
   "merglbot-core"
   "merglbot-public"
+  "merglbot-cerano"
   "merglbot-denatura"
   "merglbot-proteinaco"
   "merglbot-ruzovyslon"

--- a/scripts/pr-assistant/target-repos.txt
+++ b/scripts/pr-assistant/target-repos.txt
@@ -4,22 +4,27 @@
 # - improvement digest (cross-repo metrics)
 merglbot-core/ai_prompts
 merglbot-core/dataform
+merglbot-core/fb-viz-api
 merglbot-core/infra
 merglbot-core/merglbot-admin
 merglbot-core/platform
 merglbot-core/tf-modules-
 merglbot-public/docs
 merglbot-public/website
+merglbot-cerano/product-forecasting
+merglbot-denatura/denatura-fb-viz
+merglbot-denatura/marketing_actions_detector
+merglbot-denatura/marketing-planning
 merglbot-proteinaco/abc_product_material_analysis
 merglbot-proteinaco/btf-viz
 merglbot-proteinaco/proteinaco-web
 merglbot-proteinaco/viz-api
-merglbot-denatura/denatura-btf-data
-merglbot-denatura/denatura-fb-viz
-merglbot-denatura/marketing_actions_detector
 merglbot-ruzovyslon/business_forecasting
 merglbot-ruzovyslon/kbc_data_quality_metodology
 merglbot-ruzovyslon/ruzovyslon-web
 merglbot-ruzovyslon/viz-api
 merglbot-extractors/facebook-extractor
 merglbot-milan-private/fakturoid
+
+# Archived/read-only (excluded from rollouts):
+# - merglbot-denatura/denatura-btf-data


### PR DESCRIPTION
## Why

- `workflow_dispatch` default Anthropic model was hard-coded to `claude-opus-4-5-20250929`, which overrides org vars and causes `not_found_error` + fallback to Sonnet in some orgs.
- Some repos also fail in `Gather Full PR Context` because `statusCheckRollup` can trigger a GraphQL "Resource not accessible" error.

## What

- Add `org_default` sentinel for `anthropic_model` input and make it the default.
- Prefer org var `vars.MERGLBOT_ANTHROPIC_MODEL` (SSOT default `claude-opus-4-5-20251101`) when `org_default`.
- Update Step 1 fallback order to try `claude-opus-4-5-20251101` before older variants.
- Make PR context fetch robust: retry `gh pr view` without `statusCheckRollup` on GraphQL access errors (best-effort CI summary).
- Update rollout helpers: `set-org-vars.sh` default Anthropic model -> `20251101` and include `merglbot-cerano`; extend `target-repos.txt` and exclude archived repo.

## Notes

- No secrets changed.
- Rollout across target repos will follow via `deploy-v3.sh`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes model selection and improves workflow resilience.
> 
> - **Model selection**: Introduces `org_default` for `anthropic_model` input; prefers `vars.MERGLBOT_ANTHROPIC_MODEL` and updates defaults/fallbacks to `claude-opus-4-5-20251101` across steps and `pr-assistant-step1` (including try order)
> - **Context gathering**: Makes `gh pr view` robust by retrying without `statusCheckRollup` on GraphQL access errors (best‑effort checks summary)
> - **Rollout helpers**: `set-org-vars.sh` default Anthropic -> `20251101` and adds `merglbot-cerano`; expands `target-repos.txt` and excludes an archived repo
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 657acc64b87f18277e9a6263d6e2317f99d0e8f4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->