### PR TITLE
fix(workflow): format readiness Slack message as multiline blocks

### DIFF
--- a/.github/workflows/forecast-d1-readiness.yml
+++ b/.github/workflows/forecast-d1-readiness.yml
@@ -212,11 +212,14 @@ jobs:
           EPS = 1e-9  # Float tolerance for "non-zero" sums (avoid precision noise)
 
           def slack_escape(s: str) -> str:
-              """Escape Slack link/mention primitives + break @mentions (HTML entities baseline)."""
+              """Escape Slack link primitives, stabilize mrkdwn code spans, and break @mentions."""
               return (
                   s.replace("&", "&amp;")
                    .replace("<", "&lt;")
                    .replace(">", "&gt;")
+                   .replace("`", "ˋ")       # prevent breaking inline code spans
+                   .replace("\n", " ")
+                   .replace("\r", " ")
                    .replace("@", "@\u200b")  # zero-width space breaks mentions
               )
 


### PR DESCRIPTION
Cíl: zlepšit čitelnost Slack zprávy z workflow  (multiline layout: header + 🏢 tenant bloky + 1 řádek per country).

- Zachovává ikony ✅/⚠️/❌ + .
- Nezasahuje do readiness logiky / gatingu, jen formát výstupu.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to Slack message construction; main risk is minor formatting/escaping regressions in notifications, with no impact on readiness evaluation or workflow control flow.
> 
> **Overview**
> Reformats the Forecast D-1 readiness Slack payload to use mrkdwn `section` blocks with a bolded header and per-tenant multiline sections (🏢 tenant header + one indented line per country), instead of the previous single-line “badge” layout.
> 
> Adds `slack_escape()` to sanitize tenant/country/reason strings for Slack mrkdwn (escape `&<>`, neutralize backticks/newlines, and break `@` mentions), and tweaks the context line separators for clearer readability; readiness/gating logic remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa3f66376513ea4069a04a9a4112abe5e8be8de7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->