### PR TITLE
ci(deps): bump github/codeql-action from 4.32.0 to 4.32.2

### DIFF
--- a/.github/workflows/reusable-build-attest.yml
+++ b/.github/workflows/reusable-build-attest.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: inputs.scan && always()
-        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/reusable-codeql-analysis.yml
+++ b/.github/workflows/reusable-codeql-analysis.yml
@@ -36,15 +36,15 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30  # v4.32.0
+      uses: github/codeql-action/init@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2  # v4.32.2
       with:
         languages: ${{ matrix.language }}
         token: ${{ env.CODEQL_AUTH_TOKEN }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@b20883b0cd1f46c72ae0ba6d1090936928f9fa30  # v4.32.0
+      uses: github/codeql-action/autobuild@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2  # v4.32.2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30  # v4.32.0
+      uses: github/codeql-action/analyze@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2  # v4.32.2
       with:
         token: ${{ env.CODEQL_AUTH_TOKEN }}

--- a/.github/workflows/reusable-deploy-cloud-run-wif.yml
+++ b/.github/workflows/reusable-deploy-cloud-run-wif.yml
@@ -97,7 +97,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30  # v4
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2  # v4
         if: always()
         continue-on-error: true
         with:

--- a/.github/workflows/reusable-deploy-cloud-run.yml
+++ b/.github/workflows/reusable-deploy-cloud-run.yml
@@ -167,7 +167,7 @@ jobs:
           ignore-unfixed: true  # Don't fail on unfixable vulns
       
       - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30  # v4
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2  # v4
         if: always()
         continue-on-error: true  # Don't fail if SARIF upload has permission issues
         with:

--- a/.github/workflows/reusable-security-scorecard.yml
+++ b/.github/workflows/reusable-security-scorecard.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload SARIF
         if: inputs.publish_results
-        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
         with:
           sarif_file: scorecard-results.sarif
 

--- a/.github/workflows/security-gitleaks.yml
+++ b/.github/workflows/security-gitleaks.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Upload SARIF report
         if: always()
         continue-on-error: true  # SARIF upload may fail in reusable workflow context due to token permissions
-        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30  # v4.32.0
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2  # v4.32.2
         with:
           sarif_file: gitleaks-report.sarif
           category: gitleaks


### PR DESCRIPTION
Ported from Dependabot PR #255 to a human-authored branch so Cursor Bugbot can run.

Original PR: https://github.com/merglbot-core/github/pull/255

Notes:
- Same commit(s) cherry-picked with -x.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pin-only CI dependency update to the CodeQL action; behavior changes are limited to whatever upstream fixes are in `4.32.2`.
> 
> **Overview**
> Bumps `github/codeql-action` from `4.32.0` to `4.32.2` (SHA update) across reusable GitHub Actions workflows.
> 
> This updates the CodeQL `init`/`autobuild`/`analyze` steps and all `upload-sarif` usages used for Trivy, Scorecard, and Gitleaks SARIF uploads, without changing workflow logic or thresholds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1176bc0722c4ee2ee4b6fd8469c752490dd40994. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->