### PR TITLE
chore(pr-assistant): freeze verifier formatter for rollout

### DIFF
--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -5,6 +5,9 @@ The script intentionally reads public GitHub PR/comment truth through `gh` and
 prints one JSON object. It does not mutate GitHub state.
 """
 
+# Managed rollout artifact copied into repositories with different Black configs.
+# fmt: off
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary

Freezes Black formatting for the managed PR Assistant verifier artifact before rollout into heterogeneous target repositories.

## Root Cause

Rollout target repositories use conflicting Black versions/configuration. The verifier is a managed copied artifact, so target-local Black should not rewrite it differently per repository.

## Validation

- `black==25.12.0 --check scripts/pr-assistant/verify-review-receipt.py`
- `black==26.3.1 --check scripts/pr-assistant/verify-review-receipt.py`
- `ruff==0.15.10 check --select E,F,I scripts/pr-assistant/verify-review-receipt.py`
- `mypy==1.20.0 scripts/pr-assistant/verify-review-receipt.py`
- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`

## Scope

- Adds formatter guard comments only.
- No semantic verifier change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds `# fmt: off` and a brief comment to prevent target-repo Black reformatting; no runtime or logic changes.
> 
> **Overview**
> Freezes formatting for the managed PR Assistant verifier artifact by adding a `# fmt: off` guard (with an explanatory comment) at the top of `scripts/pr-assistant/verify-review-receipt.py` to avoid Black reformatting differences across rollout target repositories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12eb4e2fe28f846d84d3481f903c4201b034e820. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->