### PR TITLE
ci: hotfix PR Assistant v3.5.2 (dependabot[bot])

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -500,7 +500,7 @@ jobs:
           
             if [ "${SKIP_REASON:-}" == "potential_secret" ]; then
               {
-              printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5.1"
+              printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5.2"
               printf '%s\n' ""
               printf '%s\n' "⛔️ Skipped: potential secret-like material detected in the PR context."
               printf '%s\n' ""
@@ -517,7 +517,7 @@ jobs:
                 exit 0
               fi
               {
-              printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5.1"
+              printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5.2"
               printf '%s\n' ""
               printf '%s\n' "⏭️ No new commits since last Merglbot review (\`${PREV_SHA:0:12}\`).  "
               printf '%s\n' "Current head: \`${HEAD_SHA:0:12}\`."
@@ -582,7 +582,7 @@ jobs:
           fi
 
           {
-            printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5.1"
+            printf '%s\n' "## 🤖 Merglbot PR Assistant v3.5.2"
             printf '%s\n' ""
             printf '%s\n' "⛔️ Review failed during Step 1 (model API calls)."
             printf '%s\n' ""
@@ -1166,13 +1166,13 @@ jobs:
           
           if [ ! -s final_review.txt ] || grep -q "^API_ERROR$" final_review.txt; then
             {
-              echo "## 🤖 Merglbot PR Assistant v3.5.1"
+              echo "## 🤖 Merglbot PR Assistant v3.5.2"
               echo ""
               echo "❌ Review generation failed. Please check workflow logs."
             } > comment.md
           else
             {
-              echo "## 🤖 Merglbot PR Assistant v3.5.1"
+              echo "## 🤖 Merglbot PR Assistant v3.5.2"
               echo ""
               cat final_review.txt
               echo ""
@@ -1270,7 +1270,7 @@ jobs:
           SKIP_REASON="${{ steps.context.outputs.skip_reason }}"
           if [ "$SKIPPED" == "true" ]; then
             {
-              echo "## 🤖 Merglbot PR Assistant v3.5.1 - Summary"
+              echo "## 🤖 Merglbot PR Assistant v3.5.2 - Summary"
               echo ""
               echo "- **PR**: #${{ env.PR_NUMBER }}"
               if [ "$SKIP_REASON" == "potential_secret" ]; then
@@ -1298,7 +1298,7 @@ jobs:
           fi
           
           {
-            echo "## 🤖 Merglbot PR Assistant v3.5.1 - Summary"
+            echo "## 🤖 Merglbot PR Assistant v3.5.2 - Summary"
             echo ""
             echo "| Field | Value |"
             echo "|-------|-------|"

--- a/docs/claude-pr-assistant.md
+++ b/docs/claude-pr-assistant.md
@@ -21,7 +21,7 @@ For lighter review: `@merglbot review --light`
 
 ## Current Workflow Location
 
-- **Canonical source**: `merglbot-core/github/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml` (v3.5.1)
+- **Canonical source**: `merglbot-core/github/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml` (v3.5.2)
 - **Deployed copy** (per target repo): `.github/workflows/merglbot-pr-v3-on-demand.yml` via `scripts/pr-assistant/deploy-v3.sh`
 - **Coverage**: defined by `merglbot-core/github/scripts/pr-assistant/target-repos.txt` (SSOT: `merglbot-public/docs/MERGLBOT_PR_ASSISTANT_V3.md`)
 

--- a/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+++ b/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
@@ -232,9 +232,9 @@ OPENAI_REASONING_EFFORT="high"
 # Dependabot "superlight" mode is only enabled for the `issue_comment` trigger.
 # If a human explicitly runs `workflow_dispatch`, treat it as an override and keep default/full behavior.
 IS_DEPENDABOT="false"
-case "${PR_AUTHOR:-}" in
-  dependabot[bot]|app/dependabot) IS_DEPENDABOT="true" ;;
-esac
+if [ "${PR_AUTHOR:-}" = "dependabot[bot]" ] || [ "${PR_AUTHOR:-}" = "app/dependabot" ]; then
+  IS_DEPENDABOT="true"
+fi
 if [ "$IS_DEPENDABOT" = "true" ] && [ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]; then
   BOT_MODE="dependabot"
   OPENAI_REASONING_EFFORT="medium"
@@ -405,7 +405,7 @@ echo "Review depth: $REVIEW_DEPTH"
 
 # Build prompt using printf to file (single redirect)
 {
-printf '%s\n' "# Merglbot Multi-Model Code Review v3.5.1"
+printf '%s\n' "# Merglbot Multi-Model Code Review v3.5.2"
 printf '%s\n' ""
 printf '%s\n' "You are a senior code reviewer for Merglbot - a platform for AI-powered code intelligence."
 printf '%s\n' ""


### PR DESCRIPTION
Fix Dependabot superlight detection to match BOTH logins:

- `dependabot[bot]` (bot user)
- `app/dependabot` (GitHub App)

This avoids bash `case` glob pitfalls and prevents expensive default pipeline on Dependabot PRs.

Also bumps user-facing strings to v3.5.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub Actions workflow logic that controls when/how expensive LLM calls run; a mistake could increase cost or change review behavior, though the change is small and well-scoped.
> 
> **Overview**
> Updates PR Assistant v3 to correctly detect Dependabot PRs authored as either `dependabot[bot]` or `app/dependabot`, ensuring Dependabot uses the cheaper *superlight* review path instead of the default pipeline.
> 
> Bumps user-facing workflow/prompt/doc strings from `v3.5.1` to `v3.5.2` (PR comments, step summaries, and prompt header).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54787e69fdc9e0d9b1fe5f02e59fd9ee2b4f46cf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->