### PR TITLE
docs: add PR assistant improvement digest 2026-03-07

### DIFF
--- a/docs/pr-assistant/improvement-digest/2026-03-07.md
+++ b/docs/pr-assistant/improvement-digest/2026-03-07.md
@@ -1,7 +1,7 @@
 # 🤖 PR Assistant — Improvement Digest
 
 Generated: 2026-03-07 10:24 UTC  
-Window: last 7 day(s) (since 2026-02-28T00:00:00Z)
+Window: last 7 days (since 2026-02-28T00:00:00Z)
 
 ## Global Summary
 
@@ -10,55 +10,20 @@ Window: last 7 day(s) (since 2026-02-28T00:00:00Z)
 | Total reviews | 0 |
 | 👍 Helpful | 0 |
 | 👎 Not helpful | 0 |
-| Satisfaction | N/A% |
+| Satisfaction | N/A |
 
 ## Per-Repo Summary
 
-| Repo | Reviews | 👍 | 👎 | Approve | Changes needed | Unknown |
-|------|---------|----|----|---------|----------------|---------|
-| merglbot-core/ai_prompts | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-core/dataform | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-core/fb-viz-api | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-core/infra | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-core/merglbot-admin | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-core/platform | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-core/tf-modules- | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-public/docs | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-public/kazdavterina-web | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-public/livero-web | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-public/website | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-cerano/cerano-web | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-cerano/feed-generator | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-cerano/product-forecasting | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-denatura/denatura-fb-viz | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-denatura/marketing_actions_detector | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-denatura/marketing-planning | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-proteinaco/abc_product_material_analysis | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-proteinaco/btf-legacy-implementation | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-proteinaco/btf-viz | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-proteinaco/proteinaco-web | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-proteinaco/viz-api | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-ruzovyslon/business_forecasting | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-ruzovyslon/data-pipelines | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-ruzovyslon/kbc_data_quality_metodology | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-ruzovyslon/ruzovyslon-web | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-ruzovyslon/viz-api | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-extractors/facebook-extractor | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-milan-private/fakturoid | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-autodoplnky/autodoplnky-web | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-hodinarstvibechyne/hodinarstvi-web | 0 | 0 | 0 | 0 | 0 | 0 |
-| merglbot-kiteboarding/kiteboarding-web | 0 | 0 | 0 | 0 | 0 | 0 |
+Detailed per-repo breakdown is omitted from the public digest. This window had no reviewed PRs, so there are no repo-level results to publish.
 
 ## Top MERGLBOT Rule Codes (frequency)
 
 ```
-
+None
 ```
 
 ## Recent 👎 Review Comments (triage list)
 
 ```
-repo\tPR\tverdict\tfeedback\tcomment_url
-
+None
 ```
-

--- a/docs/pr-assistant/improvement-digest/2026-03-07.md
+++ b/docs/pr-assistant/improvement-digest/2026-03-07.md
@@ -1,0 +1,64 @@
+# 🤖 PR Assistant — Improvement Digest
+
+Generated: 2026-03-07 10:24 UTC  
+Window: last 7 day(s) (since 2026-02-28T00:00:00Z)
+
+## Global Summary
+
+| Metric | Value |
+|--------|-------|
+| Total reviews | 0 |
+| 👍 Helpful | 0 |
+| 👎 Not helpful | 0 |
+| Satisfaction | N/A% |
+
+## Per-Repo Summary
+
+| Repo | Reviews | 👍 | 👎 | Approve | Changes needed | Unknown |
+|------|---------|----|----|---------|----------------|---------|
+| merglbot-core/ai_prompts | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-core/dataform | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-core/fb-viz-api | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-core/infra | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-core/merglbot-admin | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-core/platform | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-core/tf-modules- | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-public/docs | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-public/kazdavterina-web | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-public/livero-web | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-public/website | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-cerano/cerano-web | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-cerano/feed-generator | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-cerano/product-forecasting | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-denatura/denatura-fb-viz | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-denatura/marketing_actions_detector | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-denatura/marketing-planning | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-proteinaco/abc_product_material_analysis | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-proteinaco/btf-legacy-implementation | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-proteinaco/btf-viz | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-proteinaco/proteinaco-web | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-proteinaco/viz-api | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-ruzovyslon/business_forecasting | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-ruzovyslon/data-pipelines | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-ruzovyslon/kbc_data_quality_metodology | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-ruzovyslon/ruzovyslon-web | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-ruzovyslon/viz-api | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-extractors/facebook-extractor | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-milan-private/fakturoid | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-autodoplnky/autodoplnky-web | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-hodinarstvibechyne/hodinarstvi-web | 0 | 0 | 0 | 0 | 0 | 0 |
+| merglbot-kiteboarding/kiteboarding-web | 0 | 0 | 0 | 0 | 0 | 0 |
+
+## Top MERGLBOT Rule Codes (frequency)
+
+```
+
+```
+
+## Recent 👎 Review Comments (triage list)
+
+```
+repo\tPR\tverdict\tfeedback\tcomment_url
+
+```
+

--- a/docs/pr-assistant/improvement-digest/LATEST.md
+++ b/docs/pr-assistant/improvement-digest/LATEST.md
@@ -1,3 +1,5 @@
 # Latest improvement digest
 
+This file always points to the most recent public digest snapshot.
+
 - [2026-03-07.md](2026-03-07.md)

--- a/docs/pr-assistant/improvement-digest/LATEST.md
+++ b/docs/pr-assistant/improvement-digest/LATEST.md
@@ -1,0 +1,3 @@
+# Latest improvement digest
+
+- [2026-03-07.md](2026-03-07.md)


### PR DESCRIPTION
## Purpose
- replace app-authored digest PR with human-authored equivalent so V5.5 review bots can process the head deterministically

## Changes
- add daily PR Assistant improvement digest for 2026-03-07
- keep `LATEST.md` pointing to the current digest via clickable link
- no workflow/runtime changes

## Risk
- low, docs-only change under `docs/pr-assistant/improvement-digest/`

## Test plan
- GitHub PR checks (`lint`, `ci`, `CodeQL`)
- `/gemini review`
- `@cursor review`
- `@merglbot review`

## Rollback
- revert the digest files from the PR branch or close without merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds a new digest file and updates a pointer link; no runtime or logic changes.
> 
> **Overview**
> Adds a new documentation snapshot `2026-03-07.md` for the PR Assistant improvement digest (7-day window) with global metrics and empty sections due to no reviews in the period.
> 
> Updates `docs/pr-assistant/improvement-digest/LATEST.md` to link to the new snapshot as the current digest.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddf077cdcc3a3cae30296b6cec5fd49a0488f4dd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->