### PR TITLE
fix(guardrails): BigQuery sanity for self-heal

### DIFF
--- a/.github/workflows/forecast-self-heal.yml
+++ b/.github/workflows/forecast-self-heal.yml
@@ -65,6 +65,37 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_WIF_SERVICE_ACCOUNT }}
 
+      - name: Sanity check BigQuery access (denatura CZ)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          PATCH_DATE_LOCAL: ${{ inputs.patch_date_local }}
+        run: |
+          set -euo pipefail
+          export TZ=Europe/Prague
+          DATE="${PATCH_DATE_LOCAL:-$(date -d "yesterday" +%F)}"
+
+          echo "Sanity date (Europe/Prague): $DATE"
+
+          echo ""
+          echo "[sanity] final_prep_denatura_cz txns"
+          bq query \
+            --project_id=denatura-main \
+            --use_legacy_sql=false \
+            --format=csv \
+            --parameter=d:STRING:${DATE} \
+            "SELECT COUNT(1) AS rows, SUM(sessions) AS sessions, SUM(revenue_db) AS revenue_db, SUM(transactions_db) AS transactions_db FROM \`denatura-main.final_prep_denatura_cz.8_join_tran_db_ga4_transactions_denatura_cz\` WHERE CAST(date AS STRING)=@d" \
+            | sed -n '1,5p'
+
+          echo ""
+          echo "[sanity] visualisation_final_denatura_cz 13_*"
+          bq query \
+            --project_id=denatura-main \
+            --use_legacy_sql=false \
+            --format=csv \
+            --parameter=d:STRING:${DATE} \
+            "SELECT COUNT(1) AS rows, SUM(sessions) AS sessions, SUM(revenue_db) AS revenue_db, SUM(transactions_db) AS transactions_db, SUM(cost) AS cost FROM \`denatura-main.visualisation_final_denatura_cz.13_tran_db_ga4_join_all_channel_cost_plan_final_with_forecasts_denatura_cz\` WHERE CAST(date AS STRING)=@d" \
+            | sed -n '1,5p'
+
       - name: Run forecast self-heal
         id: guardrail
         continue-on-error: true


### PR DESCRIPTION
Adds a workflow_dispatch-only step that runs two small BigQuery error in query operation: No query string provided sanity checks (denatura CZ final_prep + 13_*) so we can validate WIF/IAM end-to-end from the run logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds read-only BigQuery queries gated to manual runs; low blast radius aside from potential noise/failures if those tables/permissions are unavailable.
> 
> **Overview**
> Adds a `workflow_dispatch`-only *BigQuery sanity check* step to `forecast-self-heal.yml` that runs two parameterized `bq query` statements (for `final_prep_denatura_cz` and `visualisation_final_denatura_cz` tables) using the selected `patch_date_local` (defaulting to yesterday in `Europe/Prague`).
> 
> This makes manual runs fail fast and provides run-log evidence that GCP WIF authentication and BigQuery permissions are working before the main forecast self-heal script executes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e27075372c5e9c07dd8a0a083e32d9c870e4957. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->