### PR TITLE
ci: hotfix PR Assistant v3.5.1

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -500,7 +500,7 @@ jobs:
           
             if [ "${SKIP_REASON:-}" == "potential_secret" ]; then
               {
-              printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5"
+              printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5.1"
               printf '%s\n' ""
               printf '%s\n' "⛔️ Skipped: potential secret-like material detected in the PR context."
               printf '%s\n' ""
@@ -517,7 +517,7 @@ jobs:
                 exit 0
               fi
               {
-              printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5"
+              printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5.1"
               printf '%s\n' ""
               printf '%s\n' "⏭️ No new commits since last Merglbot review (\`${PREV_SHA:0:12}\`).  "
               printf '%s\n' "Current head: \`${HEAD_SHA:0:12}\`."
@@ -582,7 +582,7 @@ jobs:
           fi
 
           {
-            printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5"
+            printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5.1"
             printf '%s\n' ""
             printf '%s\n' "⛔️ Review failed during Step 1 (model API calls)."
             printf '%s\n' ""
@@ -884,10 +884,17 @@ jobs:
             local out=""
             out="$(echo "$json" | jq -r '.output_text // empty' 2>/dev/null || true)"
             if [ -z "$out" ] || [ "$out" = "null" ]; then
-              out="$(echo "$json" | jq -r '[.output[]? | select(.type=="message") | .content[]? | select(.type=="output_text") | .text] | join("\n")' 2>/dev/null || true)"
+              # More robust extraction: support multiple Responses API shapes (message content types may vary).
+              out="$(echo "$json" | jq -r '[.output[]? | select(.type=="message") | .content[]? | .text? // empty] | map(select(type=="string" and length>0)) | join("\n")' 2>/dev/null || true)"
             fi
             if [ -z "$out" ] || [ "$out" = "null" ]; then
-              out="$(echo "$json" | jq -r '.output[0].content[0].text // empty' 2>/dev/null || true)"
+              out="$(echo "$json" | jq -r '[.output[]? | .text? // empty] | map(select(type=="string" and length>0)) | join("\n")' 2>/dev/null || true)"
+            fi
+            if [ -z "$out" ] || [ "$out" = "null" ]; then
+              out="$(echo "$json" | jq -r '[.output[]? | .content? | if type=="string" then . elif type=="array" then (.[]? | .text? // empty) else empty end] | map(select(type=="string" and length>0)) | join("\n")' 2>/dev/null || true)"
+            fi
+            if [ -z "$out" ] || [ "$out" = "null" ]; then
+              out="$(echo "$json" | jq -r '[.output[]? | .content[]? | .text? // empty] | map(select(type=="string" and length>0)) | join("\n")' 2>/dev/null || true)"
             fi
             printf '%s' "$out"
           }
@@ -1159,13 +1166,13 @@ jobs:
           
           if [ ! -s final_review.txt ] || grep -q "^API_ERROR$" final_review.txt; then
             {
-              echo "## 🤖 Merglbot PR Assistant v3.5"
+              echo "## 🤖 Merglbot PR Assistant v3.5.1"
               echo ""
               echo "❌ Review generation failed. Please check workflow logs."
             } > comment.md
           else
             {
-              echo "## 🤖 Merglbot PR Assistant v3.5"
+              echo "## 🤖 Merglbot PR Assistant v3.5.1"
               echo ""
               cat final_review.txt
               echo ""
@@ -1263,7 +1270,7 @@ jobs:
           SKIP_REASON="${{ steps.context.outputs.skip_reason }}"
           if [ "$SKIPPED" == "true" ]; then
             {
-              echo "## 🤖 Merglbot PR Assistant v3.5 - Summary"
+              echo "## 🤖 Merglbot PR Assistant v3.5.1 - Summary"
               echo ""
               echo "- **PR**: #${{ env.PR_NUMBER }}"
               if [ "$SKIP_REASON" == "potential_secret" ]; then
@@ -1291,7 +1298,7 @@ jobs:
           fi
           
           {
-            echo "## 🤖 Merglbot PR Assistant v3.5 - Summary"
+            echo "## 🤖 Merglbot PR Assistant v3.5.1 - Summary"
             echo ""
             echo "| Field | Value |"
             echo "|-------|-------|"

--- a/docs/claude-pr-assistant.md
+++ b/docs/claude-pr-assistant.md
@@ -21,9 +21,9 @@ For lighter review: `@merglbot review --light`
 
 ## Current Workflow Location
 
-- **Source**: `.github/workflows/merglbot-pr-assistant-v3-on-demand.yml`
-- **Tag**: `merglbot-core/github@v3.5.0`
-- **Coverage**: 32/32 active target repos across 11 organizations (archived/read-only excluded; snapshot as of 2026-02-23). Source: SSOT `merglbot-public/docs/MERGLBOT_PR_ASSISTANT_V3.md`.
+- **Canonical source**: `merglbot-core/github/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml` (v3.5.1)
+- **Deployed copy** (per target repo): `.github/workflows/merglbot-pr-v3-on-demand.yml` via `scripts/pr-assistant/deploy-v3.sh`
+- **Coverage**: defined by `merglbot-core/github/scripts/pr-assistant/target-repos.txt` (SSOT: `merglbot-public/docs/MERGLBOT_PR_ASSISTANT_V3.md`)
 
 ---
 

--- a/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+++ b/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
@@ -231,7 +231,11 @@ BOT_MODE="default"
 OPENAI_REASONING_EFFORT="high"
 # Dependabot "superlight" mode is only enabled for the `issue_comment` trigger.
 # If a human explicitly runs `workflow_dispatch`, treat it as an override and keep default/full behavior.
-if [ "${PR_AUTHOR:-}" = "dependabot[bot]" ] && [ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]; then
+IS_DEPENDABOT="false"
+case "${PR_AUTHOR:-}" in
+  dependabot[bot]|app/dependabot) IS_DEPENDABOT="true" ;;
+esac
+if [ "$IS_DEPENDABOT" = "true" ] && [ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]; then
   BOT_MODE="dependabot"
   OPENAI_REASONING_EFFORT="medium"
   OPENAI_MODEL="gpt-5-mini"
@@ -401,7 +405,7 @@ echo "Review depth: $REVIEW_DEPTH"
 
 # Build prompt using printf to file (single redirect)
 {
-printf '%s\n' "# Merglbot Multi-Model Code Review v3.5"
+printf '%s\n' "# Merglbot Multi-Model Code Review v3.5.1"
 printf '%s\n' ""
 printf '%s\n' "You are a senior code reviewer for Merglbot - a platform for AI-powered code intelligence."
 printf '%s\n' ""
@@ -715,10 +719,17 @@ extract_output_text_responses() {
   local out=""
   out="$(echo "$json" | jq -r '.output_text // empty' 2>/dev/null || true)"
   if [ -z "$out" ] || [ "$out" = "null" ]; then
-    out="$(echo "$json" | jq -r '[.output[]? | select(.type=="message") | .content[]? | select(.type=="output_text") | .text] | join("\n")' 2>/dev/null || true)"
+    # More robust extraction: support multiple Responses API shapes (message content types may vary).
+    out="$(echo "$json" | jq -r '[.output[]? | select(.type=="message") | .content[]? | .text? // empty] | map(select(type=="string" and length>0)) | join("\n")' 2>/dev/null || true)"
   fi
   if [ -z "$out" ] || [ "$out" = "null" ]; then
-    out="$(echo "$json" | jq -r '.output[0].content[0].text // empty' 2>/dev/null || true)"
+    out="$(echo "$json" | jq -r '[.output[]? | .text? // empty] | map(select(type=="string" and length>0)) | join("\n")' 2>/dev/null || true)"
+  fi
+  if [ -z "$out" ] || [ "$out" = "null" ]; then
+    out="$(echo "$json" | jq -r '[.output[]? | .content? | if type=="string" then . elif type=="array" then (.[]? | .text? // empty) else empty end] | map(select(type=="string" and length>0)) | join("\n")' 2>/dev/null || true)"
+  fi
+  if [ -z "$out" ] || [ "$out" = "null" ]; then
+    out="$(echo "$json" | jq -r '[.output[]? | .content[]? | .text? // empty] | map(select(type=="string" and length>0)) | join("\n")' 2>/dev/null || true)"
   fi
   printf '%s' "$out"
 }


### PR DESCRIPTION
Fixes two post-merge regressions found during end-to-end validation of v3.5.0:

- Dependabot superlight: detect real-world PR author login variants (`dependabot[bot]` and `app/dependabot`).
- OpenAI Responses parsing: more robust `output_text` extraction for GPT-5 models (fixes `Responses API contained no output_text` for `gpt-5-mini`).

Also bumps user-facing strings to v3.5.1.

Follow-ups:
- After merge, rollout to all repos in `scripts/pr-assistant/target-repos.txt` via `deploy-v3.sh` and open PR wave.
- Create git tag `v3.5.1` (and backfill `v3.5.0` if desired) for SSOT alignment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted CI workflow/script changes; primary risk is unexpected behavior in OpenAI JSON parsing or Dependabot detection affecting review generation.
> 
> **Overview**
> Updates PR Assistant branding from `v3.5` to `v3.5.1` across PR comments, workflow summaries, and the review prompt header.
> 
> Fixes two workflow regressions: Dependabot “superlight” mode now triggers for both `dependabot[bot]` and `app/dependabot` authors, and OpenAI Responses output parsing now handles more response shapes to prevent false “no `output_text`” failures (applied in both the main workflow and Step 1 script).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31704a81d5e9fe61f99f875f7230d572b35f5fb6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->