### PR TITLE
ci: narrow workflow permissions + fail on missing keys

### DIFF
--- a/.github/workflows/forecast-d1-readiness.yml
+++ b/.github/workflows/forecast-d1-readiness.yml
@@ -33,7 +33,7 @@ on:
         description: "Skip Slack notifications"
         required: false
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: read
@@ -274,24 +274,42 @@ jobs:
 
           status_norm = (status or "").strip().upper()
           if status_norm == "FAIL" or req_failed > 0:
+              icon = "🔴"
               if req_failed > 0:
-                  header_text = f"🔴 Forecast D-1 Readiness: FAIL ({req_failed} required failures)"
+                  title_text = f"Forecast D-1 Readiness: FAIL ({req_failed} required failures)"
               else:
-                  header_text = "🔴 Forecast D-1 Readiness: FAIL (see details)"
+                  title_text = "Forecast D-1 Readiness: FAIL (see details)"
           elif opt_failed > 0:
-              header_text = f"⚠️ Forecast D-1 Readiness: PASS ({opt_failed} optional warnings)"
+              icon = "⚠️"
+              title_text = f"Forecast D-1 Readiness: PASS ({opt_failed} optional warnings)"
           elif status_norm == "PASS":
-              header_text = "✅ Forecast D-1 Readiness: ALL PASS"
+              icon = "✅"
+              title_text = "Forecast D-1 Readiness: ALL PASS"
           else:
-              header_text = f"❓ Forecast D-1 Readiness: UNKNOWN (status={status_norm or '?'})"
+              icon = "❓"
+              title_text = f"Forecast D-1 Readiness: UNKNOWN (status={status_norm or '?'})"
+
+          header_info_parts: list[str] = []
+          header_info_parts.append(f"📅 {patch_date or '?'}")
+          time_part = slot_disp or (slot if slot else "?")
+          header_info_parts.append(f"🕐 {time_part} {tz_abbrev}")
+          header_info_parts.append(f"Policy: {policy or '?'}")
+
+          header_info_plain = " | ".join(header_info_parts).strip()
+          header_text_plain = f"{icon} {title_text}" + (f" — {header_info_plain}" if header_info_plain else "")
+
+          info_mrkdwn_parts: list[str] = []
+          info_mrkdwn_parts.append(f"📅 `{slack_escape(patch_date or '?')}`")
+          info_mrkdwn_parts.append(f"🕐 `{slack_escape(time_part)} {tz_abbrev}`")
+          info_mrkdwn_parts.append(f"Policy: `{slack_escape(policy or '?')}`")
+
+          header_info_mrkdwn = " | ".join(info_mrkdwn_parts).strip()
+          header_mrkdwn = f"{icon} *{slack_escape(title_text)}*" + (f" — {header_info_mrkdwn}" if header_info_mrkdwn else "")
 
           blocks: list[dict] = []
-          # header_text format: "EMOJI Forecast D-1 Readiness: STATUS" (emoji first)
-          icon, sep, rest = header_text.partition(" ")
-          header_mrkdwn = f"{icon} *{rest}*" if sep else f"*{header_text}*"
           blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": header_mrkdwn}})
 
-          tenant_map: dict[str, list[tuple[str, str, str, bool, int, float, float, float, str]]] = defaultdict(list)
+          tenant_map: dict[str, list[dict[str, object]]] = defaultdict(list)
           req_fail_list: list[tuple[str, str, str, str, str]] = []
           opt_fail_list: list[tuple[str, str, str, str, str]] = []
 
@@ -309,19 +327,41 @@ jobs:
                       revenue_db_sum = _to_float(row.get("revenue_db_sum"))
                       cost_sum = _to_float(row.get("cost_sum"))
                       cost_present = (row.get("cost_present") or "").strip().lower()
+                      status_13 = (row.get("status_13") or "").strip() or st
+                      reason_13 = (row.get("reason_13") or "").strip()
+                      table_fq_14 = (row.get("table_fq_14") or "").strip()
+                      domain = (row.get("domain") or "").strip()
+                      status_14 = (row.get("status_14") or "").strip()
+                      reason_14 = (row.get("reason_14") or "").strip()
+                      row_count_14 = _to_int(row.get("row_count_14"))
+                      actuals_sum_14 = _to_float(row.get("actuals_sum_14"))
+                      revenue_db_sum_14 = _to_float(row.get("revenue_db_sum_14"))
+                      cost_sum_14 = _to_float(row.get("cost_sum_14"))
+                      cost_present_14 = (row.get("cost_present_14") or "").strip().lower()
 
                       tenant_map[tenant].append(
-                          (
-                              country,
-                              st,
-                              reason,
-                              is_req,
-                              row_count,
-                              actuals_sum,
-                              revenue_db_sum,
-                              cost_sum,
-                              cost_present,
-                          )
+                          {
+                              "country": country,
+                              "status": st,
+                              "reason": reason,
+                              "is_required": is_req,
+                              "row_count": row_count,
+                              "actuals_sum": actuals_sum,
+                              "revenue_db_sum": revenue_db_sum,
+                              "cost_sum": cost_sum,
+                              "cost_present": cost_present,
+                              "status_13": status_13,
+                              "reason_13": reason_13,
+                              "table_fq_14": table_fq_14,
+                              "domain": domain,
+                              "status_14": status_14,
+                              "reason_14": reason_14,
+                              "row_count_14": row_count_14,
+                              "actuals_sum_14": actuals_sum_14,
+                              "revenue_db_sum_14": revenue_db_sum_14,
+                              "cost_sum_14": cost_sum_14,
+                              "cost_present_14": cost_present_14,
+                          }
                       )
 
                       if st == "FAIL":
@@ -334,52 +374,73 @@ jobs:
 
           tenant_items: list[tuple[int, int, str, str]] = []
           for tenant, entries in tenant_map.items():
-              has_req_fail = any(e[1] == "FAIL" and e[3] for e in entries)
-              has_opt_fail = any(e[1] == "FAIL" and (not e[3]) for e in entries)
+              has_req_fail = any(str(e.get("status", "")) == "FAIL" and bool(e.get("is_required")) for e in entries)
+              has_opt_fail = any(str(e.get("status", "")) == "FAIL" and (not bool(e.get("is_required"))) for e in entries)
               tenant_items.append((0 if has_req_fail else 1, 0 if has_opt_fail else 1, tenant.lower(), tenant))
           tenant_items.sort()
 
           tenant_limit = MAX_TENANTS_DISPLAY
           for _, _, _, tenant in tenant_items[:tenant_limit]:
               entries = tenant_map.get(tenant, [])
-              decorated: list[tuple[int, int, str, str, str, str, bool, int, float, float, float, str]] = []
-              for country, st, reason, is_req, row_count, actuals_sum, revenue_db_sum, cost_sum, cost_present in entries:
+              decorated: list[tuple[int, int, str, dict[str, object]]] = []
+              for e in entries:
+                  country = str(e.get("country", "") or "?")
+                  st = str(e.get("status", "") or "?")
+                  is_req = bool(e.get("is_required"))
                   fail_rank = 0 if st == "FAIL" else 1
                   sev_rank = 0 if (st == "FAIL" and is_req) else 1 if st == "FAIL" else 2
-                  decorated.append(
-                      (
-                          fail_rank,
-                          sev_rank,
-                          country.lower(),
-                          country,
-                          st,
-                          reason,
-                          is_req,
-                          row_count,
-                          actuals_sum,
-                          revenue_db_sum,
-                          cost_sum,
-                          cost_present,
-                      )
-                  )
+                  decorated.append((fail_rank, sev_rank, country.lower(), e))
               decorated.sort()
 
               country_lines: list[str] = []
-              for _, _, _, country, st, reason, is_req, row_count, actuals_sum, revenue_db_sum, cost_sum, cost_present in decorated:
-                  if st == "PASS":
-                      icon = "✅"
+              for _, _, _, e in decorated:
+                  country = str(e.get("country", "") or "?")
+                  st = str(e.get("status", "") or "?")
+                  reason = str(e.get("reason", "") or "").strip()
+                  is_req = bool(e.get("is_required"))
+                  row_count = _to_int(e.get("row_count"))
+                  actuals_sum = _to_float(e.get("actuals_sum"))
+                  revenue_db_sum = _to_float(e.get("revenue_db_sum"))
+                  cost_sum = _to_float(e.get("cost_sum"))
+                  cost_present = str(e.get("cost_present", "") or "").strip().lower()
+                  status_13 = str(e.get("status_13", "") or "").strip() or st
+                  table_fq_14 = str(e.get("table_fq_14", "") or "")
+                  domain = str(e.get("domain", "") or "")
+                  status_14 = str(e.get("status_14", "") or "").strip()
+                  row_count_14 = _to_int(e.get("row_count_14"))
+                  actuals_sum_14 = _to_float(e.get("actuals_sum_14"))
+                  revenue_db_sum_14 = _to_float(e.get("revenue_db_sum_14"))
+                  cost_sum_14 = _to_float(e.get("cost_sum_14"))
+
+                  if status_13 == "PASS":
                       rev_icon = "✅" if abs(revenue_db_sum) > EPS else "⚠️"
                       if cost_present == "yes":
                           cost_icon = "✅" if abs(cost_sum) > EPS else "⚠️"
                       else:
                           cost_icon = "⚠️"
-                      metrics = f"(rev {rev_icon} cost {cost_icon})"
+                  else:
+                      rev_icon = "❌"
+                      cost_icon = "❌"
+
+                  extra_14 = ""
+                  if table_fq_14.strip():
+                      icon_14 = "✅" if status_14 == "PASS" else "❌" if status_14 == "FAIL" else "❓"
+                      extra_14 = f", 14 {icon_14}"
+
+                  metrics = f"(rev {rev_icon} cost {cost_icon}{extra_14})"
+
+                  if st == "PASS":
+                      icon = "✅"
                       country_lines.append(f"    {icon} `{slack_escape(country)}` {metrics}")
                   else:
                       icon = "❌" if is_req else "⚠️"
-                      metrics = "(rev ❌ cost ❌)"
                       det = reason or "FAIL"
-                      if det in ("no_rows_for_date", "actuals_zero"):
+                      if det.startswith("14_"):
+                          det = (
+                              f"{det} (domain={domain or '?'}, rows={row_count_14}, sum_14={actuals_sum_14:.6f}, "
+                              f"rev_14={revenue_db_sum_14:.6f}, cost_14={cost_sum_14:.6f})"
+                          )
+                      elif det in ("no_rows_for_date", "actuals_zero"):
                           det = (
                               f"{det} ({row_count} rows, sum={actuals_sum:.6f}, "
                               f"rev={revenue_db_sum:.6f}, cost={cost_sum:.6f})"
@@ -406,7 +467,10 @@ jobs:
           blocks.append({"type": "divider"})
 
           req_mark = "✓" if req_failed == 0 else "❌"
-          ctx = f"📅 {patch_date}  |  🕐 {slot_disp} {tz_abbrev}  |  Policy: {policy}  |  Required: {req_ok}/{req_total} {req_mark}"
+          ctx = (
+              f"📅 `{slack_escape(patch_date or '?')}`  |  🕐 `{slack_escape(time_part)} {tz_abbrev}`  |  "
+              f"Policy: `{slack_escape(policy or '?')}`  |  Required: {req_ok}/{req_total} {req_mark}"
+          )
           if opt_total > 0:
               opt_mark = "⚠️" if opt_failed > 0 else "✓"
               ctx += f"  |  Optional: {opt_failed}/{opt_total} {opt_mark}"
@@ -457,7 +521,7 @@ jobs:
                   }
               )
 
-          payload = {"text": header_text, "blocks": blocks}
+          payload = {"text": header_text_plain, "blocks": blocks}
           print(json.dumps(payload))
           PY
           )"

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -61,8 +61,8 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write # required for `gh pr comment` (PR review output)
-  issues: write # required for reactions and some PR comment flows
+  pull-requests: read
+  issues: read
   checks: read
 
 concurrency:
@@ -189,6 +189,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30  # Context gather + LLM calls; typical 10-20m
     
+    permissions:
+      contents: read
+      pull-requests: write # required for `gh pr comment` (PR review output)
+      issues: write # required for PR comments via Issues API
+      checks: read
+
     env:
       ANTHROPIC_API_VERSION: "2023-06-01"
       PR_NUMBER: ${{ needs.check-trigger.outputs.pr_number }}
@@ -201,14 +207,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-      
-      - name: React to Comment
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
-            -f content='eyes' || true
       
       - name: Gather Full PR Context
         id: context
@@ -445,7 +443,7 @@ jobs:
           # Security pre-scan: if PR context contains secret-like patterns, skip AI review to avoid exfiltration to LLM APIs.
           # IMPORTANT: never print the matching line(s) to logs.
           if [ "$SKIP_REVIEW" != "true" ]; then
-            SECRET_PATTERN='-----BEGIN (RSA|OPENSSH|EC|PGP) PRIVATE KEY-----|-----BEGIN PRIVATE KEY-----|xox[baprs]-|ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{20,}|gh[orsu]_[A-Za-z0-9]{30,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}'
+            SECRET_PATTERN='-----BEGIN (RSA|OPENSSH|EC|PGP) PRIVATE KEY-----|-----BEGIN PRIVATE KEY-----|xox[baprs]-|ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{20,}|gh[oprsu]_[A-Za-z0-9]{30,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}'
             for SECRET_SCAN_FILE in pr_diff.txt pr_title.txt pr_body.txt bugbot_findings.txt changed_files.txt pr_checks_summary.txt; do
               if [ -s "$SECRET_SCAN_FILE" ] && grep -Eqi "$SECRET_PATTERN" "$SECRET_SCAN_FILE"; then
                 echo "⛔️ Potential secret-like material detected in PR context; skipping AI review."
@@ -499,15 +497,6 @@ jobs:
           fi
           
           gh pr comment "$PR_NUM" --body-file comment.md
-          
-          if [ "${{ github.event_name }}" == "issue_comment" ]; then
-            REACTION="hooray"
-            if [ "${SKIP_REASON:-}" == "potential_secret" ]; then
-              REACTION="confused"
-            fi
-            gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
-              -f content="$REACTION" || true
-          fi
 
       - name: Step 1 - Parallel API Calls
         if: success() && steps.context.outputs.skip_review != 'true'
@@ -970,11 +959,6 @@ jobs:
           
           gh pr comment "$PR_NUM" --body-file comment.md
           echo "Review posted to PR #$PR_NUM"
-          
-          if [ "${{ github.event_name }}" == "issue_comment" ]; then
-            gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
-              -f content='rocket' || true
-          fi
       
       - name: Workflow Summary
         run: |

--- a/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+++ b/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
@@ -104,7 +104,7 @@ if [ "$ANTHROPIC_API_KEY_PRESENT" != "true" ] && [ "$OPENAI_API_KEY_PRESENT" != 
   echo "ERROR: Both ANTHROPIC_API_KEY and OPENAI_API_KEY are missing; cannot run analysis." >&2
   printf '%s' "API_ERROR" > anthropic_review.txt
   printf '%s' "API_ERROR" > openai_review.txt
-  exit 0
+  exit 1
 fi
 
 if [ "$ANTHROPIC_API_KEY_PRESENT" == "true" ]; then


### PR DESCRIPTION
Follow-up to v3.4 rollout: addresses Merglbot CHANGES NEEDED on downstream deploy PRs by:
- narrowing workflow-level permissions (write perms only on the review job)
- removing non-essential reactions API calls
- failing fast when *both* Anthropic+OpenAI API keys are missing (misconfig should not look like success)
- expanding GitHub token secret-scan regex to include ghp/gho/ghr/ghs/ghu prefixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI enforcement and guardrail pass/fail behavior (missing AI keys now fails the job, and readiness now depends on an additional optional table check), which could alter operational alerting and workflow outcomes.
> 
> **Overview**
> **Merglbot PR Assistant workflow is locked down and simplified.** Workflow-level permissions are reduced to read-only, with write permissions scoped only to the `multi-model-review` job; non-essential GitHub comment reaction calls are removed, and the secret pre-scan regex is expanded to detect additional `gh*_*` token prefixes.
> 
> **AI review execution now fails fast when misconfigured.** `pr-assistant-step1-parallel-api-calls.sh` exits non-zero if *both* Anthropic and OpenAI API keys are missing (instead of succeeding with `API_ERROR` artifacts).
> 
> **Forecast D-1 readiness guardrail adds an optional “14” BigQuery validation path and richer Slack messaging.** The Python guardrail now reads `bq_table_14`, derives a `domain`, runs a second query with extra required columns, records per-table statuses/metrics into the CSV, and updates the workflow’s Slack payload to include clearer headers/context plus 14-check status indicators and failure details; the manual `dry_run` default flips to `true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb2aee753fa5013d186d64c75a1e18c449bfeaa9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->