### PR TITLE
docs(guardrails): align generator schedules with :10 imports (cerano/livero/autodoplnky)

### DIFF
--- a/scripts/guardrails/FORECAST_GENERATOR_SCHEDULES.md
+++ b/scripts/guardrails/FORECAST_GENERATOR_SCHEDULES.md
@@ -55,11 +55,11 @@ Pozn.: Nejde o “forecast generator”, ale o producer, který zapisuje GCS CSV
 Pozn.: `13_*` importy zde typicky startují v **`:10` UTC** (např. `05:10Z`). Schedule níže je nastavená tak, aby se CSV přepsalo ~20 min před importem.
 
 - **cerano_cz** (import `:10` UTC → generator `:50` UTC): `50 4-14 * * *`
-- **cerano_sk** (import `:10` UTC → generator `:50` UTC): `50 13-15 * * *`
-- **cerano_hu** (import `:10` UTC → generator `:50` UTC): `50 13-15 * * *`
-- **cerano_pl** (import `:10` UTC → generator `:50` UTC): `50 13-15 * * *`
+- **cerano_sk** (import `:10` UTC → generator `:50` UTC): `50 12-14 * * *`
+- **cerano_hu** (import `:10` UTC → generator `:50` UTC): `50 12-14 * * *`
+- **cerano_pl** (import `:10` UTC → generator `:50` UTC): `50 12-14 * * *`
 - **livero_cz** (import `:10` UTC → generator `:50` UTC): `50 4-14 * * *`
-- **livero_sk** (import `:10` UTC → generator `:50` UTC): `50 13-15 * * *`
+- **livero_sk** (import `:10` UTC → generator `:50` UTC): `50 12-14 * * *`
 
 ### Ruzovyslon — které Deepnote notebooky přenastavit
 Notebook mapping je v:


### PR DESCRIPTION
RCA: morning readiness often failed when the GCS\u2192BQ import minute was mis-assumed (":00" vs real ":10" UTC), causing generators to overwrite too late / too early and import stale or all-zero CSVs.\n\nChanges:\n- Make CET/CEST conversion explicit when scheduling in Europe/Prague.\n- Cerano/Livero: document import at :10 UTC \u2192 generator at :50 UTC, and expand CZ window to include the pre-07:00 local slot.\n- Autodoplnky (readiness CSV producer): document import at :10 UTC \u2192 producer at :50 UTC.\n\nNo code changes; docs-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; risk is limited to potential operational mis-scheduling if the new cron guidance is applied incorrectly.
> 
> **Overview**
> Updates `scripts/guardrails/FORECAST_GENERATOR_SCHEDULES.md` to align documented Deepnote cron schedules with BigQuery DTS imports occurring at `:10` UTC (notably **Cerano/Livero**) by shifting generators to `:50` UTC and adjusting the CZ/non‑CZ hourly windows accordingly.
> 
> Also clarifies how to convert the recommended **UTC** schedules to `Europe/Prague` local time for both **CET** and **CEST**, and documents an **Autodoplnky** (readiness CSV producer) schedule using the same `:10`→`:50` pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1024881e882b167bcb727b4c6b845e7d81b89483. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->