### PR TITLE
fix(pr-assistant): accept deployed review workflow path

### DIFF
--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -16,7 +16,10 @@ from typing import Any
 
 
 MARKER_RE = re.compile(r"<!--\s*(MERGLBOT_[A-Z0-9_]+)\s*:\s*([\s\S]*?)\s*-->")
-PR_ASSISTANT_WORKFLOW_PATH = ".github/workflows/merglbot-pr-assistant-v3-on-demand.yml"
+PR_ASSISTANT_WORKFLOW_PATHS = {
+    ".github/workflows/merglbot-pr-assistant-v3-on-demand.yml",
+    ".github/workflows/merglbot-pr-v3-on-demand.yml",
+}
 
 
 def gh_json(args: list[str]) -> Any:
@@ -103,7 +106,7 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
             run_path = str(run.get("path") or "")
         except Exception as exc:  # pragma: no cover - exercised through live CLI usage.
             blockers.append(f"review_run_lookup_failed:{exc}")
-        if run_path and run_path != PR_ASSISTANT_WORKFLOW_PATH:
+        if run_path and run_path not in PR_ASSISTANT_WORKFLOW_PATHS:
             blockers.append("review_run_not_from_pr_assistant_workflow")
 
     return {
@@ -164,6 +167,8 @@ def self_test() -> int:
         blockers.append("review_not_approved_for_closeout")
     assert blockers == ["review_not_approved_for_closeout"]
     assert expected_run_url("https://github.enterprise.example/o/r/pull/42", "123") == "https://github.enterprise.example/o/r/actions/runs/123"
+    assert ".github/workflows/merglbot-pr-assistant-v3-on-demand.yml" in PR_ASSISTANT_WORKFLOW_PATHS
+    assert ".github/workflows/merglbot-pr-v3-on-demand.yml" in PR_ASSISTANT_WORKFLOW_PATHS
     print(json.dumps({"ok": True, "self_test": "passed"}))
     return 0
 


### PR DESCRIPTION
## Summary

Fixes the WSA steady-state rollout verifier so it accepts both the canonical source workflow path and the deployed PR Assistant workflow path.

## Root Cause

The rollout copies the PR Assistant workflow to `.github/workflows/merglbot-pr-v3-on-demand.yml`, but the verifier only accepted `.github/workflows/merglbot-pr-assistant-v3-on-demand.yml`. Current rollout PRs therefore generated valid receipts that the verifier could classify as non-PR-Assistant-originated.

## Validation

- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`
- `bash -n scripts/pr-assistant/deploy-v3.sh`
- `git diff --check`

## Scope

- Verifier-only hotfix.
- No workflow logic, token, deploy, or runtime behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk verifier-only change that broadens an allowlist for acceptable GitHub Actions workflow paths and updates the self-test accordingly; no runtime workflow logic or permissions are modified.
> 
> **Overview**
> The PR assistant receipt verifier now accepts reviews coming from either the canonical workflow file or the deployed/copied workflow path by replacing a single expected path check with a small allowlist (`PR_ASSISTANT_WORKFLOW_PATHS`).
> 
> The script’s `--self-test` is updated to assert both workflow paths are recognized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99efd20626fec98068d5d5719c77e4a572d47970. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->