### PR TITLE
ci: PR Assistant v3.4 hotfix (always write skip outputs)

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -317,6 +317,11 @@ jobs:
           
           SKIP_REVIEW="false"
           SKIP_REASON="none"
+          write_skip_outputs() {
+            echo "skip_review=${SKIP_REVIEW:-false}" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=${SKIP_REASON:-}" >> "$GITHUB_OUTPUT"
+          }
+          trap write_skip_outputs EXIT
           if [ "$DIFF_SCOPE_MODE" != "full" ] && [ -n "$PREV_REVIEW_HEAD_SHA" ] && [ "$PREV_REVIEW_HEAD_SHA" == "$PR_HEAD_SHA" ]; then
             SKIP_REVIEW="true"
             SKIP_REASON="no_new_commits"
@@ -450,9 +455,6 @@ jobs:
               fi
             done
           fi
-          
-          echo "skip_review=$SKIP_REVIEW" >> "$GITHUB_OUTPUT"
-          echo "skip_reason=$SKIP_REASON" >> "$GITHUB_OUTPUT"
           
           echo "========================================="
           echo "CONTEXT GATHERING COMPLETE"


### PR DESCRIPTION
Hotfix: ensure `skip_review` / `skip_reason` outputs are always written in the context step.

Why:
- Merglbot flagged that any future early-exit (or unexpected exit) could skip writing outputs, leading to later steps running without the intended guardrails.

Change:
- Add `write_skip_outputs()` + `trap write_skip_outputs EXIT` in `.github/workflows/merglbot-pr-assistant-v3-on-demand.yml`.
- Remove the explicit output writes at the end (trap writes final values).

After merge:
- Re-deploy canonical copy to all rollout PR branches and rerun Cursor + Merglbot gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI workflow change limited to output handling; main risk is unintended output values if the trap fires before variables are set, but defaults are provided.
> 
> **Overview**
> The workflow’s `Gather Full PR Context` step now defines `write_skip_outputs()` and registers `trap ... EXIT` so `skip_review` and `skip_reason` outputs are **always** emitted, even on early/failed exits.
> 
> It removes the prior explicit output writes at the end of the step, relying on the trap to publish the final skip state used by downstream guardrail/review steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26a82c2a150ba44735f95a8f75f975d734af3ae4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->