### PR TITLE
fix(ci): harden PR Assistant v3 workflow

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -409,7 +409,7 @@ jobs:
             {
               echo "### Existing Review Comments"
               echo ""
-              jq -r '.[] | select(.outdated != true) | "**\(.user.login)** on \(.path): \(.body)"' review_comments.json 2>/dev/null || echo "None"
+              jq -r '[.[] | select(.outdated != true)] | sort_by(.created_at) | .[-50:] | .[] | "**\(.user.login)** on \(.path): \(.body)"' review_comments.json 2>/dev/null || echo "None"
               echo ""
             } >> bugbot_findings.txt
           fi


### PR DESCRIPTION
Fixes rollout blockers flagged by Cursor Bugbot + Merglbot review:\n\n- Secret pre-scan scans PR diff + title + body (adds github_pat_/gh[opsu]_ patterns)\n- gh pr view fallback only for statusCheckRollup-related errors (otherwise fail-fast)\n- statusCheckRollup parsing handles contexts shape\n- Synthesis/Codex prompts exclude failed reviews (API_ERROR)\n- Use printf for deterministic file writes\n- Add checks: read permission\n- Only treat github-actions comments as previous Merglbot review marker\n\nGoal: make rollout PRs merge-ready (Cursor 0 issues + Merglbot APPROVE).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability and security of `merglbot-pr-assistant-v3-on-demand.yml`.
> 
> - **Permissions/metadata**: Adds `checks: read`; narrows previous-review detection to `github-actions` comments only
> - **PR data fetching**: `gh pr view` now fail-fast unless error is `statusCheckRollup`-related; supports `.statusCheckRollup.contexts` shape and counts `error/cancelled/timed_out/failure`
> - **Secret scanning (guardrail)**: Pre-scan expanded to PR context (diff, title, body, bugbot, changed files, checks summary) with added patterns (`github_pat_`, `gh[opsur]_`); skip message updated to "PR context"
> - **Safer IO and logs**: Use `printf` for file writes; send API errors to stderr
> - **Prompt hardening**: Mark PR content as untrusted, escape MERGLBOT tokens, and include Anthropic/OpenAI snippets only if not `API_ERROR`; wrap PR title/bugbot/diff in untrusted blocks
> - **Synthesis robustness**: Include only successful reviews, handle single/zero inputs with fallbacks, accurate word counts, and conditional model sections
> - **Review comments**: Only include comments on current `commit_id` when summarizing existing review feedback
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ed8a35b0c06071d164b3edf1585b2ee7b033275. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->