### PR TITLE
feat(pr-assistant): add current-head receipt verifier

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1817,10 +1817,6 @@ jobs:
               blocked_missing_authority) REVIEW_VERDICT="blocked_missing_authority" ;;
             esac
           fi
-          if [ "$DOCUMENTATION_OBLIGATION_STATE" = "unknown" ] && [ "$REVIEW_VERDICT" = "approved_for_closeout" ]; then
-            REVIEW_VERDICT="blocked_missing_authority"
-          fi
-
           FOLLOW_UP_ID="pr-${PR_NUM}-review-${GITHUB_RUN_ID}"
           CLOSEOUT_MODE="human_merge_only"
           REVIEW_RECEIPT_SCHEMA_VERSION="1"

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1823,9 +1823,15 @@ jobs:
 
           FOLLOW_UP_ID="pr-${PR_NUM}-review-${GITHUB_RUN_ID}"
           CLOSEOUT_MODE="human_merge_only"
+          REVIEW_RECEIPT_SCHEMA_VERSION="1"
+          REVIEW_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           PR_CHECK_SURFACE_STATE="$(tr -d '\r\n' < pr_check_surface_state.txt 2>/dev/null || true)"
           if [ -z "${PR_CHECK_SURFACE_STATE:-}" ]; then
             PR_CHECK_SURFACE_STATE="missing"
+          fi
+          REVIEW_STATUS="success"
+          if [ "$REVIEW_VERDICT" != "approved_for_closeout" ]; then
+            REVIEW_STATUS="blocked"
           fi
           
           echo "Building PR comment..."
@@ -1835,12 +1841,48 @@ jobs:
               echo "## 🤖 Merglbot PR Assistant v3.5.4"
               echo ""
               echo "❌ Review generation failed. Please check workflow logs."
+              echo ""
+              echo "### Merglbot Review Receipt"
+              echo ""
+              echo "| Field | Value |"
+              echo "|-------|-------|"
+              printf '%s\n' "| schema_version | \`$REVIEW_RECEIPT_SCHEMA_VERSION\` |"
+              printf '%s\n' "| head_sha | \`${PR_HEAD_SHA}\` |"
+              printf '%s\n' "| run_url | $REVIEW_RUN_URL |"
+              printf '%s\n' "| verdict | \`review_generation_failed\` |"
+              printf '%s\n' "| status | \`failed\` |"
+              printf '%s\n' "| diff_scope | \`$DIFF_SCOPE\` |"
+              printf '%s\n' "| pr_check_surface | \`$PR_CHECK_SURFACE_STATE\` |"
+              echo ""
+              echo "<!-- MERGLBOT_PR_ASSISTANT_V3 -->"
+              echo "<!-- MERGLBOT_REVIEW_RECEIPT_SCHEMA_VERSION: $REVIEW_RECEIPT_SCHEMA_VERSION -->"
+              echo "<!-- MERGLBOT_REVIEW_HEAD_SHA: $PR_HEAD_SHA -->"
+              echo "<!-- MERGLBOT_REVIEW_VERDICT: review_generation_failed -->"
+              echo "<!-- MERGLBOT_REVIEW_STATUS: failed -->"
+              echo "<!-- MERGLBOT_PR_CHECK_SURFACE: $PR_CHECK_SURFACE_STATE -->"
+              echo "<!-- MERGLBOT_RUN_ID: ${{ github.run_id }} -->"
+              echo "<!-- MERGLBOT_RUN_URL: $REVIEW_RUN_URL -->"
+              echo "<!-- MERGLBOT_DIFF_SCOPE: $DIFF_SCOPE -->"
             } > comment.md
           else
             {
               echo "## 🤖 Merglbot PR Assistant v3.5.4"
               echo ""
               cat final_review.txt
+              echo ""
+              echo "---"
+              echo ""
+              echo "### Merglbot Review Receipt"
+              echo ""
+              echo "| Field | Value |"
+              echo "|-------|-------|"
+              printf '%s\n' "| schema_version | \`$REVIEW_RECEIPT_SCHEMA_VERSION\` |"
+              printf '%s\n' "| head_sha | \`${PR_HEAD_SHA}\` |"
+              printf '%s\n' "| run_url | $REVIEW_RUN_URL |"
+              printf '%s\n' "| verdict | \`$REVIEW_VERDICT\` |"
+              printf '%s\n' "| status | \`$REVIEW_STATUS\` |"
+              printf '%s\n' "| diff_scope | \`$DIFF_SCOPE\` |"
+              printf '%s\n' "| pr_check_surface | \`$PR_CHECK_SURFACE_STATE\` |"
               echo ""
               echo "---"
               echo ""
@@ -1903,10 +1945,12 @@ jobs:
               echo "</details>"
               echo ""
               echo "<!-- MERGLBOT_PR_ASSISTANT_V3 -->"
+              echo "<!-- MERGLBOT_REVIEW_RECEIPT_SCHEMA_VERSION: $REVIEW_RECEIPT_SCHEMA_VERSION -->"
               echo "<!-- MERGLBOT_REVIEW_BOUNDARY: review_only -->"
               echo "<!-- MERGLBOT_FOLLOW_UP_ID: $FOLLOW_UP_ID -->"
               echo "<!-- MERGLBOT_REVIEW_HEAD_SHA: $PR_HEAD_SHA -->"
               echo "<!-- MERGLBOT_REVIEW_VERDICT: $REVIEW_VERDICT -->"
+              echo "<!-- MERGLBOT_REVIEW_STATUS: $REVIEW_STATUS -->"
               echo "<!-- MERGLBOT_DOCUMENTATION_OBLIGATION_STATE: $DOCUMENTATION_OBLIGATION_STATE -->"
               echo "<!-- MERGLBOT_DOCS_FOLLOW_UP_HINT: $DOCS_FOLLOW_UP_HINT -->"
               echo "<!-- MERGLBOT_SUGGESTED_DOCS_TARGETS: $SUGGESTED_DOCS_TARGETS_JSON -->"
@@ -1919,6 +1963,7 @@ jobs:
               echo "<!-- MERGLBOT_DIFF_SCOPE: $DIFF_SCOPE -->"
               echo "<!-- MERGLBOT_DIFF_RANGE: $DIFF_RANGE -->"
               echo "<!-- MERGLBOT_RUN_ID: ${{ github.run_id }} -->"
+              echo "<!-- MERGLBOT_RUN_URL: $REVIEW_RUN_URL -->"
               echo ""
               echo "---"
               echo ""
@@ -2168,6 +2213,14 @@ jobs:
           SYNTHESIS_USAGE_JSON="${SYNTHESIS_USAGE_JSON:-{}}"
 
           PR_AUTHOR="$(sed -n '1p' pr_author.txt 2>/dev/null || echo '')"
+          PR_HEAD_SHA="$(sed -n '1p' pr_head_sha.txt 2>/dev/null || echo '')"
+          DIFF_SCOPE="$(sed -n '1p' pr_diff_scope.txt 2>/dev/null || echo 'full')"
+          PR_CHECK_SURFACE_STATE="$(tr -d '\r\n' < pr_check_surface_state.txt 2>/dev/null || true)"
+          if [ -z "${PR_CHECK_SURFACE_STATE:-}" ]; then
+            PR_CHECK_SURFACE_STATE="missing"
+          fi
+          REVIEW_RECEIPT_SCHEMA_VERSION="1"
+          REVIEW_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
 
           ANTHROPIC_USAGE_JSON_SAFE="$(normalize_usage_json "$ANTHROPIC_USAGE_JSON")"
           OPENAI_USAGE_JSON_SAFE="$(normalize_usage_json "$OPENAI_USAGE_JSON")"
@@ -2201,6 +2254,11 @@ jobs:
             --arg bugbot_sources "$BUGBOT_SOURCES" \
             --arg status "${JOB_STATUS:-unknown}" \
             --arg review_status "$REVIEW_STATUS" \
+            --arg receipt_schema_version "$REVIEW_RECEIPT_SCHEMA_VERSION" \
+            --arg head_sha "$PR_HEAD_SHA" \
+            --arg run_url "$REVIEW_RUN_URL" \
+            --arg diff_scope "$DIFF_SCOPE" \
+            --arg pr_check_surface "$PR_CHECK_SURFACE_STATE" \
             --argjson anthropic_usage "$ANTHROPIC_USAGE_JSON_SAFE" \
             --argjson openai_usage "$OPENAI_USAGE_JSON_SAFE" \
             --argjson synthesis_usage "$SYNTHESIS_USAGE_JSON_SAFE" \
@@ -2246,6 +2304,16 @@ jobs:
                   low: ($low_count | toint)
                 },
                 verdict: $verdict,
+                review_receipt: {
+                  schema_version: $receipt_schema_version,
+                  head_sha: $head_sha,
+                  run_id: $run_id,
+                  run_url: $run_url,
+                  verdict: $verdict,
+                  status: $review_status,
+                  diff_scope: $diff_scope,
+                  pr_check_surface: $pr_check_surface
+                },
                 bugbot: {
                   source_count: ($bugbot_count | toint),
                   sources: $bugbot_sources

--- a/docs/claude-pr-assistant.md
+++ b/docs/claude-pr-assistant.md
@@ -24,6 +24,21 @@ The review comment now also carries advisory docs metadata:
 
 These fields are soft review metadata only. They do not add a required check, they do not create a merge blocker, and `documentation_obligation_state` remains non-authoritative review output rather than docs-classifier truth.
 
+The review comment must also carry a visible **Merglbot Review Receipt** and
+matching hidden markers so autonomous closeout can prove current-head review
+truth. Required markers are:
+
+- `MERGLBOT_REVIEW_RECEIPT_SCHEMA_VERSION`
+- `MERGLBOT_REVIEW_HEAD_SHA`
+- `MERGLBOT_REVIEW_VERDICT`
+- `MERGLBOT_REVIEW_STATUS`
+- `MERGLBOT_PR_CHECK_SURFACE`
+- `MERGLBOT_RUN_ID`
+- `MERGLBOT_RUN_URL`
+
+Use `scripts/pr-assistant/verify-review-receipt.py --repo <owner/repo> --pr
+<number>` to emit the JSON verifier contract for closeout lanes.
+
 For lighter review: `@merglbot review --light`
 
 ---

--- a/docs/claude-pr-assistant.md
+++ b/docs/claude-pr-assistant.md
@@ -37,7 +37,12 @@ truth. Required markers are:
 - `MERGLBOT_RUN_URL`
 
 Use `scripts/pr-assistant/verify-review-receipt.py --repo <owner/repo> --pr
-<number>` to emit the JSON verifier contract for closeout lanes.
+<number>` to emit the JSON verifier contract for closeout lanes. The verifier
+also checks that `MERGLBOT_RUN_ID` belongs to the PR Assistant workflow path and
+validates `MERGLBOT_RUN_URL` against the PR URL host, so the contract works on
+GitHub Enterprise hosts without hard-coding `github.com`. `ok=true` is reserved
+for current-head `status=success` with `verdict=approved_for_closeout`; blocked
+or failed receipts remain parseable evidence but are not merge approval.
 
 For lighter review: `@merglbot review --light`
 

--- a/scripts/pr-assistant/deploy-v3.sh
+++ b/scripts/pr-assistant/deploy-v3.sh
@@ -63,6 +63,7 @@ else
 fi
 SOURCE_WORKFLOW="${WORKSPACE_ROOT}/merglbot-core/github/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml"
 SOURCE_STEP1="${WORKSPACE_ROOT}/merglbot-core/github/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh"
+SOURCE_VERIFIER="${WORKSPACE_ROOT}/merglbot-core/github/scripts/pr-assistant/verify-review-receipt.py"
 MANIFEST_TOOL="${WORKSPACE_ROOT}/merglbot-core/github/scripts/pr-assistant/repo-policy-manifest.py"
 MANIFEST_FILE="${WORKSPACE_ROOT}/merglbot-core/github/scripts/pr-assistant/repo-policy-manifest.json"
 TARGET_REPOS_FILE="${WORKSPACE_ROOT}/merglbot-core/github/scripts/pr-assistant/target-repos.txt"
@@ -74,6 +75,11 @@ fi
 
 if [ ! -f "$SOURCE_STEP1" ]; then
   echo "ERROR: Source Step1 script not found: $SOURCE_STEP1" >&2
+  exit 1
+fi
+
+if [ ! -f "$SOURCE_VERIFIER" ]; then
+  echo "ERROR: Source review receipt verifier not found: $SOURCE_VERIFIER" >&2
   exit 1
 fi
 
@@ -142,6 +148,7 @@ is_git_clean() {
 echo "Workspace: $WORKSPACE_ROOT"
 echo "Source:    $SOURCE_WORKFLOW"
 echo "Step1:     $SOURCE_STEP1"
+echo "Verifier:  $SOURCE_VERIFIER"
 echo "Mode:      $([ "$DRY_RUN" == "true" ] && echo "DRY RUN" || echo "APPLY")"
 echo "Force:     $FORCE"
 if [ -n "$ONLY_REPOS_RAW" ]; then
@@ -153,6 +160,7 @@ for repo in "${TARGET_REPOS[@]}"; do
   repo_dir="${WORKSPACE_ROOT}/${repo}"
   dest_workflow="${repo_dir}/.github/workflows/merglbot-pr-v3-on-demand.yml"
   dest_step1="${repo_dir}/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh"
+  dest_verifier="${repo_dir}/scripts/pr-assistant/verify-review-receipt.py"
 
   if [ ! -d "$repo_dir" ]; then
     echo "⏭️  SKIP (missing dir): $repo"
@@ -173,15 +181,22 @@ for repo in "${TARGET_REPOS[@]}"; do
   if [ "$DRY_RUN" == "true" ]; then
     echo "DRY:  $repo -> $dest_workflow"
     echo "DRY:  $repo -> $dest_step1"
+    echo "DRY:  $repo -> $dest_verifier"
     continue
   fi
 
   mkdir -p "$(dirname "$dest_workflow")"
   mkdir -p "$(dirname "$dest_step1")"
+  mkdir -p "$(dirname "$dest_verifier")"
   cp "$SOURCE_WORKFLOW" "$dest_workflow"
   cp "$SOURCE_STEP1" "$dest_step1"
+  cp "$SOURCE_VERIFIER" "$dest_verifier"
   if ! chmod +x "$dest_step1"; then
     echo "ERROR: Failed to chmod +x: $dest_step1" >&2
+    exit 1
+  fi
+  if ! chmod +x "$dest_verifier"; then
+    echo "ERROR: Failed to chmod +x: $dest_verifier" >&2
     exit 1
   fi
   echo "✅    $repo"

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -16,6 +16,7 @@ from typing import Any
 
 
 MARKER_RE = re.compile(r"<!--\s*(MERGLBOT_[A-Z0-9_]+)\s*:\s*([\s\S]*?)\s*-->")
+PR_ASSISTANT_WORKFLOW_PATH = ".github/workflows/merglbot-pr-assistant-v3-on-demand.yml"
 
 
 def gh_json(args: list[str]) -> Any:
@@ -40,6 +41,12 @@ def latest_receipt(comments: list[dict[str, Any]]) -> tuple[dict[str, str] | Non
         markers = parse_markers(body)
         return markers, str(comment.get("html_url") or comment.get("url") or "")
     return None, None
+
+
+def expected_run_url(pr_url: str, run_id: str) -> str:
+    if "/pull/" not in pr_url:
+        return ""
+    return f"{pr_url.split('/pull/', 1)[0]}/actions/runs/{run_id}"
 
 
 def verify(repo: str, pr_number: int) -> dict[str, Any]:
@@ -75,6 +82,8 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
         blockers.append("missing_or_invalid_review_status")
     if verdict not in {"approved_for_closeout", "changes_required", "blocked_missing_authority", "review_generation_failed"}:
         blockers.append("missing_or_invalid_review_verdict")
+    if status != "success" or verdict != "approved_for_closeout":
+        blockers.append("review_not_approved_for_closeout")
     if status == "success" and verdict != "approved_for_closeout":
         blockers.append("review_status_verdict_mismatch")
     if status == "failed" and verdict != "review_generation_failed":
@@ -85,8 +94,17 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
         blockers.append("missing_review_run_id")
     if not run_url:
         blockers.append("missing_review_run_url")
-    elif run_id and run_url != f"https://github.com/{repo}/actions/runs/{run_id}":
+    elif run_id and run_url != expected_run_url(str(pr.get("url") or ""), run_id):
         blockers.append("review_run_url_mismatch")
+    run_path = ""
+    if run_id:
+        try:
+            run = gh_json(["api", f"repos/{repo}/actions/runs/{run_id}"])
+            run_path = str(run.get("path") or "")
+        except Exception as exc:  # pragma: no cover - exercised through live CLI usage.
+            blockers.append(f"review_run_lookup_failed:{exc}")
+        if run_path and run_path != PR_ASSISTANT_WORKFLOW_PATH:
+            blockers.append("review_run_not_from_pr_assistant_workflow")
 
     return {
         "ok": len(blockers) == 0,
@@ -103,6 +121,7 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
         "comment_url": comment_url,
         "run_id": run_id or None,
         "run_url": run_url or None,
+        "run_path": run_path or None,
         "blockers": blockers,
     }
 
@@ -138,6 +157,13 @@ def self_test() -> int:
     )
     assert failed["MERGLBOT_REVIEW_VERDICT"] == "review_generation_failed"
     assert failed["MERGLBOT_REVIEW_STATUS"] == "failed"
+    blockers: list[str] = []
+    status = "blocked"
+    verdict = "changes_required"
+    if status != "success" or verdict != "approved_for_closeout":
+        blockers.append("review_not_approved_for_closeout")
+    assert blockers == ["review_not_approved_for_closeout"]
+    assert expected_run_url("https://github.enterprise.example/o/r/pull/42", "123") == "https://github.enterprise.example/o/r/actions/runs/123"
     print(json.dumps({"ok": True, "self_test": "passed"}))
     return 0
 

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Verify the latest Merglbot PR Assistant current-head review receipt.
+
+The script intentionally reads public GitHub PR/comment truth through `gh` and
+prints one JSON object. It does not mutate GitHub state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+MARKER_RE = re.compile(r"<!--\s*(MERGLBOT_[A-Z0-9_]+)\s*:\s*([\s\S]*?)\s*-->")
+
+
+def gh_json(args: list[str]) -> Any:
+    proc = subprocess.run(["gh", *args], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"gh {' '.join(args)} failed")
+    return json.loads(proc.stdout)
+
+
+def parse_markers(body: str) -> dict[str, str]:
+    return {key.strip(): value.strip() for key, value in MARKER_RE.findall(body or "")}
+
+
+def latest_receipt(comments: list[dict[str, Any]]) -> tuple[dict[str, str] | None, str | None]:
+    for comment in reversed(comments):
+        user = comment.get("user") if isinstance(comment.get("user"), dict) else {}
+        if user.get("login") != "github-actions[bot]" or user.get("type") != "Bot":
+            continue
+        body = str(comment.get("body") or "")
+        if "<!-- MERGLBOT_PR_ASSISTANT_V3 -->" not in body:
+            continue
+        markers = parse_markers(body)
+        return markers, str(comment.get("html_url") or comment.get("url") or "")
+    return None, None
+
+
+def verify(repo: str, pr_number: int) -> dict[str, Any]:
+    pr = gh_json(["pr", "view", str(pr_number), "--repo", repo, "--json", "headRefOid,url,state"])
+    head_sha = str(pr.get("headRefOid") or "")
+    comments_pages = gh_json(["api", "--paginate", "--slurp", f"repos/{repo}/issues/{pr_number}/comments?per_page=100"])
+    comments = [
+        item
+        for page in (comments_pages if isinstance(comments_pages, list) else [])
+        for item in (page if isinstance(page, list) else [page])
+    ]
+    markers, comment_url = latest_receipt(comments)
+
+    blockers: list[str] = []
+    if not markers:
+        blockers.append("missing_merglbot_review_receipt")
+        markers = {}
+
+    review_head_sha = markers.get("MERGLBOT_REVIEW_HEAD_SHA", "")
+    verdict = markers.get("MERGLBOT_REVIEW_VERDICT", "")
+    status = markers.get("MERGLBOT_REVIEW_STATUS", "")
+    schema_version = markers.get("MERGLBOT_REVIEW_RECEIPT_SCHEMA_VERSION", "")
+    pr_check_surface = markers.get("MERGLBOT_PR_CHECK_SURFACE", "")
+    run_id = markers.get("MERGLBOT_RUN_ID", "")
+    run_url = markers.get("MERGLBOT_RUN_URL", "")
+
+    current_head_match = bool(head_sha and review_head_sha and head_sha == review_head_sha)
+    if not current_head_match:
+        blockers.append("merglbot_review_head_sha_mismatch")
+    if schema_version != "1":
+        blockers.append("unsupported_or_missing_receipt_schema")
+    if status not in {"success", "blocked", "failed"}:
+        blockers.append("missing_or_invalid_review_status")
+    if verdict not in {"approved_for_closeout", "changes_required", "blocked_missing_authority", "review_generation_failed"}:
+        blockers.append("missing_or_invalid_review_verdict")
+    if status == "success" and verdict != "approved_for_closeout":
+        blockers.append("review_status_verdict_mismatch")
+    if status == "failed" and verdict != "review_generation_failed":
+        blockers.append("review_status_verdict_mismatch")
+    if pr_check_surface != "verified":
+        blockers.append("pr_check_surface_not_verified")
+    if not run_id:
+        blockers.append("missing_review_run_id")
+    if not run_url:
+        blockers.append("missing_review_run_url")
+    elif run_id and run_url != f"https://github.com/{repo}/actions/runs/{run_id}":
+        blockers.append("review_run_url_mismatch")
+
+    return {
+        "ok": len(blockers) == 0,
+        "repo": repo,
+        "pr_number": pr_number,
+        "pr_url": pr.get("url"),
+        "head_sha": head_sha or None,
+        "review_head_sha": review_head_sha or None,
+        "current_head_match": current_head_match,
+        "schema_version": schema_version or None,
+        "verdict": verdict or None,
+        "status": status or None,
+        "pr_check_surface": pr_check_surface or None,
+        "comment_url": comment_url,
+        "run_id": run_id or None,
+        "run_url": run_url or None,
+        "blockers": blockers,
+    }
+
+
+def self_test() -> int:
+    body = "\n".join(
+        [
+            "<!-- MERGLBOT_PR_ASSISTANT_V3 -->",
+            "<!-- MERGLBOT_REVIEW_RECEIPT_SCHEMA_VERSION: 1 -->",
+            "<!-- MERGLBOT_REVIEW_HEAD_SHA: abc123 -->",
+            "<!-- MERGLBOT_REVIEW_VERDICT: approved_for_closeout -->",
+            "<!-- MERGLBOT_REVIEW_STATUS: success -->",
+            "<!-- MERGLBOT_PR_CHECK_SURFACE: verified -->",
+            "<!-- MERGLBOT_RUN_ID: 42 -->",
+            "<!-- MERGLBOT_RUN_URL: https://github.com/o/r/actions/runs/42 -->",
+        ]
+    )
+    markers = parse_markers(body)
+    assert markers["MERGLBOT_REVIEW_HEAD_SHA"] == "abc123"
+    assert markers["MERGLBOT_REVIEW_STATUS"] == "success"
+    assert markers["MERGLBOT_RUN_ID"] == "42"
+    trusted_markers, _ = latest_receipt([{"body": body, "user": {"login": "github-actions[bot]", "type": "Bot"}}])
+    assert trusted_markers and trusted_markers["MERGLBOT_REVIEW_HEAD_SHA"] == "abc123"
+    spoofed_markers, _ = latest_receipt([{"body": body, "user": {"login": "octocat", "type": "User"}}])
+    assert spoofed_markers is None
+    failed = parse_markers(
+        "\n".join(
+            [
+                "<!-- MERGLBOT_REVIEW_VERDICT: review_generation_failed -->",
+                "<!-- MERGLBOT_REVIEW_STATUS: failed -->",
+            ]
+        )
+    )
+    assert failed["MERGLBOT_REVIEW_VERDICT"] == "review_generation_failed"
+    assert failed["MERGLBOT_REVIEW_STATUS"] == "failed"
+    print(json.dumps({"ok": True, "self_test": "passed"}))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", help="Repository in owner/name form")
+    parser.add_argument("--pr", type=int, help="Pull request number")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.repo or not args.pr:
+        parser.error("--repo and --pr are required unless --self-test is used")
+
+    result = verify(args.repo, args.pr)
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the WSA docs#620 PR Assistant current-head evidence contract in the canonical GitHub control-plane repo.

- Adds a visible `Merglbot Review Receipt` section to PR Assistant comments.
- Adds hidden machine-readable receipt markers for schema version, current head, verdict, status, check surface, run id, and run URL.
- Adds `scripts/pr-assistant/verify-review-receipt.py` to return audit JSON for current-head review evidence.
- Extends `deploy-v3.sh` so rollout copies the verifier alongside the workflow and Step1 helper.

## Validation

- `bash -n scripts/pr-assistant/deploy-v3.sh`
- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`
- `git diff --check`
- `deploy-v3.sh --dry-run` source validation with clean temporary workspace layout

Refs merglbot-public/docs#620.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the PR Assistant workflow’s published comment/metrics contract, which downstream closeout automation may depend on; failures could block or mis-classify reviews but no sensitive auth/data paths are modified.
> 
> **Overview**
> Adds a **current-head “Merglbot Review Receipt” contract** to PR Assistant v3 comments, including a visible table plus hidden `MERGLBOT_*` markers (schema version, head SHA, verdict/status, PR check surface, run id/url) to make review evidence machine-verifiable.
> 
> Introduces `scripts/pr-assistant/verify-review-receipt.py`, a `gh`-backed verifier that locates the latest PR Assistant comment, validates required receipt fields against the live PR head, and emits an audit JSON (non-mutating).
> 
> Extends rollout tooling (`deploy-v3.sh`) to copy the verifier into target repos, and updates docs to describe the receipt markers and verification command; metrics output now also includes a `review_receipt` object with the same fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff77e03c7dede89d7cbc9d4500e2ffe703975f9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->