### PR TITLE
fix: setup-gcp-auth remove unsupported input

### DIFF
--- a/.github/actions/setup-gcp-auth/action.yml
+++ b/.github/actions/setup-gcp-auth/action.yml
@@ -52,7 +52,6 @@ runs:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}
         create_credentials_file: true
-        credentials_file_path: "${{ runner.temp }}/gcp-credentials.json"
         export_environment_variables: ${{ inputs.export_environment_variables }}
         cleanup_credentials: true
         token_format: 'access_token'


### PR DESCRIPTION
## Summary
Fixes the composite action .github/actions/setup-gcp-auth to work with the pinned google-github-actions/auth version.

## What changed
- Removed unsupported input: credentials_file_path

## Why
Workflow runs were failing with:
- Unexpected input(s) 'credentials_file_path'

## Test plan
- Run workflow_dispatch for Forecast D-1 Readiness Guardrail and Forecast Self-Heal Guardrail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI configuration change limited to a composite GitHub Action input; low blast radius and no application code or secret-handling logic changes.
> 
> **Overview**
> Fixes the `.github/actions/setup-gcp-auth` composite action by removing the unsupported `credentials_file_path` input from the pinned `google-github-actions/auth@v2.1.4` step.
> 
> This prevents workflow failures caused by `Unexpected input(s) 'credentials_file_path'` while keeping credential file creation, env var export, and cleanup behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c18bad01aa0f192fc3927a398b09c1991858d024. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->