### PR TITLE
Fix forecast D-1 readiness: abs actuals_sum, 14_* checks, manual slot

### DIFF
--- a/.github/workflows/forecast-d1-readiness.yml
+++ b/.github/workflows/forecast-d1-readiness.yml
@@ -29,6 +29,15 @@ on:
         description: "Date to check (YYYY-MM-DD, Europe/Prague). Default: yesterday."
         required: false
         type: string
+      slot:
+        description: "Slot policy to simulate (08/10=cz_only, 15=all)."
+        required: false
+        type: choice
+        options:
+          - "08"
+          - "10"
+          - "15"
+        default: "15"
       dry_run:
         description: "Skip Slack notifications"
         required: false
@@ -71,13 +80,14 @@ jobs:
         continue-on-error: true
         env:
           PATCH_DATE_LOCAL: ${{ inputs.patch_date_local }}
+          SLOT: ${{ inputs.slot || '15' }}
           MODE: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'auto' }}
           GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
         run: |
           set -euo pipefail
           OUTDIR="forecast-d1-readiness-out"
 
-          CMD="python scripts/guardrails/forecast_d1_readiness.py --outdir $OUTDIR --timezone Europe/Prague --mode ${MODE}"
+          CMD="python scripts/guardrails/forecast_d1_readiness.py --outdir $OUTDIR --timezone Europe/Prague --mode ${MODE} --slot ${SLOT}"
           if [ -n "${PATCH_DATE_LOCAL}" ]; then
             CMD="$CMD --patch-date-local ${PATCH_DATE_LOCAL}"
           fi
@@ -279,9 +289,19 @@ jobs:
               }
           )
 
-          tenant_map: dict[str, list[tuple[str, str, str, bool, int, float]]] = defaultdict(list)
+          # Report rows are table-level; Slack summary must be pipeline-level (tenant/country) without duplicates.
+          tenant_map: dict[str, list[dict]] = defaultdict(list)
+          pipeline_map: dict[tuple[str, str], dict] = {}
           req_fail_list: list[tuple[str, str, str, str, str]] = []
           opt_fail_list: list[tuple[str, str, str, str, str]] = []
+
+          def _fmt_fail_detail(kind: str, reason: str, row_count: int, actuals_sum: float, domain: str) -> str:
+              det = (reason or "FAIL").strip() or "FAIL"
+              if det in ("no_rows_for_date", "actuals_zero"):
+                  det = f"{det} ({row_count} rows, sum={actuals_sum:.6f})"
+              if kind == "14" and domain:
+                  det = f"{det}, domain={domain}"
+              return f"{kind}:{det}"
 
           try:
               with open(report_csv, "r", encoding="utf-8", newline="") as f:
@@ -289,63 +309,112 @@ jobs:
                   for row in reader:
                       tenant = (row.get("tenant") or "").strip() or "?"
                       country = (row.get("country") or "").strip() or "?"
+                      kind = (row.get("table_kind") or "").strip() or "13"
+                      domain = (row.get("domain") or "").strip()
                       st = (row.get("status") or "").strip() or "?"
                       reason = (row.get("reason") or "").strip()
                       is_req = (row.get("is_required") or "").strip() == "yes"
                       row_count = _to_int(row.get("row_count"))
                       actuals_sum = _to_float(row.get("actuals_sum"))
 
-                      tenant_map[tenant].append((country, st, reason, is_req, row_count, actuals_sum))
+                      key = (tenant, country)
+                      p = pipeline_map.get(key)
+                      if not p:
+                          p = {"tenant": tenant, "country": country, "is_req": is_req, "checks": {}}
+                          pipeline_map[key] = p
+                      p["is_req"] = bool(p.get("is_req")) or is_req
 
-                      if st == "FAIL":
-                          if is_req:
-                              req_fail_list.append((tenant.lower(), tenant, country.lower(), country, reason))
-                          else:
-                              opt_fail_list.append((tenant.lower(), tenant, country.lower(), country, reason))
+                      checks = p.get("checks") or {}
+                      p["checks"] = checks
+
+                      cur = {
+                          "status": st,
+                          "reason": reason,
+                          "row_count": row_count,
+                          "actuals_sum": actuals_sum,
+                          "domain": domain,
+                      }
+                      prev = checks.get(kind)
+                      if not prev:
+                          checks[kind] = cur
+                      else:
+                          # Keep the worst status (FAIL wins) for each check kind.
+                          if str(prev.get("status", "")).strip() != "FAIL" and st == "FAIL":
+                              checks[kind] = cur
           except Exception:
               pass
 
+          for (tenant, country), p in pipeline_map.items():
+              checks = p.get("checks") or {}
+              kinds = sorted(str(k) for k in checks.keys())
+              pipeline_pass = bool(kinds) and all(str(checks[k].get("status", "")).strip() == "PASS" for k in kinds)
+
+              fail_details: list[str] = []
+              for k in sorted(kinds):
+                  info = checks.get(k) or {}
+                  if str(info.get("status", "")).strip() == "FAIL":
+                      fail_details.append(
+                          _fmt_fail_detail(
+                              k,
+                              str(info.get("reason", "") or ""),
+                              _to_int(info.get("row_count")),
+                              _to_float(info.get("actuals_sum")),
+                              str(info.get("domain", "") or ""),
+                          )
+                      )
+
+              p["pipeline_pass"] = pipeline_pass
+              p["fail_summary"] = "; ".join(fail_details) if fail_details else ""
+              tenant_map[tenant].append(p)
+
+              if not pipeline_pass:
+                  summary = p.get("fail_summary") or "FAIL"
+                  if bool(p.get("is_req")):
+                      req_fail_list.append((tenant.lower(), tenant, country.lower(), country, summary))
+                  else:
+                      opt_fail_list.append((tenant.lower(), tenant, country.lower(), country, summary))
+
           tenant_items: list[tuple[int, int, str, str]] = []
           for tenant, entries in tenant_map.items():
-              has_req_fail = any(st == "FAIL" and is_req for _, st, _, is_req, _, _ in entries)
-              has_opt_fail = any(st == "FAIL" and (not is_req) for _, st, _, is_req, _, _ in entries)
+              has_req_fail = any((not bool(p.get("pipeline_pass"))) and bool(p.get("is_req")) for p in entries)
+              has_opt_fail = any((not bool(p.get("pipeline_pass"))) and (not bool(p.get("is_req"))) for p in entries)
               tenant_items.append((0 if has_req_fail else 1, 0 if has_opt_fail else 1, tenant.lower(), tenant))
           tenant_items.sort()
 
           tenant_limit = MAX_TENANTS_DISPLAY
           for _, _, _, tenant in tenant_items[:tenant_limit]:
               entries = tenant_map.get(tenant, [])
-              decorated: list[tuple[int, int, str, str, str, str, bool, int, float]] = []
-              for country, st, reason, is_req, row_count, actuals_sum in entries:
-                  fail_rank = 0 if st == "FAIL" else 1
-                  sev_rank = 0 if (st == "FAIL" and is_req) else 1 if st == "FAIL" else 2
+              decorated: list[tuple[int, int, str, str, bool, bool, str]] = []
+              for p in entries:
+                  country = str(p.get("country") or "?")
+                  is_req = bool(p.get("is_req"))
+                  pipeline_pass = bool(p.get("pipeline_pass"))
+                  fail_summary = str(p.get("fail_summary") or "")
+                  fail_rank = 0 if (not pipeline_pass) else 1
+                  sev_rank = 0 if ((not pipeline_pass) and is_req) else 1 if (not pipeline_pass) else 2
                   decorated.append(
                       (
                           fail_rank,
                           sev_rank,
                           country.lower(),
                           country,
-                          st,
-                          reason,
+                          pipeline_pass,
                           is_req,
-                          row_count,
-                          actuals_sum,
+                          fail_summary,
                       )
                   )
               decorated.sort()
 
               badges: list[str] = []
               detail_lines: list[str] = []
-              for _, _, _, country, st, reason, is_req, row_count, actuals_sum in decorated:
-                  if st == "PASS":
+              for _, _, _, country, pipeline_pass, is_req, fail_summary in decorated:
+                  if pipeline_pass:
                       badges.append(f"✅ `{country}`")
                   else:
                       icon = "❌" if is_req else "⚠️"
                       badges.append(f"{icon} `{country}`")
 
-                      det = reason or "FAIL"
-                      if det in ("no_rows_for_date", "actuals_zero"):
-                          det = f"{det} ({row_count} rows, sum={actuals_sum:.6f})"
+                      det = fail_summary or "FAIL"
                       detail_lines.append(f"• {icon} `{country}` — _{det}_")
 
               section_text = f"*📊 {tenant}*\n" + "  ".join(badges)

--- a/.github/workflows/forecast-d1-readiness.yml
+++ b/.github/workflows/forecast-d1-readiness.yml
@@ -317,11 +317,11 @@ jobs:
                       row_count = _to_int(row.get("row_count"))
                       actuals_sum = _to_float(row.get("actuals_sum"))
 
-                      key = (tenant, country)
-                      p = pipeline_map.get(key)
+                      pipeline_tc = (tenant, country)
+                      p = pipeline_map.get(pipeline_tc)
                       if not p:
                           p = {"tenant": tenant, "country": country, "is_req": is_req, "checks": {}}
-                          pipeline_map[key] = p
+                          pipeline_map[pipeline_tc] = p
                       p["is_req"] = bool(p.get("is_req")) or is_req
 
                       checks = p.get("checks") or {}

--- a/scripts/guardrails/forecast_d1_readiness.py
+++ b/scripts/guardrails/forecast_d1_readiness.py
@@ -39,6 +39,12 @@ EPS = 1e-9
 REQUIRED_COLUMNS = ("date", "sessions", "revenue_db", "transactions_db")
 OPTIONAL_COLUMN_COST = "cost"
 
+# Local, minimal override for domain mismatches in 14_* checks.
+# Default domain format is `{tenant}.{country}` (e.g. `cerano.cz`).
+DOMAIN_OVERRIDE: dict[tuple[str, str], str] = {
+    # ("tenant", "country"): "custom.domain",
+}
+
 
 @dataclass(frozen=True)
 class PipelineSpec:
@@ -46,6 +52,7 @@ class PipelineSpec:
     tenant: str
     country: str
     bq_table_13: str
+    bq_table_14: str
 
 
 @dataclass(frozen=True)
@@ -57,7 +64,9 @@ class ResultRow:
     required_policy: str
     patch_date_local: str
     is_required: str
+    table_kind: str
     table_fq: str
+    domain: str
     status: str
     reason: str
     row_count: int
@@ -298,11 +307,21 @@ def _load_specs(csv_path: Path) -> list[PipelineSpec]:
                     country=row["country"].strip(),
                     # Preserve spaces in table names (legacy can have leading spaces in other columns).
                     bq_table_13=row["bq_table_13"],
+                    bq_table_14=row["bq_table_14"],
                 )
             )
     if not specs:
         raise ValueError(f"No specs found in {csv_path}")
     return specs
+
+
+def _infer_domain(*, tenant: str, country: str) -> str:
+    key = ((tenant or "").strip().lower(), (country or "").strip().lower())
+    if key in DOMAIN_OVERRIDE:
+        return DOMAIN_OVERRIDE[key]
+    if key[0] and key[1]:
+        return f"{key[0]}.{key[1]}"
+    return ""
 
 
 def _write_csv(path: Path, rows: list[ResultRow]) -> None:
@@ -318,7 +337,9 @@ def _write_csv(path: Path, rows: list[ResultRow]) -> None:
                 "required_policy",
                 "patch_date_local",
                 "is_required",
+                "table_kind",
                 "table_fq",
+                "domain",
                 "status",
                 "reason",
                 "row_count",
@@ -341,7 +362,9 @@ def _write_csv(path: Path, rows: list[ResultRow]) -> None:
                     r.required_policy,
                     r.patch_date_local,
                     r.is_required,
+                    r.table_kind,
                     r.table_fq,
+                    r.domain,
                     r.status,
                     r.reason,
                     str(r.row_count),
@@ -384,6 +407,7 @@ def _write_md(
     lines.append(f"- Status: **{status}**")
     lines.append(f"- Required: {required_total - required_failed} PASS / {required_failed} FAIL (total: {required_total})")
     lines.append(f"- Optional: {optional_total - optional_failed} PASS / {optional_failed} FAIL (total: {optional_total})")
+    lines.append("- Note: Required/optional counts are per pipeline; table-level checks below may show multiple rows per pipeline.")
     lines.append("")
 
     required_fail = [r for r in rows if r.status == "FAIL" and r.is_required == "yes"]
@@ -392,22 +416,22 @@ def _write_md(
     if required_fail:
         lines.append("## Required failures (first 20)")
         lines.append("")
-        lines.append("| Project | Tenant | Country | Table | Reason | row_count | actuals_sum | cost_sum |")
-        lines.append("|---|---|---|---|---|---:|---:|---:|")
+        lines.append("| Project | Tenant | Country | Check | Table | Domain | Reason | row_count | actuals_sum | cost_sum |")
+        lines.append("|---|---|---|---:|---|---|---|---:|---:|---:|")
         for r in required_fail[:20]:
             lines.append(
-                f"| `{r.project_id}` | `{r.tenant}` | `{r.country}` | `{r.table_fq}` | `{r.reason}` | {r.row_count} | {r.actuals_sum:.6f} | {r.cost_sum:.6f} |"
+                f"| `{r.project_id}` | `{r.tenant}` | `{r.country}` | `{r.table_kind}` | `{r.table_fq}` | `{r.domain or ''}` | `{r.reason}` | {r.row_count} | {r.actuals_sum:.6f} | {r.cost_sum:.6f} |"
             )
         lines.append("")
 
     if optional_fail:
         lines.append("## Optional failures (first 20)")
         lines.append("")
-        lines.append("| Project | Tenant | Country | Table | Reason | row_count | actuals_sum | cost_sum |")
-        lines.append("|---|---|---|---|---|---:|---:|---:|")
+        lines.append("| Project | Tenant | Country | Check | Table | Domain | Reason | row_count | actuals_sum | cost_sum |")
+        lines.append("|---|---|---|---:|---|---|---|---:|---:|---:|")
         for r in optional_fail[:20]:
             lines.append(
-                f"| `{r.project_id}` | `{r.tenant}` | `{r.country}` | `{r.table_fq}` | `{r.reason}` | {r.row_count} | {r.actuals_sum:.6f} | {r.cost_sum:.6f} |"
+                f"| `{r.project_id}` | `{r.tenant}` | `{r.country}` | `{r.table_kind}` | `{r.table_fq}` | `{r.domain or ''}` | `{r.reason}` | {r.row_count} | {r.actuals_sum:.6f} | {r.cost_sum:.6f} |"
             )
         lines.append("")
 
@@ -419,14 +443,16 @@ def _write_json_summary(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def run(*, config_csv: Path, outdir: Path, tz_name: str, patch_date_local_str: str, mode: str) -> int:
+def run(*, config_csv: Path, outdir: Path, tz_name: str, patch_date_local_str: str, mode: str, slot_override: str) -> int:
     tz = ZoneInfo(tz_name)
     now_local = datetime.now(tz=tz)
 
     gh_schedule = (os.environ.get("GITHUB_EVENT_SCHEDULE", "") or "").strip()
     if mode == "manual":
-        slot = "15"
-        required_policy = "all"
+        slot = (slot_override or "15").strip()
+        if slot not in ("08", "10", "15"):
+            raise ValueError(f"Invalid --slot for manual mode: {slot!r} (expected 08|10|15)")
+        required_policy = "cz_only" if slot in ("08", "10") else "all"
     elif mode == "auto":
         slot = _infer_slot_auto(now_local, gh_schedule=gh_schedule)
         if slot == "noop":
@@ -482,90 +508,103 @@ def run(*, config_csv: Path, outdir: Path, tz_name: str, patch_date_local_str: s
 
         print(f"[check] {spec.project_id} {spec.tenant}/{spec.country} (required={'yes' if req else 'no'})", file=sys.stderr)
 
-        status = "FAIL"
-        reason = "bq_error"
-        row_count = 0
-        sessions_sum = 0.0
-        revenue_sum = 0.0
-        transactions_sum = 0.0
-        actuals_sum = 0.0
-        cost_sum = 0.0
-        cost_present = "no"
-        error_snippet = ""
+        def check_table(*, table_kind: str, table_fq: str, domain: str) -> ResultRow:
+            status = "FAIL"
+            reason = "bq_error"
+            row_count = 0
+            sessions_sum = 0.0
+            revenue_sum = 0.0
+            transactions_sum = 0.0
+            actuals_sum = 0.0
+            cost_sum = 0.0
+            cost_present = "no"
+            error_snippet = ""
 
-        try:
-            meta = _bq_show_table_json(job_project_id=spec.project_id, table_fq=spec.bq_table_13)
-            fields = meta.get("schema", {}).get("fields", []) or []
-            cols = {str(f.get("name", "") or "").strip().lower() for f in fields if isinstance(f, dict)}
-            missing = [c for c in REQUIRED_COLUMNS if c not in cols]
-            cost_present = "yes" if OPTIONAL_COLUMN_COST in cols else "no"
+            try:
+                meta = _bq_show_table_json(job_project_id=spec.project_id, table_fq=table_fq)
+                fields = meta.get("schema", {}).get("fields", []) or []
+                cols = {str(f.get("name", "") or "").strip().lower() for f in fields if isinstance(f, dict)}
+                filter_col = ""
+                if table_kind == "14":
+                    # Some 14_* union tables are domain-level (`domain` column), others are country-level (`country` column).
+                    if "domain" in cols:
+                        filter_col = "domain"
+                    elif "country" in cols:
+                        filter_col = "country"
+                required_cols = REQUIRED_COLUMNS + ((filter_col,) if filter_col else (("domain", "country") if table_kind == "14" else ()))
+                missing = [c for c in required_cols if c not in cols]
+                cost_present = "yes" if OPTIONAL_COLUMN_COST in cols else "no"
 
-            if missing:
-                status = "FAIL"
-                reason = "missing_columns:" + ",".join(missing)
-            else:
-                select_parts = [
-                    "COUNT(1) AS row_count",
-                    "IFNULL(SUM(sessions), 0) AS sessions_sum",
-                    "IFNULL(SUM(revenue_db), 0) AS revenue_db_sum",
-                    "IFNULL(SUM(transactions_db), 0) AS transactions_db_sum",
-                ]
-                if cost_present == "yes":
-                    select_parts.append("IFNULL(SUM(cost), 0) AS cost_sum")
-
-                sql = (
-                    "SELECT "
-                    + ", ".join(select_parts)
-                    + f" FROM `{spec.bq_table_13}`"
-                    + " WHERE CAST(date AS STRING)=@d"
-                )
-
-                out = _bq_query_csv(job_project_id=spec.project_id, sql=sql, parameters=[f"d:STRING:{patch_date}"])
-                qrows = _parse_csv_rows(out)
-                if qrows:
-                    r = qrows[0]
-                    row_count = _as_int(r.get("row_count"))
-                    sessions_sum = _as_float(r.get("sessions_sum"))
-                    revenue_sum = _as_float(r.get("revenue_db_sum"))
-                    transactions_sum = _as_float(r.get("transactions_db_sum"))
-                    actuals_sum = sessions_sum + revenue_sum + transactions_sum
-                    if cost_present == "yes":
-                        cost_sum = _as_float(r.get("cost_sum"))
-
-                if row_count <= 0:
+                if missing:
                     status = "FAIL"
-                    reason = "no_rows_for_date"
-                elif actuals_sum <= EPS:
-                    status = "FAIL"
-                    reason = "actuals_zero"
+                    reason = "missing_columns:" + ",".join(missing)
                 else:
-                    status = "PASS"
-                    reason = ""
-        except Exception as exc:  # noqa: BLE001
-            msg = str(exc)
-            kind = "bq_error"
-            if msg.startswith("not_found:"):
-                kind = "not_found"
-            elif msg.startswith("forbidden:"):
-                kind = "forbidden"
-            elif msg.startswith("bq_error:"):
+                    select_parts = [
+                        "COUNT(1) AS row_count",
+                        "IFNULL(SUM(sessions), 0) AS sessions_sum",
+                        "IFNULL(SUM(revenue_db), 0) AS revenue_db_sum",
+                        "IFNULL(SUM(transactions_db), 0) AS transactions_db_sum",
+                    ]
+                    if cost_present == "yes":
+                        select_parts.append("IFNULL(SUM(cost), 0) AS cost_sum")
+
+                    where_parts = ["CAST(date AS STRING)=@d"]
+                    parameters = [f"d:STRING:{patch_date}"]
+                    if table_kind == "14":
+                        if filter_col == "domain":
+                            where_parts.append("domain=@dom")
+                            parameters.append(f"dom:STRING:{domain}")
+                        elif filter_col == "country":
+                            where_parts.append("country=@country")
+                            parameters.append(f"country:STRING:{spec.country}")
+
+                    sql = (
+                        "SELECT "
+                        + ", ".join(select_parts)
+                        + f" FROM `{table_fq}`"
+                        + " WHERE "
+                        + " AND ".join(where_parts)
+                    )
+
+                    out = _bq_query_csv(job_project_id=spec.project_id, sql=sql, parameters=parameters)
+                    qrows = _parse_csv_rows(out)
+                    if qrows:
+                        r = qrows[0]
+                        row_count = _as_int(r.get("row_count"))
+                        sessions_sum = _as_float(r.get("sessions_sum"))
+                        revenue_sum = _as_float(r.get("revenue_db_sum"))
+                        transactions_sum = _as_float(r.get("transactions_db_sum"))
+                        actuals_sum = abs(sessions_sum) + abs(revenue_sum) + abs(transactions_sum)
+                        if cost_present == "yes":
+                            cost_sum = _as_float(r.get("cost_sum"))
+
+                    if row_count <= 0:
+                        status = "FAIL"
+                        reason = "no_rows_for_date"
+                    elif actuals_sum <= EPS:
+                        status = "FAIL"
+                        reason = "actuals_zero"
+                    else:
+                        status = "PASS"
+                        reason = ""
+            except Exception as exc:  # noqa: BLE001
+                msg = str(exc)
                 kind = "bq_error"
+                if msg.startswith("not_found:"):
+                    kind = "not_found"
+                elif msg.startswith("forbidden:"):
+                    kind = "forbidden"
+                elif msg.startswith("bq_error:"):
+                    kind = "bq_error"
 
-            reason = kind
-            if "stderr(first" in msg:
-                error_snippet = msg.split("stderr(first", 1)[-1]
-                error_snippet = error_snippet[-800:]
-            else:
-                error_snippet = msg[:800]
+                reason = kind
+                if "stderr(first" in msg:
+                    error_snippet = msg.split("stderr(first", 1)[-1]
+                    error_snippet = error_snippet[-800:]
+                else:
+                    error_snippet = msg[:800]
 
-        if status != "PASS":
-            if req:
-                required_failed += 1
-            else:
-                optional_failed += 1
-
-        rows.append(
-            ResultRow(
+            return ResultRow(
                 project_id=spec.project_id,
                 tenant=spec.tenant,
                 country=spec.country,
@@ -573,7 +612,9 @@ def run(*, config_csv: Path, outdir: Path, tz_name: str, patch_date_local_str: s
                 required_policy=required_policy,
                 patch_date_local=patch_date,
                 is_required="yes" if req else "no",
-                table_fq=spec.bq_table_13,
+                table_kind=table_kind,
+                table_fq=table_fq,
+                domain=domain,
                 status=status,
                 reason=reason,
                 row_count=row_count,
@@ -585,7 +626,22 @@ def run(*, config_csv: Path, outdir: Path, tz_name: str, patch_date_local_str: s
                 cost_present=cost_present,
                 error_snippet=error_snippet,
             )
-        )
+
+        check_rows: list[ResultRow] = []
+        check_rows.append(check_table(table_kind="13", table_fq=spec.bq_table_13, domain=""))
+
+        if (spec.bq_table_14 or "").strip():
+            dom = _infer_domain(tenant=spec.tenant, country=spec.country)
+            check_rows.append(check_table(table_kind="14", table_fq=spec.bq_table_14, domain=dom))
+
+        pipeline_failed = any(r.status != "PASS" for r in check_rows)
+        if pipeline_failed:
+            if req:
+                required_failed += 1
+            else:
+                optional_failed += 1
+
+        rows.extend(check_rows)
 
     status = "FAIL" if required_failed > 0 else "PASS"
 
@@ -645,6 +701,12 @@ def main() -> int:
         help="Date to check (YYYY-MM-DD, evaluated in --timezone). Default: yesterday in --timezone.",
     )
     ap.add_argument("--mode", default="auto", choices=["auto", "manual"])
+    ap.add_argument(
+        "--slot",
+        default="15",
+        choices=["08", "10", "15"],
+        help="Manual slot override (only used when --mode=manual). Controls required policy: 08/10=cz_only, 15=all.",
+    )
     ap.add_argument("--outdir", default="forecast-d1-readiness-out")
     args = ap.parse_args()
 
@@ -655,6 +717,7 @@ def main() -> int:
             tz_name=args.timezone,
             patch_date_local_str=args.patch_date_local.strip(),
             mode=args.mode.strip(),
+            slot_override=args.slot.strip(),
         )
     except Exception as exc:  # noqa: BLE001
         # Best-effort summary so CI can Slack even on unexpected errors.


### PR DESCRIPTION
RCA
- Readiness používal raw součet (sessions + revenue_db + transactions_db). Při refund-heavy dnech (revenue_db záporné) může raw součet vyjít <= 0 → false-positive actuals_zero.

Změny
- scripts/guardrails/forecast_d1_readiness.py
  - actuals_sum = abs(sessions_sum) + abs(revenue_sum) + abs(transactions_sum)
  - 14_* check: pokud je v inventory vyplněné bq_table_14, kontroluje se i 14 tabulka pro konkrétní slice:
    - primárně filtr date=@d AND domain=@dom (pokud tabulka má sloupec domain)
    - fallback date=@d AND country=@country (pokud je 14 tabulka country-level, bez sloupce domain)
  - Pipeline PASS jen pokud 13 OK a (pokud existuje) 14 OK; required/optional počty zůstávají per pipeline.
  - manual slot override: nový arg --slot (08|10|15) pro mode=manual.
- .github/workflows/forecast-d1-readiness.yml
  - workflow_dispatch input slot=08|10|15 (default 15) + předání --slot
  - Slack payload dedup: agreguje table-level rows do pipeline-level (tenant/country) bez duplicit + zobrazuje i 14_* fail důvody (včetně domain, pokud relevantní)

Verifikace
- Lokální smoke: mode=manual, slot=08, patch-date-local=2026-02-13 → PASS.
- Na reálných datech existují dny s negativním raw součtem (refund-heavy), které by před fixem byly false FAIL; s abs-sum už ne.

Poznámky
- Bez secretů; Actions dál používá WIF/OIDC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches guardrail logic that gates CI alerts and changes how PASS/FAIL is computed by adding additional table checks and altering the `actuals_sum` calculation. Main risk is increased false negatives/positives or mis-scoped filtering for `14_*` tables affecting alerting.
> 
> **Overview**
> Improves the forecast D-1 readiness guardrail by adding an optional second check against inventory-provided `bq_table_14` tables (slice-filtered by `domain` or `country` when present) and by changing `actuals_sum` to use absolute component sums to avoid false `actuals_zero` failures.
> 
> Adds a manual `--slot` override (08/10/15) and wires it through the GitHub Actions `workflow_dispatch` input, adjusting required-policy selection accordingly. Updates report outputs (`forecast_d1_readiness_report.csv`/`.md`) to include `table_kind` and `domain`, and updates the workflow’s Slack payload generation to *dedupe table-level rows into pipeline-level status* and surface combined failure reasons (including domain for `14` checks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 462a9ca89aa84c5e60ca7791aeaf5cd6630e725c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->