### PR TITLE
ci: expand PR Assistant rollout targets (enterprise)

### DIFF
--- a/scripts/pr-assistant/target-repos.txt
+++ b/scripts/pr-assistant/target-repos.txt
@@ -12,7 +12,8 @@ merglbot-core/fb-viz-api
 merglbot-core/infra
 merglbot-core/merglbot-admin
 merglbot-core/platform
-merglbot-core/tf-modules-  # NOTE: repo name intentionally ends with '-' (matches GitHub repo slug)
+# NOTE: `merglbot-core/tf-modules-` repo name intentionally ends with '-' (matches GitHub repo slug)
+merglbot-core/tf-modules-
 merglbot-public/docs
 merglbot-public/kazdavterina-web
 merglbot-public/livero-web


### PR DESCRIPTION
Updates `scripts/pr-assistant/target-repos.txt` to cover all ACTIVE platform repos per SSOT `merglbot-public/docs/REPOSITORY_MAP.md`.

Excludes:
- `merglbot-core/github` (canonical source)
- archived/read-only repos (listed in file)

Test plan:
- Cursor: `@cursor review`
- Merglbot: `@merglbot review --light`
- Verify target list count matches SSOT active repos (minus exclusions).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates a repo allowlist used by rollout/metrics scripts; the main risk is unintentionally targeting or missing a repository during deployments.
> 
> **Overview**
> Expands `scripts/pr-assistant/target-repos.txt` so PR Assistant deployments and improvement-digest metrics run across more active platform repositories.
> 
> Adds documentation in the file about the SSOT (`merglbot-public/docs/REPOSITORY_MAP.md`), explicit exclusions (e.g., `merglbot-core/github` and archived repos), and notes an edge-case repo slug (`merglbot-core/tf-modules-`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe18fc68e188d3e9bdc0565498cf46ea70632159. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->