### PR TITLE
fix(security): re-enable Trivy gating in reusable deploy workflows

### DIFF
--- a/.github/workflows/reusable-deploy-cloud-run-wif.yml
+++ b/.github/workflows/reusable-deploy-cloud-run-wif.yml
@@ -84,16 +84,27 @@ jobs:
           docker push $IMAGE
           echo "IMAGE=$IMAGE" >> $GITHUB_ENV
 
-      # Container Security: Trivy scan with SARIF upload
-      - name: Run Trivy vulnerability scanner
+      # Container Security: Trivy gating (CRITICAL blocks deploy)
+      - name: Run Trivy (gate CRITICAL)
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1
-        continue-on-error: true  # Allow deploy while we tune blocking thresholds
+        with:
+          image-ref: ${{ env.IMAGE }}
+          format: 'table'
+          severity: 'CRITICAL'  # Block on CRITICAL immediately
+          exit-code: '1'
+          ignore-unfixed: true
+
+      # Container Security: Trivy SARIF upload (best-effort, includes HIGH)
+      - name: Run Trivy (SARIF)
+        if: always()
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1
+        continue-on-error: true
         with:
           image-ref: ${{ env.IMAGE }}
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL'
-          exit-code: '0'         # Do not fail deploy on scan; surfaced via SARIF
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
           ignore-unfixed: true
 
       - name: Upload Trivy results

--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -155,17 +155,27 @@ jobs:
       # Container Security: Trivy Scanning
       # CRITICAL vulnerabilities block deploy, HIGH are reported to Code Scanning
       # Per MERGLBOT_AI_AGENT_APPENDIX Rule 12: Security gating must not be weakened
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy (gate CRITICAL)
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1
-        continue-on-error: true  # Temporarily allow deploy while investigating SARIF exit-code issue
+        with:
+          image-ref: ${{ steps.build.outputs.full_image }}
+          format: 'table'
+          severity: 'CRITICAL'  # Block on CRITICAL immediately
+          exit-code: '1'
+          ignore-unfixed: true  # Don't fail on unfixable vulns
+
+      - name: Run Trivy (SARIF)
+        if: always()
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1
+        continue-on-error: true
         with:
           image-ref: ${{ steps.build.outputs.full_image }}
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL'  # Block on CRITICAL only
-          exit-code: '0'        # Temporarily set to 0 - SARIF has false positive exit codes
-          ignore-unfixed: true  # Don't fail on unfixable vulns
-      
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
+          ignore-unfixed: true
+
       - name: Upload Trivy results
         uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89  # v4
         if: always()


### PR DESCRIPTION
Closes:
- merglbot-core/github#215

## What changed
- Re-enabled **blocking** Trivy gating for CRITICAL vulnerabilities in:
  - `reusable-deploy-cloud-run.yml`
  - `reusable-deploy-cloud-run-wif.yml`
- Kept SARIF upload best-effort for visibility (CRITICAL+HIGH), but decoupled it from the gating exit-code to avoid SARIF-related false positives.

## How to test
- In a caller repo, run the reusable deploy workflow against an image with known CRITICAL findings → job fails before deploy.
- In a caller repo with a clean image → job proceeds and deploys; SARIF is uploaded to Code Scanning.

## Rollout plan
1) Merge this PR.
2) For any repo blocked by CRITICAL findings, fix/upgrade base images/dependencies (do not weaken gates).

## Rollback plan
- Revert this PR (not recommended) or temporarily stop using the reusable workflow in the caller repo while remediating findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens CI/CD security gates and can newly block production deploys when CRITICAL image vulnerabilities are present; otherwise changes are confined to workflow behavior.
> 
> **Overview**
> **Re-enables security gating in the reusable Cloud Run deploy workflows.** Trivy scanning is split into two steps: a *gating* scan that fails the workflow on **CRITICAL** vulnerabilities (table output, `exit-code: 1`), and a separate *best-effort* SARIF scan that reports **CRITICAL+HIGH** findings to GitHub Code Scanning (`exit-code: 0`, `continue-on-error: true`).
> 
> This change applies to both `reusable-deploy-cloud-run.yml` and `reusable-deploy-cloud-run-wif.yml`, ensuring deploys are blocked only by CRITICAL findings while SARIF upload issues don’t block deployments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81dbc20ae7509cc9d473b1cd0971bcfabf24ba7c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->