### PR TITLE
style(pr-assistant): match target repo formatter

### DIFF
--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -13,7 +13,6 @@ import re
 import subprocess
 from typing import Any
 
-
 MARKER_RE = re.compile(r"<!--\s*(MERGLBOT_[A-Z0-9_]+)\s*:\s*([\s\S]*?)\s*-->")
 PR_ASSISTANT_WORKFLOW_PATHS = {
     ".github/workflows/merglbot-pr-assistant-v3-on-demand.yml",
@@ -58,9 +57,7 @@ def expected_run_url(pr_url: str, run_id: str) -> str:
 
 
 def verify(repo: str, pr_number: int) -> dict[str, Any]:
-    pr = gh_json(
-        ["pr", "view", str(pr_number), "--repo", repo, "--json", "headRefOid,url,state"]
-    )
+    pr = gh_json(["pr", "view", str(pr_number), "--repo", repo, "--json", "headRefOid,url,state"])
     head_sha = str(pr.get("headRefOid") or "")
     comments_pages = gh_json(
         [


### PR DESCRIPTION
## Summary

Aligns the PR Assistant verifier formatting with stricter target-repo formatter settings observed during rollout.

## Root Cause

Some rollout repositories run Ruff import sorting and Black with line length 100. The source repo accepted the verifier formatting, but target CI still flagged one import-spacing issue and Black reformatting.

## Validation

- `black --line-length 100 scripts/pr-assistant/verify-review-receipt.py`
- `ruff check --select E,F,I --line-length 100 --fix scripts/pr-assistant/verify-review-receipt.py`
- `ruff check --select E,F,I --line-length 100 scripts/pr-assistant/verify-review-receipt.py`
- `black --line-length 100 --check scripts/pr-assistant/verify-review-receipt.py`
- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`

## Scope

- Formatter-only compatibility patch.
- No verifier semantic changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: formatting-only changes (line wrapping/whitespace) in `verify-review-receipt.py` with no behavioral impact.
> 
> **Overview**
> Aligns `scripts/pr-assistant/verify-review-receipt.py` formatting with stricter Black/Ruff settings (e.g., line-length wrapping and whitespace cleanup) to avoid CI failures in rollout repos. No functional or logic changes are introduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ed9108654f7f9f7f4f07fa41cf5b0afe3917ada. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->