### PR TITLE
fix(pr-assistant): align review receipt hard gates

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1752,16 +1752,23 @@ jobs:
           }
 
           DOCUMENTATION_OBLIGATION_STATE="unknown"
+          SSOT_SYNC_DOCS_NONE="false"
+          if awk 'BEGIN{IGNORECASE=1; in_section=0} /^##[[:space:]]+SSOT Sync \(Docs\)/{in_section=1; next} /^##[[:space:]]/{in_section=0} in_section && $0 ~ /^[[:space:]]*None[[:space:]]*$/ {found=1} END{exit(found?0:1)}' final_review.txt 2>/dev/null; then
+            SSOT_SYNC_DOCS_NONE="true"
+          fi
           DOC_STATE_LINE="$(extract_zaver_review_field_line 'Documentation Obligation State' || true)"
           if [ -n "$DOC_STATE_LINE" ]; then
             DOCUMENTATION_OBLIGATION_STATE="$(normalize_machine_token "$(printf '%s' "$DOC_STATE_LINE" | sed -E 's/^Documentation Obligation State:[[:space:]]*//I')")"
-          elif awk 'BEGIN{IGNORECASE=1; in_section=0} /^##[[:space:]]+SSOT Sync \(Docs\)/{in_section=1; next} /^##[[:space:]]/{in_section=0} in_section && $0 ~ /^[[:space:]]*None[[:space:]]*$/ {found=1} END{exit(found?0:1)}' final_review.txt 2>/dev/null; then
+          elif [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
             DOCUMENTATION_OBLIGATION_STATE="not_required"
           fi
           case "$DOCUMENTATION_OBLIGATION_STATE" in
             satisfied|not_required|missing|unknown) ;;
             *) DOCUMENTATION_OBLIGATION_STATE="unknown" ;;
           esac
+          if [ "$DOCUMENTATION_OBLIGATION_STATE" = "unknown" ] && [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
+            DOCUMENTATION_OBLIGATION_STATE="not_required"
+          fi
 
           DOCS_FOLLOW_UP_HINT="none"
           DOCS_FOLLOW_UP_HINT_LINE="$(extract_final_review_field_line 'Docs Follow-Up Hint' || true)"
@@ -1819,7 +1826,10 @@ jobs:
           fi
           case "$DOCUMENTATION_OBLIGATION_STATE" in
             satisfied|not_required) ;;
-            *) REVIEW_VERDICT="blocked_missing_authority" ;;
+            *)
+              echo "::warning::Unexpected DOCUMENTATION_OBLIGATION_STATE='${DOCUMENTATION_OBLIGATION_STATE}', blocking closeout approval."
+              REVIEW_VERDICT="blocked_missing_authority"
+              ;;
           esac
           FOLLOW_UP_ID="pr-${PR_NUM}-review-${GITHUB_RUN_ID}"
           CLOSEOUT_MODE="human_merge_only"

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1817,6 +1817,10 @@ jobs:
               blocked_missing_authority) REVIEW_VERDICT="blocked_missing_authority" ;;
             esac
           fi
+          case "$DOCUMENTATION_OBLIGATION_STATE" in
+            satisfied|not_required) ;;
+            *) REVIEW_VERDICT="blocked_missing_authority" ;;
+          esac
           FOLLOW_UP_ID="pr-${PR_NUM}-review-${GITHUB_RUN_ID}"
           CLOSEOUT_MODE="human_merge_only"
           REVIEW_RECEIPT_SCHEMA_VERSION="1"
@@ -2246,6 +2250,7 @@ jobs:
             --arg medium_count "$MEDIUM_COUNT" \
             --arg low_count "$LOW_COUNT" \
             --arg verdict "$VERDICT" \
+            --arg review_verdict "$REVIEW_VERDICT" \
             --arg bugbot_count "$BUGBOT_COUNT" \
             --arg bugbot_sources "$BUGBOT_SOURCES" \
             --arg status "${JOB_STATUS:-unknown}" \
@@ -2305,7 +2310,7 @@ jobs:
                   head_sha: $head_sha,
                   run_id: $run_id,
                   run_url: $run_url,
-                  verdict: $verdict,
+                  verdict: $review_verdict,
                   status: $review_status,
                   diff_scope: $diff_scope,
                   pr_check_surface: $pr_check_surface

--- a/docs/claude-pr-assistant.md
+++ b/docs/claude-pr-assistant.md
@@ -44,6 +44,16 @@ GitHub Enterprise hosts without hard-coding `github.com`. `ok=true` is reserved
 for current-head `status=success` with `verdict=approved_for_closeout`; blocked
 or failed receipts remain parseable evidence but are not merge approval.
 
+The PR Assistant receipt is intentionally fail-closed for documentation
+authority. If the generated review does not explicitly report
+`documentation_obligation_state=satisfied` or
+`documentation_obligation_state=not_required`, the workflow must emit
+`MERGLBOT_REVIEW_VERDICT=blocked_missing_authority` instead of approving
+closeout. The metrics artifact mirrors the same lowercase
+`review_receipt.verdict` value that appears in the visible review receipt and
+hidden markers, while the legacy top-level `verdict` field remains available
+for historical dashboards.
+
 For lighter review: `@merglbot review --light`
 
 ---

--- a/docs/claude-pr-assistant.md
+++ b/docs/claude-pr-assistant.md
@@ -49,7 +49,10 @@ authority. If the generated review does not explicitly report
 `documentation_obligation_state=satisfied` or
 `documentation_obligation_state=not_required`, the workflow must emit
 `MERGLBOT_REVIEW_VERDICT=blocked_missing_authority` instead of approving
-closeout. The metrics artifact mirrors the same lowercase
+closeout. The only normalization fallback is the explicit review section
+`SSOT Sync (Docs)` containing `None`; that machine-normalizes an otherwise
+`unknown` documentation state to `not_required` because the review already made
+the no-docs-obligation claim visible. The metrics artifact mirrors the same lowercase
 `review_receipt.verdict` value that appears in the visible review receipt and
 hidden markers, while the legacy top-level `verdict` field remains available
 for historical dashboards.


### PR DESCRIPTION
## Summary
- block approved closeout when documentation obligation is unknown or missing
- write the same lower-case review verdict into the metrics receipt that is emitted in PR comments

## Verification
- git diff --check

WSA steady-state follow-up: merglbot-public/docs#620.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens the closeout approval gate in the GitHub Actions workflow, which could newly block merges when docs state is unset/unknown and may affect downstream automation relying on prior approval behavior. Also changes emitted metrics fields, which could impact dashboards/consumers expecting the old `verdict` value in the receipt payload.
> 
> **Overview**
> **Merglbot PR Assistant workflow now fail-closes approvals when docs obligation is not explicitly satisfied.** After parsing `Documentation Obligation State`, the workflow forces `REVIEW_VERDICT` to `blocked_missing_authority` unless the state is `satisfied` or `not_required`, preventing `approved_for_closeout` when docs are `unknown`/`missing`.
> 
> **Metrics emission is adjusted to match comment receipts.** The `metrics/review-metrics.json` payload now includes a separate `review_verdict` arg and writes `review_receipt.verdict` from `REVIEW_VERDICT` (lowercase normalized) rather than the previously derived/uppercased `VERDICT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ae075233886cbb3c7f401405e72645d86e7748. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->