### PR TITLE
feat: Slack Block Kit for D-1 readiness

### DIFF
--- a/.github/workflows/forecast-d1-readiness.yml
+++ b/.github/workflows/forecast-d1-readiness.yml
@@ -209,6 +209,11 @@ jobs:
               except Exception:
                   return 0.0
 
+          # Slack Block Kit limits / readability caps
+          MAX_TENANTS_DISPLAY = 15
+          MAX_REQ_FAILURES_DISPLAY = 10
+          MAX_OPT_FAILURES_DISPLAY = 5
+
           status = "?"
           slot = ""
           policy = ""
@@ -253,12 +258,18 @@ jobs:
           except Exception:
               pass
 
-          if req_failed > 0:
-              header_text = f"🔴 Forecast D-1 Readiness: FAIL ({req_failed} required failures)"
+          status_norm = (status or "").strip().upper()
+          if status_norm == "FAIL" or req_failed > 0:
+              if req_failed > 0:
+                  header_text = f"🔴 Forecast D-1 Readiness: FAIL ({req_failed} required failures)"
+              else:
+                  header_text = "🔴 Forecast D-1 Readiness: FAIL (see details)"
           elif opt_failed > 0:
               header_text = f"⚠️ Forecast D-1 Readiness: PASS ({opt_failed} optional warnings)"
-          else:
+          elif status_norm == "PASS":
               header_text = "✅ Forecast D-1 Readiness: ALL PASS"
+          else:
+              header_text = f"❓ Forecast D-1 Readiness: UNKNOWN (status={status_norm or '?'})"
 
           blocks: list[dict] = []
           blocks.append(
@@ -301,7 +312,7 @@ jobs:
               tenant_items.append((0 if has_req_fail else 1, 0 if has_opt_fail else 1, tenant.lower(), tenant))
           tenant_items.sort()
 
-          tenant_limit = 15
+          tenant_limit = MAX_TENANTS_DISPLAY
           for _, _, _, tenant in tenant_items[:tenant_limit]:
               entries = tenant_map.get(tenant, [])
               decorated: list[tuple[int, int, str, str, str, str, bool, int, float]] = []
@@ -366,9 +377,9 @@ jobs:
 
           if req_failed > 0:
               req_fail_list.sort()
-              lines = [f"• `{t}/{c}` — {r}" for _, t, _, c, r in req_fail_list[:10]]
-              if len(req_fail_list) > 10:
-                  lines.append(f"… (+{len(req_fail_list) - 10} more)")
+              lines = [f"• `{t}/{c}` — {r}" for _, t, _, c, r in req_fail_list[:MAX_REQ_FAILURES_DISPLAY]]
+              if len(req_fail_list) > MAX_REQ_FAILURES_DISPLAY:
+                  lines.append(f"… (+{len(req_fail_list) - MAX_REQ_FAILURES_DISPLAY} more)")
               blocks.append(
                   {
                       "type": "section",
@@ -381,9 +392,9 @@ jobs:
 
           if opt_failed > 0:
               opt_fail_list.sort()
-              lines = [f"• `{t}/{c}` — {r}" for _, t, _, c, r in opt_fail_list[:5]]
-              if len(opt_fail_list) > 5:
-                  lines.append(f"… (+{len(opt_fail_list) - 5} more)")
+              lines = [f"• `{t}/{c}` — {r}" for _, t, _, c, r in opt_fail_list[:MAX_OPT_FAILURES_DISPLAY]]
+              if len(opt_fail_list) > MAX_OPT_FAILURES_DISPLAY:
+                  lines.append(f"… (+{len(opt_fail_list) - MAX_OPT_FAILURES_DISPLAY} more)")
               blocks.append(
                   {
                       "type": "section",
@@ -394,18 +405,19 @@ jobs:
                   }
               )
 
-          blocks.append(
-              {
-                  "type": "actions",
-                  "elements": [
-                      {
-                          "type": "button",
-                          "text": {"type": "plain_text", "text": "View Run Details"},
-                          "url": run_url,
-                      }
-                  ],
-              }
-          )
+          if run_url:
+              blocks.append(
+                  {
+                      "type": "actions",
+                      "elements": [
+                          {
+                              "type": "button",
+                              "text": {"type": "plain_text", "text": "View Run Details"},
+                              "url": run_url,
+                          }
+                      ],
+                  }
+              )
 
           payload = {"text": header_text, "blocks": blocks}
           print(json.dumps(payload))


### PR DESCRIPTION
Improve Slack notification formatting for `forecast-d1-readiness` using Slack Block Kit (glanceable per-tenant/per-country).\n\n- Header: ✅ ALL PASS / ⚠️ PASS (N optional warnings) / 🔴 FAIL (N required failures)\n- Body: sections per tenant with inline country badges (✅/❌/⚠️) + inline reason details for failures\n- Footer: patch date, slot (+ CET/CEST), policy, required/optional counts\n- Summary: required failures (max 10) + optional warnings (max 5)\n- Limits: max 15 tenants shown (rest referenced as in artifact)\n\nSafety/Scope:\n- Workflow-only change to Slack payload; no changes to guardrail execution, BQ queries, auth, or writes\n- Avoids OPA false positives (no `key=` patterns)\n\nTesting:\n- `workflow_dispatch` on branch: run `21992546779` (Slack webhook returned `ok`)\n\nNo secrets included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to Slack message formatting/parsing with no changes to guardrail execution or data queries; main risk is reduced/changed alert readability due to new truncation and formatting logic.
> 
> **Overview**
> Switches the `forecast-d1-readiness` workflow Slack notification from a single attachment with plain-text failure lines to a **Slack Block Kit** message that is glanceable by *tenant* and *country*.
> 
> The payload now builds a status header (ALL PASS / PASS with optional warnings / FAIL with required failures), per-tenant sections with country badges and inline failure details (including row counts/sums for select reasons), a footer context with patch date/slot and CET/CEST abbreviation, capped summaries of required/optional failures, and a “View Run Details” button; numeric parsing was hardened and output is truncated with explicit display limits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 360b583f4582437c8bf40f5b8b317a86bbdc3845. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->