### PR TITLE
ci: fail closed on stale automated releases

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Detect dependency lockfile

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -213,6 +213,11 @@ jobs:
         if: always()
         run: |
           set -eo pipefail
+          # Fail closed: if the plan step did not succeed, surface the failure
+          if [ "${{ steps.plan.outcome }}" != "success" ]; then
+            echo "::error::Plan step did not succeed (outcome: ${{ steps.plan.outcome }}). Failing closed."
+            exit 1
+          fi
           if [ "${{ steps.plan.outputs.release_needed }}" != "true" ]; then
             RELEASE_STATUS="release_skipped_no_release_needed"
             RELEASE_URL=""
@@ -291,13 +296,8 @@ jobs:
           RELEASE_STATUS="${{ needs.release.outputs.release_status }}"
           VERSION="v${{ needs.release.outputs.version }}"
 
-          if [ "$RELEASE_STATUS" = "release_created" ]; then
-            SLACK_TEXT="🚀 New Release Created: ${VERSION}"
-            SLACK_COLOR="good"
-          else
-            SLACK_TEXT="ℹ️ Release ${VERSION} already existed (idempotent no-op)"
-            SLACK_COLOR="#cccccc"
-          fi
+          SLACK_TEXT="🚀 New Release Created: ${VERSION}"
+          SLACK_COLOR="good"
 
           PAYLOAD=$(jq -n \
             --arg text "$SLACK_TEXT" \

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -29,9 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: ${{ steps.plan.outputs.resolved_version }}
       changelog: ${{ steps.changelog.outputs.changelog }}
+      release_needed: ${{ steps.plan.outputs.release_needed }}
       release_status: ${{ steps.release_state.outputs.release_status }}
+      tag_status: ${{ steps.plan.outputs.tag_status }}
+      release_url: ${{ steps.release_state.outputs.release_url }}
+      tag_commit_sha: ${{ steps.plan.outputs.tag_commit_sha }}
+      latest_existing_release: ${{ steps.plan.outputs.latest_existing_release }}
+      reason: ${{ steps.plan.outputs.reason }}
       
     steps:
       - name: Checkout
@@ -84,44 +90,31 @@ jobs:
         run: |
           npm install -g semantic-release @semantic-release/git @semantic-release/changelog
       
-      - name: Determine version
-        id: version
+      - name: Determine release plan
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -eo pipefail
-          if [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
-          else
-            # jq is already available in GitHub Actions Ubuntu runners
-            # Parse semantic-release output more robustly with JSON output when available
-            RELEASE_OUTPUT=$(npx semantic-release --dry-run --no-ci 2>&1 || true)
-            
-            # First try to extract from JSON output if available
-            VERSION=$(echo "$RELEASE_OUTPUT" | grep -o '{"nextRelease":{[^}]*}}' | jq -r '.nextRelease.version' 2>/dev/null || echo '')
-            
-            # Fallback to text parsing with more flexible patterns
-            if [ -z "$VERSION" ]; then
-              # Try various patterns that semantic-release might output
-              VERSION=$(echo "$RELEASE_OUTPUT" | grep -E 'next release version|new version|would publish|Release version' | \
-                        grep -oE '([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\.]+)?(\+[a-zA-Z0-9\.]+)?)' | head -1 || echo '')
-            fi
-            
-            # Final fallback: check for version in the format "Found version x.y.z"
-            if [ -z "$VERSION" ]; then
-              VERSION=$(echo "$RELEASE_OUTPUT" | grep -oE 'version[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+)' | \
-                        grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo '')
-            fi
-            if [ -z "$VERSION" ]; then
-              echo "No release needed"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Version: $VERSION"
+          NODE_PATH="$(npm root -g)"
+          export NODE_PATH
+          node scripts/release/resolve-next-release.cjs | tee release-plan.json
+          jq -r '
+            "resolved_version=\(.resolved_version)",
+            "release_needed=\(.release_needed)",
+            "release_status=\(.release_status)",
+            "tag_status=\(.tag_status)",
+            "release_url=\(.release_url)",
+            "tag_commit_sha=\(.tag_commit_sha)",
+            "latest_existing_release=\(.latest_existing_release)",
+            "reason=\(.reason)"
+          ' release-plan.json >> "$GITHUB_OUTPUT"
+          echo "Release status: $(jq -r '.release_status' release-plan.json)"
       
       - name: Generate changelog
         id: changelog
-        if: steps.version.outputs.skip != 'true'
+        if: steps.plan.outputs.release_needed == 'true'
         run: |
           set -eo pipefail
           # Generate changelog for the version
@@ -134,7 +127,7 @@ jobs:
           else
             RANGE="${PREV_TAG}..HEAD"
             COMMITS=$(git log "$RANGE" --pretty=format:"* %s (%h)" --no-merges)
-            COMPARE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${PREV_TAG}...v${{ steps.version.outputs.version }}"
+            COMPARE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${PREV_TAG}...v${{ steps.plan.outputs.resolved_version }}"
           fi
 
           COMMIT_COUNT=$(git rev-list "$RANGE" --count)
@@ -142,7 +135,7 @@ jobs:
           FILES_CHANGED=$(git diff "$RANGE" --stat | tail -1)
           
           cat > CHANGELOG_TEMP.md << EOF
-          # Release v${{ steps.version.outputs.version }}
+          # Release v${{ steps.plan.outputs.resolved_version }}
           
           ## 🚀 What's Changed
           EOF
@@ -169,39 +162,31 @@ jobs:
       
       - name: Create Git tag
         id: tag
-        if: steps.version.outputs.skip != 'true'
+        if: steps.plan.outputs.release_needed == 'true' && steps.plan.outputs.tag_status == 'tag_missing'
         run: |
           set -eo pipefail
-          VERSION="v${{ steps.version.outputs.version }}"
-          
-          # Check if tag already exists (idempotent)
-          if git tag -l "$VERSION" | grep -q "$VERSION"; then
-            echo "Tag $VERSION already exists, skipping tag creation (idempotent)"
-            echo "tag_status=tag_already_exists" >> "$GITHUB_OUTPUT"
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag -a "$VERSION" -m "Release $VERSION"
-            git push origin "$VERSION"
-            echo "Tag $VERSION created and pushed"
-            echo "tag_status=tag_created" >> "$GITHUB_OUTPUT"
-          fi
+          VERSION="${{ steps.plan.outputs.tag_name }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+          echo "Tag $VERSION created and pushed"
+          echo "tag_status=tag_created" >> "$GITHUB_OUTPUT"
       
       - name: Create GitHub Release
         id: github_release
-        if: steps.version.outputs.skip != 'true'
+        if: steps.plan.outputs.release_needed == 'true' && steps.plan.outputs.release_status != 'release_already_exists_for_current_head'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
-          VERSION="v${{ steps.version.outputs.version }}"
+          VERSION="${{ steps.plan.outputs.tag_name }}"
           RELEASE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${VERSION}"
           
-          # Check if release already exists (idempotent)
           if gh release view "$VERSION" >/dev/null 2>&1; then
-            echo "Release $VERSION already exists, skipping release creation (idempotent)"
+            echo "Release $VERSION already exists after planning; treating as same-head rerun"
             {
-              echo "release_status=release_already_exists"
+              echo "release_status=release_already_exists_for_current_head"
               echo "release_url=${RELEASE_URL}"
             } >> "$GITHUB_OUTPUT"
           else
@@ -226,10 +211,15 @@ jobs:
         if: always()
         run: |
           set -eo pipefail
-          if [ "${{ steps.version.outputs.skip }}" = "true" ]; then
-            RELEASE_STATUS="release_skipped_no_version"
+          if [ "${{ steps.plan.outputs.release_needed }}" != "true" ]; then
+            RELEASE_STATUS="release_skipped_no_release_needed"
+            RELEASE_URL=""
+          elif [ "${{ steps.plan.outputs.release_status }}" = "release_already_exists_for_current_head" ]; then
+            RELEASE_STATUS="release_already_exists_for_current_head"
+            RELEASE_URL="${{ steps.plan.outputs.release_url }}"
           else
             RELEASE_STATUS="${{ steps.github_release.outputs.release_status }}"
+            RELEASE_URL="${{ steps.github_release.outputs.release_url }}"
           fi
 
           if [ -z "$RELEASE_STATUS" ]; then
@@ -239,6 +229,7 @@ jobs:
 
           echo "Release outcome: $RELEASE_STATUS"
           echo "release_status=$RELEASE_STATUS" >> "$GITHUB_OUTPUT"
+          echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
       
       - name: Update GITHUB_STEP_SUMMARY
         if: always()
@@ -246,38 +237,40 @@ jobs:
           set -eo pipefail
           RELEASE_STATUS="${{ steps.release_state.outputs.release_status }}"
 
-          if [ "$RELEASE_STATUS" = "release_skipped_no_version" ]; then
+          if [ "$RELEASE_STATUS" = "release_skipped_no_release_needed" ]; then
             {
               echo "### ⏭️ Release Skipped"
               echo "No changes requiring a release were detected."
             } >> "$GITHUB_STEP_SUMMARY"
-          elif [ "$RELEASE_STATUS" = "release_already_exists" ]; then
+          elif [ "$RELEASE_STATUS" = "release_already_exists_for_current_head" ]; then
             {
-              echo "### ℹ️ Release v${{ steps.version.outputs.version }} Already Exists"
-              echo "This run was an idempotent no-op: the tag and GitHub release were already present."
+              echo "### ℹ️ Release v${{ steps.plan.outputs.resolved_version }} Already Exists For Current HEAD"
+              echo "This run was a safe same-head rerun; no new tag or release was created."
             } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "### 🎉 Release v${{ steps.version.outputs.version }} Created" >> "$GITHUB_STEP_SUMMARY"
+            echo "### 🎉 Release v${{ steps.plan.outputs.resolved_version }} Created" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          if [ "$RELEASE_STATUS" != "release_skipped_no_version" ]; then
+          if [ "$RELEASE_STATUS" != "release_skipped_no_release_needed" ]; then
             {
               echo ""
               echo "- Outcome: \`$RELEASE_STATUS\`"
-              echo "- Release URL: ${{ steps.github_release.outputs.release_url }}"
+              echo "- Release URL: ${{ steps.release_state.outputs.release_url }}"
+              echo "- Latest existing release: ${{ steps.plan.outputs.latest_existing_release }}"
+              echo "- Resolution reason: ${{ steps.plan.outputs.reason }}"
               echo ""
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
           if [ -f CHANGELOG_TEMP.md ]; then
             cat CHANGELOG_TEMP.md >> "$GITHUB_STEP_SUMMARY"
-          elif [ "$RELEASE_STATUS" != "release_skipped_no_version" ]; then
+          elif [ "$RELEASE_STATUS" != "release_skipped_no_release_needed" ]; then
             echo "_Changelog file missing._" >> "$GITHUB_STEP_SUMMARY"
           fi
   
   notify:
     needs: release
-    if: needs.release.outputs.release_status != 'release_skipped_no_version'
+    if: needs.release.outputs.release_status == 'release_created'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     
@@ -295,7 +288,6 @@ jobs:
 
           RELEASE_STATUS="${{ needs.release.outputs.release_status }}"
           VERSION="v${{ needs.release.outputs.version }}"
-          RELEASE_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/${VERSION}"
 
           if [ "$RELEASE_STATUS" = "release_created" ]; then
             SLACK_TEXT="🚀 New Release Created: ${VERSION}"
@@ -311,7 +303,7 @@ jobs:
             --arg outcome "${{ needs.release.outputs.release_status }}" \
             --arg version "$VERSION" \
             --arg repository "${{ github.repository }}" \
-            --arg release_url "$RELEASE_URL" \
+            --arg release_url "${{ needs.release.outputs.release_url }}" \
             '{
               text: $text,
               attachments: [{

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -104,6 +104,7 @@ jobs:
             "resolved_version=\(.resolved_version)",
             "release_needed=\(.release_needed)",
             "release_status=\(.release_status)",
+            "tag_name=\(.tag_name)",
             "tag_status=\(.tag_status)",
             "release_url=\(.release_url)",
             "tag_commit_sha=\(.tag_commit_sha)",

--- a/scripts/release/resolve-next-release-smoke-test.cjs
+++ b/scripts/release/resolve-next-release-smoke-test.cjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const {
+  buildReleasePlan,
+  compareVersions,
+  normalizeVersion,
+} = require('./resolve-next-release.cjs');
+
+assert.equal(normalizeVersion('v1.2.3'), '1.2.3');
+assert.equal(normalizeVersion('1.2.3-beta.1+build.5'), '1.2.3-beta.1+build.5');
+assert(compareVersions('1.2.4', '1.2.3') > 0);
+assert(compareVersions('1.2.3', '1.2.3') === 0);
+assert(compareVersions('1.2.3-beta.1', '1.2.3') < 0);
+
+const noRelease = buildReleasePlan({
+  releaseNeeded: false,
+  resolvedVersion: '',
+  reason: 'no_release',
+  headSha: 'a'.repeat(40),
+  latestExistingRelease: 'v24.2.10',
+  existingRelease: null,
+  tagCommitSha: '',
+});
+assert.equal(noRelease.release_status, 'release_skipped_no_release_needed');
+
+const sameHeadRerun = buildReleasePlan({
+  releaseNeeded: true,
+  resolvedVersion: '24.2.11',
+  reason: 'next_release_found',
+  headSha: 'b'.repeat(40),
+  latestExistingRelease: 'v24.2.10',
+  existingRelease: { html_url: 'https://example.invalid/release', tag_name: 'v24.2.11' },
+  tagCommitSha: 'b'.repeat(40),
+});
+assert.equal(sameHeadRerun.release_status, 'release_already_exists_for_current_head');
+
+const tagOnlySameHead = buildReleasePlan({
+  releaseNeeded: true,
+  resolvedVersion: '24.2.11',
+  reason: 'next_release_found',
+  headSha: 'c'.repeat(40),
+  latestExistingRelease: 'v24.2.10',
+  existingRelease: null,
+  tagCommitSha: 'c'.repeat(40),
+});
+assert.equal(tagOnlySameHead.release_status, 'release_pending_create');
+assert.equal(tagOnlySameHead.tag_status, 'tag_exists_for_current_head');
+
+const pendingCreate = buildReleasePlan({
+  releaseNeeded: true,
+  resolvedVersion: '24.2.11',
+  reason: 'next_release_found',
+  headSha: 'd'.repeat(40),
+  latestExistingRelease: 'v24.2.10',
+  existingRelease: null,
+  tagCommitSha: '',
+});
+assert.equal(pendingCreate.release_status, 'release_pending_create');
+assert.equal(pendingCreate.tag_status, 'tag_missing');
+
+assert.throws(
+  () =>
+    buildReleasePlan({
+      releaseNeeded: true,
+      resolvedVersion: '24.2.9',
+      reason: 'next_release_found',
+      headSha: 'e'.repeat(40),
+      latestExistingRelease: 'v24.2.10',
+      existingRelease: null,
+      tagCommitSha: '',
+    }),
+  /not newer than latest published release/
+);
+
+console.log('resolve-next-release smoke test: ok');

--- a/scripts/release/resolve-next-release.cjs
+++ b/scripts/release/resolve-next-release.cjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process');
+
+const SEMVER_RE = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/;
+
+function normalizeVersion(input) {
+  if (!input) {
+    return '';
+  }
+
+  const trimmed = String(input).trim();
+  const match = SEMVER_RE.exec(trimmed);
+  if (!match) {
+    throw new Error(`Invalid semantic version: ${trimmed}`);
+  }
+
+  return `${match[1]}.${match[2]}.${match[3]}${match[4] ? `-${match[4]}` : ''}${match[5] ? `+${match[5]}` : ''}`;
+}
+
+function parseSemver(version) {
+  const normalized = normalizeVersion(version);
+  const match = SEMVER_RE.exec(normalized);
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split('.') : [],
+  };
+}
+
+function compareIdentifiers(left, right) {
+  const leftNumeric = /^\d+$/.test(left);
+  const rightNumeric = /^\d+$/.test(right);
+
+  if (leftNumeric && rightNumeric) {
+    return Number(left) - Number(right);
+  }
+
+  if (leftNumeric) {
+    return -1;
+  }
+
+  if (rightNumeric) {
+    return 1;
+  }
+
+  if (left < right) {
+    return -1;
+  }
+
+  if (left > right) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function comparePrerelease(left, right) {
+  if (left.length === 0 && right.length === 0) {
+    return 0;
+  }
+
+  if (left.length === 0) {
+    return 1;
+  }
+
+  if (right.length === 0) {
+    return -1;
+  }
+
+  const len = Math.max(left.length, right.length);
+  for (let idx = 0; idx < len; idx += 1) {
+    const leftId = left[idx];
+    const rightId = right[idx];
+
+    if (leftId === undefined) {
+      return -1;
+    }
+
+    if (rightId === undefined) {
+      return 1;
+    }
+
+    const cmp = compareIdentifiers(leftId, rightId);
+    if (cmp !== 0) {
+      return cmp;
+    }
+  }
+
+  return 0;
+}
+
+function compareVersions(left, right) {
+  const leftParsed = parseSemver(left);
+  const rightParsed = parseSemver(right);
+
+  for (const key of ['major', 'minor', 'patch']) {
+    if (leftParsed[key] !== rightParsed[key]) {
+      return leftParsed[key] - rightParsed[key];
+    }
+  }
+
+  return comparePrerelease(leftParsed.prerelease, rightParsed.prerelease);
+}
+
+function commandOutput(command, args, options = {}) {
+  try {
+    return execFileSync(command, args, {
+      cwd: options.cwd || process.cwd(),
+      env: options.env || process.env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    if (options.allowFailure) {
+      return '';
+    }
+
+    const stderr = error.stderr ? String(error.stderr).trim() : '';
+    throw new Error(stderr || error.message);
+  }
+}
+
+function ghApi(path, allowFailure = false) {
+  const env = {
+    ...process.env,
+    GH_TOKEN: process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '',
+  };
+  const raw = commandOutput('gh', ['api', path], { env, allowFailure });
+  return raw ? JSON.parse(raw) : null;
+}
+
+function getHeadSha() {
+  return process.env.GITHUB_SHA || commandOutput('git', ['rev-parse', 'HEAD']);
+}
+
+function getLatestExistingRelease(repository) {
+  return ghApi(`repos/${repository}/releases/latest`, true);
+}
+
+function getReleaseByTag(repository, tagName) {
+  return ghApi(`repos/${repository}/releases/tags/${tagName}`, true);
+}
+
+function getTagCommitSha(tagName) {
+  return commandOutput('git', ['rev-list', '-n', '1', tagName], { allowFailure: true });
+}
+
+function buildReleasePlan({
+  releaseNeeded,
+  resolvedVersion,
+  reason,
+  headSha,
+  latestExistingRelease,
+  existingRelease,
+  tagCommitSha,
+}) {
+  if (!releaseNeeded) {
+    return {
+      release_needed: false,
+      resolved_version: '',
+      tag_name: '',
+      reason: reason || 'no_release',
+      release_status: 'release_skipped_no_release_needed',
+      tag_status: 'tag_not_applicable',
+      release_url: '',
+      tag_commit_sha: '',
+      latest_existing_release: latestExistingRelease || '',
+    };
+  }
+
+  const normalizedVersion = normalizeVersion(resolvedVersion);
+  const tagName = `v${normalizedVersion}`;
+  const latestExisting = latestExistingRelease || '';
+  const existingReleaseTag = existingRelease?.tag_name || '';
+  const existingReleaseUrl = existingRelease?.html_url || '';
+
+  if (existingReleaseTag || tagCommitSha) {
+    if (tagCommitSha && tagCommitSha === headSha) {
+      if (existingReleaseTag) {
+        return {
+          release_needed: true,
+          resolved_version: normalizedVersion,
+          tag_name: tagName,
+          reason: reason || 'release_already_exists_for_current_head',
+          release_status: 'release_already_exists_for_current_head',
+          tag_status: 'tag_exists_for_current_head',
+          release_url: existingReleaseUrl,
+          tag_commit_sha: tagCommitSha,
+          latest_existing_release: latestExisting,
+        };
+      }
+
+      return {
+        release_needed: true,
+        resolved_version: normalizedVersion,
+        tag_name: tagName,
+        reason: reason || 'tag_exists_for_current_head_release_missing',
+        release_status: 'release_pending_create',
+        tag_status: 'tag_exists_for_current_head',
+        release_url: '',
+        tag_commit_sha: tagCommitSha,
+        latest_existing_release: latestExisting,
+      };
+    }
+
+    throw new Error(
+      `Resolved version ${tagName} already exists on a different commit (${tagCommitSha || 'unknown'}), current HEAD is ${headSha}.`
+    );
+  }
+
+  if (latestExisting) {
+    const latestNormalized = normalizeVersion(latestExisting);
+    if (compareVersions(normalizedVersion, latestNormalized) <= 0) {
+      throw new Error(
+        `Resolved version ${tagName} is not newer than latest published release ${latestExisting}; failing closed.`
+      );
+    }
+  }
+
+  return {
+    release_needed: true,
+    resolved_version: normalizedVersion,
+    tag_name: tagName,
+    reason: reason || 'next_release_found',
+    release_status: 'release_pending_create',
+    tag_status: 'tag_missing',
+    release_url: '',
+    tag_commit_sha: '',
+    latest_existing_release: latestExisting,
+  };
+}
+
+async function resolveWithSemanticRelease() {
+  const semanticReleaseModule = require('semantic-release');
+  const semanticRelease = semanticReleaseModule.default || semanticReleaseModule;
+  const repositoryUrl = process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY
+    ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}.git`
+    : undefined;
+
+  const result = await semanticRelease(
+    {
+      branches: ['main'],
+      ci: false,
+      dryRun: true,
+      repositoryUrl,
+    },
+    {
+      cwd: process.cwd(),
+      env: process.env,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    }
+  );
+
+  if (!result || !result.nextRelease || !result.nextRelease.version) {
+    return {
+      releaseNeeded: false,
+      resolvedVersion: '',
+      reason: 'no_release',
+    };
+  }
+
+  return {
+    releaseNeeded: true,
+    resolvedVersion: normalizeVersion(result.nextRelease.version),
+    reason: 'next_release_found',
+  };
+}
+
+async function main() {
+  const manualInput = normalizeVersion(process.env.RELEASE_INPUT_VERSION || '');
+  const repository = process.env.GITHUB_REPOSITORY;
+
+  if (!repository) {
+    throw new Error('GITHUB_REPOSITORY is required.');
+  }
+
+  const headSha = getHeadSha();
+  const latestRelease = getLatestExistingRelease(repository);
+  const latestExistingRelease = latestRelease?.tag_name || '';
+
+  const resolution = manualInput
+    ? {
+        releaseNeeded: true,
+        resolvedVersion: manualInput,
+        reason: 'manual_input',
+      }
+    : await resolveWithSemanticRelease();
+
+  const tagName = resolution.releaseNeeded ? `v${resolution.resolvedVersion}` : '';
+  const existingRelease = tagName ? getReleaseByTag(repository, tagName) : null;
+  const tagCommitSha = tagName ? getTagCommitSha(tagName) : '';
+
+  const plan = buildReleasePlan({
+    releaseNeeded: resolution.releaseNeeded,
+    resolvedVersion: resolution.resolvedVersion,
+    reason: resolution.reason,
+    headSha,
+    latestExistingRelease,
+    existingRelease,
+    tagCommitSha,
+  });
+
+  process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`resolve-next-release: ${error.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  buildReleasePlan,
+  compareVersions,
+  normalizeVersion,
+};

--- a/scripts/release/resolve-next-release.cjs
+++ b/scripts/release/resolve-next-release.cjs
@@ -141,7 +141,8 @@ function ghApi(path, allow404 = false) {
     if (allow404 && /404|Not Found/i.test(stderr)) {
       return null;
     }
-    throw new Error(`GitHub API request failed for ${path}: ${stderr || error.message}`);
+    const safeStderr = (stderr || '').slice(0, 200).replace(/gh[pos]_[A-Za-z0-9_]+/g, '<redacted>');
+    throw new Error(`GitHub API request failed for ${path}: ${safeStderr || error.message}`);
   }
 }
 

--- a/scripts/release/resolve-next-release.cjs
+++ b/scripts/release/resolve-next-release.cjs
@@ -141,8 +141,7 @@ function ghApi(path, allow404 = false) {
     if (allow404 && /404|Not Found/i.test(stderr)) {
       return null;
     }
-    const safeStderr = (stderr || '').slice(0, 200).replace(/gh[pos]_[A-Za-z0-9_]+/g, '<redacted>');
-    throw new Error(`GitHub API request failed for ${path}: ${safeStderr || error.message}`);
+    throw new Error(`GitHub API request failed for ${path}`);
   }
 }
 

--- a/scripts/release/resolve-next-release.cjs
+++ b/scripts/release/resolve-next-release.cjs
@@ -249,7 +249,7 @@ async function resolveWithSemanticRelease() {
     {
       cwd: process.cwd(),
       env: process.env,
-      stdout: process.stdout,
+      stdout: process.stderr,
       stderr: process.stderr,
     }
   );

--- a/scripts/release/resolve-next-release.cjs
+++ b/scripts/release/resolve-next-release.cjs
@@ -122,13 +122,27 @@ function commandOutput(command, args, options = {}) {
   }
 }
 
-function ghApi(path, allowFailure = false) {
+function ghApi(path, allow404 = false) {
   const env = {
     ...process.env,
     GH_TOKEN: process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '',
   };
-  const raw = commandOutput('gh', ['api', path], { env, allowFailure });
-  return raw ? JSON.parse(raw) : null;
+
+  try {
+    const raw = execFileSync('gh', ['api', path], {
+      cwd: process.cwd(),
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    return raw ? JSON.parse(raw) : null;
+  } catch (error) {
+    const stderr = error.stderr ? String(error.stderr).trim() : '';
+    if (allow404 && /404|Not Found/i.test(stderr)) {
+      return null;
+    }
+    throw new Error(`GitHub API request failed for ${path}: ${stderr || error.message}`);
+  }
 }
 
 function getHeadSha() {


### PR DESCRIPTION
## Summary
- replace semantic-release stdout parsing with a structured release resolver helper
- fail closed when a resolved version points to an older or mismatched existing tag/release
- add a smoke test for release-resolution edge cases

## Why
Post-merge validation after #338 showed Automated Release selecting stale version `v24.2.9` and reporting a green idempotent no-op. This PR makes release resolution deterministic and blocks stale reuse.

## Validation
- `actionlint .github/workflows/automated-release.yml`
- `node scripts/release/resolve-next-release-smoke-test.cjs`
- manual helper sanity for valid future version and stale existing version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automated release tagging/release creation logic to use a new deterministic planner and to error on version/tag mismatches, which can block or alter release runs if edge cases are missed. Limited to CI/release automation but affects production release cadence.
> 
> **Overview**
> **Automated Release now uses a structured “release plan”** instead of parsing `semantic-release` stdout, via a new `scripts/release/resolve-next-release.cjs` helper that resolves the next version (or manual input) and inspects existing tags/releases.
> 
> The workflow becomes *more idempotent and safer*: it fetches tags, exposes new job outputs (`release_needed`, `tag_status`, `release_url`, etc.), only creates tags when missing, skips release creation on same-HEAD reruns, and **fails closed** if the resolved version is not newer than the latest published release or if the tag/release points at a different commit.
> 
> Adds a lightweight Node smoke test (`resolve-next-release-smoke-test.cjs`) covering key planner edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4cb00e12eaeaf11107165a36b2fb8284eeb7dc7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->