### PR TITLE
ci: v3.4 hotfix (jq metrics + Step1 failure comment)

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1261,11 +1261,18 @@ jobs:
             --argjson anthropic_usage "$ANTHROPIC_USAGE_JSON_SAFE" \
             --argjson openai_usage "$OPENAI_USAGE_JSON_SAFE" \
             --argjson synthesis_usage "$SYNTHESIS_USAGE_JSON_SAFE" \
-            '{
-              timestamp: $timestamp,
-              repository: $repository,
-              pr_number: ($pr_number | tonumber? // 0),
-              review_mode: $review_mode,
+            '
+              def toint:
+                if type == "number" then .
+                elif type == "string" and test("^[0-9]+$") then tonumber
+                else 0
+                end;
+
+              {
+                timestamp: $timestamp,
+                repository: $repository,
+                pr_number: ($pr_number | toint),
+                review_mode: $review_mode,
                 trigger: $trigger,
                 run_id: $run_id,
                 workflow: $workflow,
@@ -1273,34 +1280,35 @@ jobs:
                 actor: $actor,
                 comment_author: $comment_author,
                 pr_author: $pr_author,
-              models: {
-                anthropic: $anthropic_model,
-                openai: $openai_model
-              },
-              usage: {
-                anthropic: $anthropic_usage,
-                openai: $openai_usage,
-                synthesis: $synthesis_usage
-              },
-              output: {
-                anthropic_words: ($anthropic_words | tonumber? // 0),
-                openai_words: ($openai_words | tonumber? // 0),
-                final_words: ($final_words | tonumber? // 0)
-              },
-              findings: {
-                critical: ($critical_count | tonumber? // 0),
-                high: ($high_count | tonumber? // 0),
-                medium: ($medium_count | tonumber? // 0),
-                low: ($low_count | tonumber? // 0)
-              },
-              verdict: $verdict,
-              bugbot: {
-                source_count: ($bugbot_count | tonumber? // 0),
-                sources: $bugbot_sources
-              },
-              status: $status,
-              review_status: $review_status
-            }' > metrics/review-metrics.json
+                models: {
+                  anthropic: $anthropic_model,
+                  openai: $openai_model
+                },
+                usage: {
+                  anthropic: $anthropic_usage,
+                  openai: $openai_usage,
+                  synthesis: $synthesis_usage
+                },
+                output: {
+                  anthropic_words: ($anthropic_words | toint),
+                  openai_words: ($openai_words | toint),
+                  final_words: ($final_words | toint)
+                },
+                findings: {
+                  critical: ($critical_count | toint),
+                  high: ($high_count | toint),
+                  medium: ($medium_count | toint),
+                  low: ($low_count | toint)
+                },
+                verdict: $verdict,
+                bugbot: {
+                  source_count: ($bugbot_count | toint),
+                  sources: $bugbot_sources
+                },
+                status: $status,
+                review_status: $review_status
+              }
+            ' > metrics/review-metrics.json
           
           echo "📊 Review metrics saved to metrics/review-metrics.json"
           if ! jq -c '{timestamp,repository,pr_number,review_mode,models,findings,verdict,status,review_status}' metrics/review-metrics.json; then

--- a/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+++ b/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
@@ -106,17 +106,17 @@ if [ "$ANTHROPIC_API_KEY_PRESENT" != "true" ] && [ "$OPENAI_API_KEY_PRESENT" != 
   printf '%s' "API_ERROR" > anthropic_review.txt
   printf '%s' "API_ERROR" > openai_review.txt
 
-	safe_reason() {
-	  printf '%s' "${1:-}" | tr -d '\r\n' | grep -Eo '^[A-Za-z0-9._-]+' || true
-	}
+  safe_reason() {
+    printf '%s' "${1:-}" | tr -d '\r\n' | grep -Eo '^[A-Za-z0-9._-]+' || true
+  }
 
-	mkdir -p "$(dirname "$STEP1_REASON_FILE")"
-	printf '%s\n' \
-	  "reason=missing_api_keys" \
-	  "anthropic_skip_reason=$(safe_reason "${ANTHROPIC_SKIP_REASON:-}")" \
-	  "openai_skip_reason=$(safe_reason "${OPENAI_SKIP_REASON:-}")" \
-	  > "${STEP1_REASON_FILE}"
-	exit 1
+  mkdir -p "$(dirname "$STEP1_REASON_FILE")"
+  printf '%s\n' \
+    "reason=missing_api_keys" \
+    "anthropic_skip_reason=$(safe_reason "${ANTHROPIC_SKIP_REASON:-}")" \
+    "openai_skip_reason=$(safe_reason "${OPENAI_SKIP_REASON:-}")" \
+    > "${STEP1_REASON_FILE}"
+  exit 1
 fi
 
 if [ "$ANTHROPIC_API_KEY_PRESENT" == "true" ]; then


### PR DESCRIPTION
Fixes issues found during enterprise rollout bot-gating:
- Generate metrics JSON via `jq -n` (avoid heredoc string interpolation / invalid JSON risk)
- Post a fallback PR comment when Step1 fails (e.g. both API keys missing), with a small reason file
- Add inline verification note for the pinned `actions/checkout` SHA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI workflow control flow and PR-commenting behavior; mistakes could spam comments or break metrics/artifact generation, but scope is limited to automation infrastructure.
> 
> **Overview**
> Improves the `merglbot-pr-assistant-v3-on-demand` GitHub Actions workflow’s resilience and observability.
> 
> Adds explicit `permissions` to the `check-trigger` job, annotates the pinned `actions/checkout` SHA with a verification note, and introduces a new “Step 1 Failure Comment” that posts (or updates via marker-based dedupe) a PR comment when Step 1 model API calls fail, including sanitized failure reasons.
> 
> Reworks review metrics generation to build `metrics/review-metrics.json` via `jq -n` (instead of heredoc interpolation), adds workflow/run metadata and a computed `review_status`, and normalizes usage JSON inputs to avoid invalid/multi-document JSON issues. The Step 1 script now writes a small sanitized reason file when both API keys are missing to support the failure comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d54348d6cafaa8a57729aaad7e04ac7ec43ae0dd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->