### PR TITLE
governance: infra-like branch protection automation

### DIFF
--- a/scripts/governance/apply-infra-like-branch-protection.sh
+++ b/scripts/governance/apply-infra-like-branch-protection.sh
@@ -450,6 +450,13 @@ process_repo() {
     default_branch="$(get_default_branch "$full_name")"
   fi
 
+  # Skip repos without a default branch (e.g., empty repos with no commits)
+  if [ -z "$default_branch" ]; then
+    warn "Skip ${full_name} (no default branch - possibly empty repo)"
+    skipped=$((skipped + 1))
+    return 0
+  fi
+
   local rc=0
   apply_to_branch "$full_name" "$default_branch" || rc=$?
   case "$rc" in


### PR DESCRIPTION
Adds a governance helper to apply infra-like branch protection defaults across merglbot-* repos.

What it does:
- Sets required approving reviews to 0 (still PR-only)
- Disables “require conversation resolution before merging”
- Enables linear history
- Enables enforce-admins (no bypass)
- Optionally bootstraps missing branch protection with `--create-if-missing` (best-effort required check discovery)

What it does NOT do:
- Does not change required status checks for already-protected branches (CI differs per repo)

Usage:
- ./scripts/governance/apply-infra-like-branch-protection.sh --org merglbot-public --dry-run
- ./scripts/governance/apply-infra-like-branch-protection.sh --org merglbot-public --create-if-missing
- ./scripts/governance/apply-infra-like-branch-protection.sh --repo merglbot-cerano/feed-generator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Governance tooling that can change branch protection across many repositories; mistakes or unexpected API semantics could weaken or lock down merge policies org-wide.
> 
> **Overview**
> Adds a new governance automation script, `scripts/governance/apply-infra-like-branch-protection.sh`, to apply consistent “infra-like” branch protection settings across repos via the GitHub API.
> 
> The script targets orgs or individual repos (with optional `release/*` coverage), supports `--dry-run`, and updates existing protections to **0 required approvals**, **no conversation-resolution requirement**, **enforce admins**, and **linear history** (using a full protection PUT while preserving existing settings). It can also optionally bootstrap missing branch protection (`--create-if-missing`) with best-effort discovery of a minimal required status check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53becc42b3eb20339de3f7b44dbab6300ce42471. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->