### PR TITLE
ci(deps): bump actions/setup-python from 6.1.0 to 6.2.0

### DIFF
--- a/.github/workflows/readiness-guardrail-0600.yml
+++ b/.github/workflows/readiness-guardrail-0600.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # pinned
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # pinned
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0 pinned
         with:
           python-version: "3.11"
           cache: "pip"


### PR DESCRIPTION
Ported from Dependabot PR #254 to a human-authored branch so Cursor Bugbot can run.

Original PR: https://github.com/merglbot-core/github/pull/254

Notes:
- Same commit(s) cherry-picked with -x.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only GitHub Actions workflow change; no application/runtime logic is modified.
> 
> **Overview**
> Updates the `readiness-guardrail-0600.yml` GitHub Actions workflow to use `actions/setup-python` v6.2.0 (new pinned commit SHA) for the Python setup step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7b96d15f181517b63fab784ab3f3626b82a36a1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->