### PR TITLE
chore(deps): bump axios from 1.13.2 to 1.13.5 in /dashboard

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -13,7 +13,7 @@
         "@mui/icons-material": "^5.14.15",
         "@mui/material": "^5.14.15",
         "@tanstack/react-query": "^5.0.0",
-        "axios": "^1.6.0",
+        "axios": "^1.13.5",
         "date-fns": "^2.30.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2569,13 +2569,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -18,7 +18,7 @@
     "@mui/icons-material": "^5.14.15",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "axios": "^1.6.0",
+    "axios": "^1.13.5",
     "recharts": "^2.9.0",
     "date-fns": "^2.30.0",
     "@tanstack/react-query": "^5.0.0",


### PR DESCRIPTION
Ported from Dependabot PR #257 to a human-authored branch so Cursor Bugbot can run.

Original PR: https://github.com/merglbot-core/github/pull/257

Notes:
- Same commit(s) cherry-picked with -x.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change limited to the dashboard; main risk is minor behavioral differences in HTTP requests due to the `axios` patch update.
> 
> **Overview**
> Bumps the dashboard’s `axios` dependency from `^1.6.0`/`1.13.2` to `^1.13.5` in `package.json` and `package-lock.json`.
> 
> The lockfile update also pulls newer transitive versions for `follow-redirects` and `form-data` as required by the new `axios` release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af694d58eb6f5aa08b205842e6f2baeb8ef78d97. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->