### PR TITLE
fix(pr-assistant): limit no-docs fallback to missing field

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1752,12 +1752,14 @@ jobs:
           }
 
           DOCUMENTATION_OBLIGATION_STATE="unknown"
+          DOCUMENTATION_OBLIGATION_STATE_EXPLICIT="false"
           SSOT_SYNC_DOCS_NONE="false"
           if awk 'BEGIN{IGNORECASE=1; in_section=0} /^##[[:space:]]+SSOT Sync \(Docs\)/{in_section=1; next} /^##[[:space:]]/{in_section=0} in_section && $0 ~ /^[[:space:]]*None[[:space:]]*$/ {found=1} END{exit(found?0:1)}' final_review.txt 2>/dev/null; then
             SSOT_SYNC_DOCS_NONE="true"
           fi
           DOC_STATE_LINE="$(extract_zaver_review_field_line 'Documentation Obligation State' || true)"
           if [ -n "$DOC_STATE_LINE" ]; then
+            DOCUMENTATION_OBLIGATION_STATE_EXPLICIT="true"
             DOCUMENTATION_OBLIGATION_STATE="$(normalize_machine_token "$(printf '%s' "$DOC_STATE_LINE" | sed -E 's/^Documentation Obligation State:[[:space:]]*//I')")"
           elif [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
             DOCUMENTATION_OBLIGATION_STATE="not_required"
@@ -1766,7 +1768,7 @@ jobs:
             satisfied|not_required|missing|unknown) ;;
             *) DOCUMENTATION_OBLIGATION_STATE="unknown" ;;
           esac
-          if [ "$DOCUMENTATION_OBLIGATION_STATE" = "unknown" ] && [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
+          if [ "$DOCUMENTATION_OBLIGATION_STATE_EXPLICIT" != "true" ] && [ "$DOCUMENTATION_OBLIGATION_STATE" = "unknown" ] && [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
             DOCUMENTATION_OBLIGATION_STATE="not_required"
           fi
 

--- a/docs/claude-pr-assistant.md
+++ b/docs/claude-pr-assistant.md
@@ -51,8 +51,10 @@ authority. If the generated review does not explicitly report
 `MERGLBOT_REVIEW_VERDICT=blocked_missing_authority` instead of approving
 closeout. The only normalization fallback is the explicit review section
 `SSOT Sync (Docs)` containing `None`; that machine-normalizes an otherwise
-`unknown` documentation state to `not_required` because the review already made
-the no-docs-obligation claim visible. The metrics artifact mirrors the same lowercase
+missing `Documentation Obligation State` field to `not_required` because the
+review already made the no-docs-obligation claim visible. If the machine field
+is present but invalid, the workflow must keep the fail-closed `unknown` state
+instead of treating it as `not_required`. The metrics artifact mirrors the same lowercase
 `review_receipt.verdict` value that appears in the visible review receipt and
 hidden markers, while the legacy top-level `verdict` field remains available
 for historical dashboards.


### PR DESCRIPTION
## Summary
- only normalize  to  when the machine documentation field is absent
- keep invalid explicit documentation state fail-closed as 
- document the source contract

## Verification
- git diff --check

WSA steady-state follow-up: merglbot-public/docs#620.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the PR Assistant workflow’s documentation authority gating logic, which can change whether closeout is blocked or allowed. Low code churn, but mistakes could incorrectly approve/deny merges based on docs metadata parsing.
> 
> **Overview**
> Tightens docs-state normalization in the PR Assistant workflow so `SSOT Sync (Docs)` = `None` only backfills `Documentation Obligation State` to `not_required` when the machine field is **missing**, and stays fail-closed (`unknown`) when an explicit but invalid value is provided.
> 
> Updates the contract documentation in `docs/claude-pr-assistant.md` to match this behavior (missing field may normalize; invalid explicit field must not).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d5c4899be06d2279399e2995dad3854c34fab8c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->