### PR TITLE
ci: PR Assistant v3.5.4

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -300,20 +300,26 @@ jobs:
             CHECKS_PENDING="0"
 
             if jq -e '.statusCheckRollup != null' pr_metadata.json > /dev/null 2>&1; then
-              jq -r '
+              if jq -r '
                 (.statusCheckRollup.contexts // .statusCheckRollup // [])
                 | map(select(.name != null))
                 | map("- " + .name + ": " + ((.conclusion // .state // "UNKNOWN") | tostring | ascii_upcase))
                 | .[]
-              ' pr_metadata.json > pr_checks_summary.txt 2>/dev/null || true
+              ' pr_metadata.json > pr_checks_summary.txt 2>/dev/null; then
+                if [ -s pr_checks_summary.txt ]; then
+                  CHECKS_FAILED=$(jq -r '[ (.statusCheckRollup.contexts // .statusCheckRollup // [])[]? | ((.conclusion // .state // "") | ascii_downcase) | select(. == "failure" or . == "cancelled" or . == "timed_out" or . == "error") ] | length' pr_metadata.json 2>/dev/null || echo "0")
+                  CHECKS_PENDING=$(jq -r '[ (.statusCheckRollup.contexts // .statusCheckRollup // [])[]? | ((.conclusion // .state // "") | ascii_downcase) | select(. == "pending" or . == "in_progress" or . == "queued") ] | length' pr_metadata.json 2>/dev/null || echo "0")
+                  CHECKS_DATA_AVAILABLE="true"
+                fi
+              fi
+            fi
 
-              CHECKS_FAILED=$(jq -r '[ (.statusCheckRollup.contexts // .statusCheckRollup // [])[]? | ((.conclusion // .state // "") | ascii_downcase) | select(. == "failure" or . == "cancelled" or . == "timed_out" or . == "error") ] | length' pr_metadata.json 2>/dev/null || echo "0")
-              CHECKS_PENDING=$(jq -r '[ (.statusCheckRollup.contexts // .statusCheckRollup // [])[]? | ((.conclusion // .state // "") | ascii_downcase) | select(. == "pending" or . == "in_progress" or . == "queued") ] | length' pr_metadata.json 2>/dev/null || echo "0")
-
-              CHECKS_DATA_AVAILABLE="true"
-            elif [ -n "${PR_HEAD_SHA:-}" ]; then
-              if gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs?per_page=100" \
-                | jq -s '{check_runs: (map(.check_runs // []) | add // [])}' > check_runs.json 2>/dev/null; then
+            if [ "$CHECKS_DATA_AVAILABLE" != "true" ] && [ -n "${PR_HEAD_SHA:-}" ]; then
+              if (
+                set -o pipefail
+                gh api --silent --paginate "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs?per_page=100" 2>/dev/null \
+                  | jq -s '{check_runs: (map(.check_runs // []) | add // [])}' > check_runs.json 2>/dev/null
+              ); then
                 if jq -e '.check_runs | type == "array"' check_runs.json > /dev/null 2>&1; then
                   # Exclude check-runs for THIS workflow run so we don't count ourselves as "pending" while gathering context.
                   jq -r --arg current_run_id "${GITHUB_RUN_ID:-}" '
@@ -349,7 +355,8 @@ jobs:
                     CHECKS_DATA_AVAILABLE="true"
                   fi
                 else
-                  echo "WARN: check_runs.json invalid; skipping check-runs fallback" >&2
+                  CHECK_RUNS_JSON_SIZE="$(wc -c < check_runs.json 2>/dev/null || echo "0")"
+                  echo "WARN: check_runs.json invalid (size=${CHECK_RUNS_JSON_SIZE}B); skipping check-runs fallback" >&2
                 fi
               fi
             fi

--- a/scripts/pr-assistant/secret-scan-patterns-smoke-test.sh
+++ b/scripts/pr-assistant/secret-scan-patterns-smoke-test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck shell=bash
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=secret-scan-patterns.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/secret-scan-patterns.sh"
+
+# Google OAuth refresh token heuristic
+echo 'ya29.ABCDEFGHIJKLMNOPQRSTUV' | grep -Eiq "$_GOOGLE_OAUTH_REFRESH"
+if echo 'ya29XABCDEFGHIJ' | grep -Eiq "$_GOOGLE_OAUTH_REFRESH"; then
+  echo "unexpected match for _GOOGLE_OAUTH_REFRESH (negative case)" >&2
+  exit 1
+fi
+
+# JWT heuristic (strict-ish)
+echo 'eyJAAAAAAAAAAAAAAAAAAAA.BBBBBBBBBBBBBBBBBBBB.CCCCCCCCCCCCCCCCCCCC' | grep -Eiq "$JWT_PATTERN_STRICT"
+if echo 'eyJAAA.BBB.CCC' | grep -Eiq "$JWT_PATTERN_STRICT"; then
+  echo "unexpected match for JWT_PATTERN_STRICT (negative case)" >&2
+  exit 1
+fi
+
+echo "secret-scan-patterns smoke test: ok"

--- a/scripts/pr-assistant/secret-scan-patterns.sh
+++ b/scripts/pr-assistant/secret-scan-patterns.sh
@@ -39,4 +39,7 @@ SECRET_PATTERN_STRICT="${_BEGIN_PRIVATE_KEY}|${_BEGIN_PGP_PRIVATE_KEY}|${_SLACK_
 # AI review unnecessarily.
 SECRET_PATTERN_STRICT_NO_KEY="${_BEGIN_PRIVATE_KEY}|${_BEGIN_PGP_PRIVATE_KEY}|${_SLACK_TOKEN}|${_GITHUB_TOKEN_CLASSIC}|${_GITHUB_TOKEN_FINE_GRAINED}|${_GITHUB_TOKEN_GENERIC}|${_AWS_ACCESS_KEY}|${_GOOGLE_API_KEY}|${_GOOGLE_OAUTH_REFRESH}|${_OPENAI_PROJECT_KEY}|${_OPENAI_KEY}"
 
+# JWT detection is intentionally "strict-ish": it's used only as a *pre-scan*
+# guardrail before sending PR context to external LLM APIs. It's OK to prefer a
+# few false-positives over a false-negative that could exfiltrate secrets.
 JWT_PATTERN_STRICT='(^|[^[:alnum:]_])eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}($|[^[:alnum:]_])'


### PR DESCRIPTION
Hotfix v3.5.4:
- Fix secret pre-scan regex escaping (JWT/ya29) in scripts/pr-assistant/secret-scan-patterns.sh
- Paginate check-runs fallback to avoid under-reporting CI status

Also bumps the PR Assistant header strings to v3.5.4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR Assistant guardrails (secret pre-scan) and CI/check status aggregation logic in the workflow, which can change when reviews are skipped and how status is reported; changes are small but affect workflow control flow.
> 
> **Overview**
> Improves the PR Assistant’s CI/checks context capture by making the check-runs fallback **paginate** and only marking checks data as available when a non-empty summary is produced, with an added warning when the fallback JSON is invalid.
> 
> Fixes secret pre-scan regex escaping for Google OAuth refresh tokens (`ya29\.` → `ya29.`) and JWT detection (`\.` → `.`), and adds a small bash smoke test script to validate positive/negative matches.
> 
> Bumps all PR Assistant comment/summary headers from `v3.5.3` to `v3.5.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e48f22b407a1698febbb9a053dc1e588d2584ba2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->