### PR TITLE
ci: include missing PR Assistant targets

### DIFF
--- a/scripts/pr-assistant/target-repos.txt
+++ b/scripts/pr-assistant/target-repos.txt
@@ -6,7 +6,6 @@
 # excluding:
 # - merglbot-core/github (canonical workflow source; do not deploy copy into itself)
 # - archived/read-only repos (listed at bottom)
-merglbot-cerano/viz-api
 merglbot-core/agents-orchestrator
 merglbot-core/ai_prompts
 merglbot-core/dataform
@@ -23,6 +22,7 @@ merglbot-public/website
 merglbot-cerano/cerano-web
 merglbot-cerano/feed-generator
 merglbot-cerano/product-forecasting
+merglbot-cerano/viz-api
 merglbot-denatura/denatura-fb-viz
 merglbot-denatura/marketing_actions_detector
 merglbot-denatura/marketing-planning

--- a/scripts/pr-assistant/target-repos.txt
+++ b/scripts/pr-assistant/target-repos.txt
@@ -6,6 +6,8 @@
 # excluding:
 # - merglbot-core/github (canonical workflow source; do not deploy copy into itself)
 # - archived/read-only repos (listed at bottom)
+merglbot-cerano/viz-api
+merglbot-core/agents-orchestrator
 merglbot-core/ai_prompts
 merglbot-core/dataform
 merglbot-core/fb-viz-api


### PR DESCRIPTION
## Purpose
- include the two active repos that were missing from the canonical PR Assistant rollout target list
- make future Wave 5 rollouts match the Wave 0 audit inventory without manual patching

## Changes
- add \
- add \
- keep the rest of the target set unchanged

## Risk
- low; metadata-only change in the canonical target list
- affects future rollout coverage and digest scope

## Test plan
- compare target count with Wave 0 / Wave 5 inventory
- verify the two repos were missing from the previous create pass and are now covered

## Rollback
- revert this PR to restore the prior target list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change that just broadens which repos automation targets; no runtime or security-sensitive logic changes.
> 
> **Overview**
> Updates `scripts/pr-assistant/target-repos.txt` to include `merglbot-core/agents-orchestrator` and `merglbot-cerano/viz-api`, expanding PR Assistant workflow rollouts and improvement-digest coverage to these previously-missing active repos.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc7428faa1b8936c935413d1548410d65d66d259. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->