### PR TITLE
fix(guardrails): scheduled self-heal should not noop

### DIFF
--- a/.github/workflows/forecast-self-heal.yml
+++ b/.github/workflows/forecast-self-heal.yml
@@ -104,6 +104,7 @@ jobs:
           PATCH_DATE_LOCAL: ${{ inputs.patch_date_local }}
           RUN_MODE: ${{ inputs.run_mode }}
           DRY_RUN: ${{ inputs.dry_run }}
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
         run: |
           set -euo pipefail
           OUTDIR="forecast-self-heal-out"


### PR DESCRIPTION
## Why
We observed the scheduled 06:05 run starting late (06:25 Europe/Prague) and becoming NOOP due to the tight 15-minute auto window. That allowed D-1 zeros to persist until later.

## What
- Infer `--run-mode auto` using `github.event.schedule` (passed via env) to be robust to GitHub schedule delays and DST dual-cron.
- Trigger 14_* union refresh when a fix is applied (not only cerano).

## Evidence
Scheduled run `21774893430` produced `status=NOOP` at `now_local=06:25` with reason "Outside execution window".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scheduled run-mode inference and expands downstream DTS `14_*` triggers, which can increase the number/timing of data refresh runs if misconfigured.
> 
> **Overview**
> Improves the `forecast-self-heal` scheduled guardrail so `--run-mode auto` is inferred from `github.event.schedule` (passed via `GITHUB_EVENT_SCHEDULE`) instead of a tight wall-clock minute window, making runs resilient to GitHub schedule delays and the CET/CEST dual-cron setup; NOOP summaries now include the schedule value.
> 
> When a pipeline is actually patched, the script now queues a `dts_config_14` refresh for any spec that defines it (not just a single project), still deduplicated per run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc193375904633d3cbc0203cb5faa7d3a2bd3c8e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->