### PR TITLE
ci(deps): bump anchore/sbom-action from 0.22.1 to 0.22.2

### DIFF
--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -175,7 +175,7 @@ jobs:
       
       # Container Security: SBOM Generation
       - name: Generate SBOM
-        uses: anchore/sbom-action@deef08a0db64bfad603422135db61477b16cef56  # v0.22.1
+        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad  # v0.22.2
         with:
           image: ${{ steps.build.outputs.full_image }}
           format: 'cyclonedx-json'


### PR DESCRIPTION
Ported from Dependabot PR #253 to a human-authored branch so Cursor Bugbot can run.

Original PR: https://github.com/merglbot-core/github/pull/253

Notes:
- Same commit(s) cherry-picked with -x.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> A small CI dependency bump in the SBOM-generation step; low risk aside from potential workflow behavior differences in the updated action.
> 
> **Overview**
> Updates the Cloud Run reusable deploy workflow to use `anchore/sbom-action` v0.22.2 (from v0.22.1) for SBOM generation, by updating the pinned action digest.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ab8bf9b50e193641ec0563a93864ca06923f106. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->