### PR TITLE
fix(ci): use notes-file for release changelog

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -175,9 +175,13 @@ jobs:
           if gh release view "$VERSION" >/dev/null 2>&1; then
             echo "Release $VERSION already exists, skipping release creation (idempotent)"
           else
+            if [ ! -f CHANGELOG_TEMP.md ]; then
+              echo "::error::CHANGELOG_TEMP.md is missing; cannot create release notes."
+              exit 1
+            fi
             gh release create "$VERSION" \
               --title "Release $VERSION" \
-              --notes "${{ steps.changelog.outputs.changelog }}" \
+              --notes-file CHANGELOG_TEMP.md \
               --verify-tag \
               --latest
             echo "Release $VERSION created"
@@ -192,7 +196,11 @@ jobs:
           else
             echo "### 🎉 Release v${{ steps.version.outputs.version }} Created" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "${{ steps.changelog.outputs.changelog }}" >> $GITHUB_STEP_SUMMARY
+            if [ -f CHANGELOG_TEMP.md ]; then
+              cat CHANGELOG_TEMP.md >> $GITHUB_STEP_SUMMARY
+            else
+              echo "_Changelog file missing._" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
   
   notify:


### PR DESCRIPTION
Fixes the `Automated Release` workflow failing on commit subjects containing quotes/parentheses by avoiding inline multi-line `--notes` interpolation and using `--notes-file` instead.

Test plan:
- CI checks (incl. Cursor Bugbot)
- Post-merge: watch `Automated Release` on main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that alters how release notes are passed to `gh`; low risk aside from potentially failing releases if the changelog temp file is not generated.
> 
> **Overview**
> **Fixes the `Automated Release` workflow’s release-note handling** by switching `gh release create` from inline `--notes` interpolation to `--notes-file CHANGELOG_TEMP.md`, avoiding failures when commit subjects include quotes/parentheses.
> 
> Adds a guard to error out if `CHANGELOG_TEMP.md` is missing, and updates `GITHUB_STEP_SUMMARY` to append the file contents (or a fallback message) instead of printing the raw output variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 538751f542789bfd8a16f756d0ca5ee545e7a04e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->