### PR TITLE
feat(dependabot): add Slack telemetry receipts

### DIFF
--- a/.github/workflows/ent-dependabot-autonomous-closeout.yml
+++ b/.github/workflows/ent-dependabot-autonomous-closeout.yml
@@ -95,11 +95,11 @@ on:
         required: false
         type: boolean
         default: true
-      tracking_issue:
-        description: "Tracking issue URL"
+      comment_report:
+        description: "Post report to the default tracking issue"
         required: false
-        type: string
-        default: "https://github.com/merglbot-public/docs/issues/636"
+        type: boolean
+        default: false
       slack_notify:
         description: "Post the run telemetry summary to Slack"
         required: false
@@ -147,8 +147,8 @@ jobs:
           INPUT_MAX_PARALLEL_REPOS: ${{ inputs.max_parallel_repos || 3 }}
           INPUT_MAX_PRS_PER_REPO: ${{ inputs.max_prs_per_repo || 0 }}
           INPUT_ALLOW_POLICY_ALIGNMENT: ${{ inputs.allow_policy_alignment }}
-          INPUT_COMMENT_REPORT: ${{ github.event_name == 'workflow_dispatch' && inputs.tracking_issue != '' && 'true' || inputs.comment_report }}
-          INPUT_TRACKING_ISSUE: ${{ inputs.tracking_issue || 'https://github.com/merglbot-public/docs/issues/636' }}
+          INPUT_COMMENT_REPORT: ${{ inputs.comment_report && 'true' || 'false' }}
+          INPUT_TRACKING_ISSUE: ${{ github.event_name == 'workflow_dispatch' && 'https://github.com/merglbot-public/docs/issues/636' || inputs.tracking_issue }}
           INPUT_SLACK_NOTIFY: ${{ inputs.slack_notify }}
           INPUT_PR_ALLOWLIST: ${{ inputs.pr_allowlist || '' }}
           INPUT_APPROVAL_NOTE: ${{ inputs.approval_note || '' }}

--- a/.github/workflows/ent-dependabot-autonomous-closeout.yml
+++ b/.github/workflows/ent-dependabot-autonomous-closeout.yml
@@ -43,6 +43,26 @@ on:
         required: false
         type: string
         default: "https://github.com/merglbot-public/docs/issues/636"
+      slack_notify:
+        description: "Post the run telemetry summary to Slack via SLACK_DEPENDABOT_WEBHOOK_URL."
+        required: false
+        type: boolean
+        default: true
+      pr_allowlist:
+        description: "Optional comma/space/newline-separated owner/repo#PR or PR URLs approved for apply mode."
+        required: false
+        type: string
+        default: ""
+      approval_note:
+        description: "Human approval note recorded in the receipt for user-approved apply runs."
+        required: false
+        type: string
+        default: ""
+      approval_issue_url:
+        description: "Optional GitHub issue URL containing the apply approval packet."
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       mode:
@@ -65,11 +85,6 @@ on:
         description: "owner/repo when repo_scope=single_repo"
         required: false
         type: string
-      max_parallel_repos:
-        description: "Upper bound recorded in receipts; mutation lane remains repo-sequential"
-        required: false
-        type: number
-        default: 3
       max_prs_per_repo:
         description: "0 means unlimited"
         required: false
@@ -90,6 +105,19 @@ on:
         required: false
         type: string
         default: "https://github.com/merglbot-public/docs/issues/636"
+      slack_notify:
+        description: "Post the run telemetry summary to Slack"
+        required: false
+        type: boolean
+        default: true
+      pr_allowlist:
+        description: "Optional owner/repo#PR or PR URLs approved for apply mode"
+        required: false
+        type: string
+      approval_note:
+        description: "Human approval note recorded in the receipt"
+        required: false
+        type: string
 
 permissions:
   actions: read
@@ -122,6 +150,11 @@ jobs:
           INPUT_ALLOW_POLICY_ALIGNMENT: ${{ inputs.allow_policy_alignment }}
           INPUT_COMMENT_REPORT: ${{ inputs.comment_report }}
           INPUT_TRACKING_ISSUE: ${{ inputs.tracking_issue || 'https://github.com/merglbot-public/docs/issues/636' }}
+          INPUT_SLACK_NOTIFY: ${{ inputs.slack_notify }}
+          INPUT_PR_ALLOWLIST: ${{ inputs.pr_allowlist || '' }}
+          INPUT_APPROVAL_NOTE: ${{ inputs.approval_note || '' }}
+          INPUT_APPROVAL_ISSUE_URL: ${{ inputs.approval_issue_url || '' }}
+          SLACK_DEPENDABOT_WEBHOOK_URL: ${{ secrets.SLACK_DEPENDABOT_WEBHOOK_URL }}
           ENT_DEPENDABOT_REVIEW_WAIT_SECONDS: "1500"
           ENT_DEPENDABOT_REVIEW_POLL_SECONDS: "60"
           ENT_DEPENDABOT_REBASE_WAIT_SECONDS: "600"
@@ -137,6 +170,10 @@ jobs:
           ALLOW_POLICY_ALIGNMENT="$INPUT_ALLOW_POLICY_ALIGNMENT"
           COMMENT_REPORT="$INPUT_COMMENT_REPORT"
           TRACKING_ISSUE="$INPUT_TRACKING_ISSUE"
+          SLACK_NOTIFY="$INPUT_SLACK_NOTIFY"
+          PR_ALLOWLIST="$INPUT_PR_ALLOWLIST"
+          APPROVAL_NOTE="$INPUT_APPROVAL_NOTE"
+          APPROVAL_ISSUE_URL="$INPUT_APPROVAL_ISSUE_URL"
 
           ARGS=(
             --mode "$MODE"
@@ -145,6 +182,9 @@ jobs:
             --max-prs-per-repo "$MAX_PRS_PER_REPO"
             --output-dir "reports/ent-dependabot-weekly"
             --tracking-issue "$TRACKING_ISSUE"
+            --pr-allowlist "$PR_ALLOWLIST"
+            --approval-note "$APPROVAL_NOTE"
+            --approval-issue-url "$APPROVAL_ISSUE_URL"
           )
 
           if [ -n "$SINGLE_REPO" ]; then
@@ -156,6 +196,9 @@ jobs:
           if [ "$COMMENT_REPORT" = "true" ]; then
             ARGS+=(--comment-report)
           fi
+          if [ "$SLACK_NOTIFY" = "true" ]; then
+            ARGS+=(--slack-notify --slack-webhook-url "$SLACK_DEPENDABOT_WEBHOOK_URL")
+          fi
 
           mkdir -p reports/ent-dependabot-weekly
           python3 scripts/dependabot/ent_dependabot_closeout.py "${ARGS[@]}" | tee reports/ent-dependabot-weekly/stdout.json
@@ -164,6 +207,40 @@ jobs:
             echo ""
             cat reports/ent-dependabot-weekly/summary.md
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post Slack fallback if closeout crashes before receipt
+        if: failure() && inputs.slack_notify
+        env:
+          SLACK_DEPENDABOT_WEBHOOK_URL: ${{ secrets.SLACK_DEPENDABOT_WEBHOOK_URL }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -f reports/ent-dependabot-weekly/ent_dependabot_weekly_receipt.json ]; then
+            exit 0
+          fi
+          if [ -z "${SLACK_DEPENDABOT_WEBHOOK_URL:-}" ]; then
+            exit 0
+          fi
+          python3 - <<'PY'
+          import json
+          import os
+          from urllib.request import Request, urlopen
+
+          payload = {
+              "text": (
+                  "*ENT Dependabot Weekly Closeout* `workflow_failed_before_receipt`\n"
+                  f"Run: {os.environ.get('GITHUB_RUN_URL', 'not available')}"
+              )
+          }
+          request = Request(
+              os.environ["SLACK_DEPENDABOT_WEBHOOK_URL"],
+              data=json.dumps(payload).encode("utf-8"),
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          with urlopen(request, timeout=15) as response:
+              response.read()
+          PY
 
       - name: Upload weekly receipt artifacts
         if: always()

--- a/.github/workflows/ent-dependabot-autonomous-closeout.yml
+++ b/.github/workflows/ent-dependabot-autonomous-closeout.yml
@@ -148,7 +148,7 @@ jobs:
           INPUT_MAX_PRS_PER_REPO: ${{ inputs.max_prs_per_repo || 0 }}
           INPUT_ALLOW_POLICY_ALIGNMENT: ${{ inputs.allow_policy_alignment }}
           INPUT_COMMENT_REPORT: ${{ inputs.comment_report && 'true' || 'false' }}
-          INPUT_TRACKING_ISSUE: ${{ github.event_name == 'workflow_dispatch' && 'https://github.com/merglbot-public/docs/issues/636' || inputs.tracking_issue }}
+          INPUT_TRACKING_ISSUE: ${{ inputs.tracking_issue || 'https://github.com/merglbot-public/docs/issues/636' }}
           INPUT_SLACK_NOTIFY: ${{ inputs.slack_notify }}
           INPUT_PR_ALLOWLIST: ${{ inputs.pr_allowlist || '' }}
           INPUT_APPROVAL_NOTE: ${{ inputs.approval_note || '' }}

--- a/.github/workflows/ent-dependabot-autonomous-closeout.yml
+++ b/.github/workflows/ent-dependabot-autonomous-closeout.yml
@@ -196,8 +196,8 @@ jobs:
           if [ "$COMMENT_REPORT" = "true" ]; then
             ARGS+=(--comment-report)
           fi
-          if [ "$SLACK_NOTIFY" = "true" ]; then
-            ARGS+=(--slack-notify --slack-webhook-url "$SLACK_DEPENDABOT_WEBHOOK_URL")
+          if [ "$SLACK_NOTIFY" = "true" ] && [ -n "${SLACK_DEPENDABOT_WEBHOOK_URL:-}" ]; then
+            ARGS+=(--slack-notify)
           fi
 
           mkdir -p reports/ent-dependabot-weekly
@@ -214,7 +214,7 @@ jobs:
           SLACK_DEPENDABOT_WEBHOOK_URL: ${{ secrets.SLACK_DEPENDABOT_WEBHOOK_URL }}
           GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          set -euo pipefail
+          set -u
           if [ -f reports/ent-dependabot-weekly/ent_dependabot_weekly_receipt.json ]; then
             exit 0
           fi
@@ -224,6 +224,7 @@ jobs:
           python3 - <<'PY'
           import json
           import os
+          import sys
           from urllib.request import Request, urlopen
 
           payload = {
@@ -232,14 +233,17 @@ jobs:
                   f"Run: {os.environ.get('GITHUB_RUN_URL', 'not available')}"
               )
           }
-          request = Request(
-              os.environ["SLACK_DEPENDABOT_WEBHOOK_URL"],
-              data=json.dumps(payload).encode("utf-8"),
-              headers={"Content-Type": "application/json"},
-              method="POST",
-          )
-          with urlopen(request, timeout=15) as response:
-              response.read()
+          try:
+              request = Request(
+                  os.environ["SLACK_DEPENDABOT_WEBHOOK_URL"],
+                  data=json.dumps(payload).encode("utf-8"),
+                  headers={"Content-Type": "application/json"},
+                  method="POST",
+              )
+              with urlopen(request, timeout=15) as response:
+                  response.read()
+          except Exception:
+              sys.exit(0)
           PY
 
       - name: Upload weekly receipt artifacts

--- a/.github/workflows/ent-dependabot-autonomous-closeout.yml
+++ b/.github/workflows/ent-dependabot-autonomous-closeout.yml
@@ -95,11 +95,6 @@ on:
         required: false
         type: boolean
         default: true
-      comment_report:
-        description: "Post report to tracking issue"
-        required: false
-        type: boolean
-        default: false
       tracking_issue:
         description: "Tracking issue URL"
         required: false
@@ -116,6 +111,10 @@ on:
         type: string
       approval_note:
         description: "Human approval note recorded in the receipt"
+        required: false
+        type: string
+      approval_issue_url:
+        description: "Optional GitHub issue URL containing the apply approval packet"
         required: false
         type: string
 
@@ -148,7 +147,7 @@ jobs:
           INPUT_MAX_PARALLEL_REPOS: ${{ inputs.max_parallel_repos || 3 }}
           INPUT_MAX_PRS_PER_REPO: ${{ inputs.max_prs_per_repo || 0 }}
           INPUT_ALLOW_POLICY_ALIGNMENT: ${{ inputs.allow_policy_alignment }}
-          INPUT_COMMENT_REPORT: ${{ inputs.comment_report }}
+          INPUT_COMMENT_REPORT: ${{ github.event_name == 'workflow_dispatch' && inputs.tracking_issue != '' && 'true' || inputs.comment_report }}
           INPUT_TRACKING_ISSUE: ${{ inputs.tracking_issue || 'https://github.com/merglbot-public/docs/issues/636' }}
           INPUT_SLACK_NOTIFY: ${{ inputs.slack_notify }}
           INPUT_PR_ALLOWLIST: ${{ inputs.pr_allowlist || '' }}

--- a/.github/workflows/ent-dependabot-weekly.yml
+++ b/.github/workflows/ent-dependabot-weekly.yml
@@ -31,6 +31,19 @@ on:
         required: false
         type: number
         default: 0
+      slack_notify:
+        description: "Post telemetry to Slack"
+        required: false
+        type: boolean
+        default: true
+      pr_allowlist:
+        description: "Optional owner/repo#PR or PR URLs approved for manual apply mode"
+        required: false
+        type: string
+      approval_note:
+        description: "Human approval note or approval packet URL for manual apply mode"
+        required: false
+        type: string
 
 permissions:
   actions: read
@@ -56,4 +69,7 @@ jobs:
       allow_policy_alignment: true
       comment_report: true
       tracking_issue: "https://github.com/merglbot-public/docs/issues/636"
+      slack_notify: ${{ github.event_name == 'schedule' && true || inputs.slack_notify }}
+      pr_allowlist: ${{ github.event_name == 'schedule' && '' || inputs.pr_allowlist }}
+      approval_note: ${{ github.event_name == 'schedule' && 'scheduled weekly run' || inputs.approval_note }}
     secrets: inherit

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -54,17 +54,19 @@ the Slack webhook configuration.
 Slack messages include the run status, scanned repo count, merged/closed/blocked
 Dependabot PR counts, remaining Dependabot and non-Dependabot PR totals, open
 issue totals, top blocker reasons, and the GitHub Actions run URL. The JSON
-artifact remains the authoritative receipt if Slack delivery fails. A Slack
-failure before mutations may block the run; a Slack failure after completed
-mutations must not cause automatic PR/issue mutation retries and should be
-reported as telemetry-degraded.
+artifact remains the authoritative receipt if Slack delivery fails. Slack is
+best-effort for the weekly workflow: missing Slack configuration is recorded as
+`not_configured`, POST failure is recorded as `telemetry_degraded`, and neither
+case may cause automatic PR/issue mutation retries.
 
 Manual apply validation can pass a `pr_allowlist` plus `approval_note` or
 `approval_issue_url`; the workflow records those values in the receipt and only
 acts on the allowlisted PRs. `pr_allowlist` accepts comma- or whitespace-separated
 `owner/repo#number` tokens or GitHub PR URLs; the approval note/packet must record
 approver identity, timestamp, approved scope, authorized run or commit, and
-expected action per PR.
+expected action per PR. For `post_change_validation=true`, the workflow fails
+closed unless `pr_allowlist` is non-empty or the approval note explicitly says
+`approval_scope=full_queue`.
 
 ## Merge Gate
 

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -42,6 +42,22 @@ Platform policy authority remains in `merglbot-public/docs`:
 - The workflow does not deploy, run Terraform apply, mutate secrets, change
   default branches, or bypass branch protection.
 
+## Slack Telemetry
+
+The reusable workflow posts a compact run summary to Slack when
+`slack_notify=true` and the `SLACK_DEPENDABOT_WEBHOOK_URL` secret is configured
+in `merglbot-core/github`. The secret value must never be printed or embedded in
+logs; channel routing is controlled by the Slack webhook configuration.
+
+Slack messages include the run status, scanned repo count, merged/closed/blocked
+Dependabot PR counts, remaining Dependabot and non-Dependabot PR totals, open
+issue totals, top blocker reasons, and the GitHub Actions run URL. The JSON
+artifact remains the authoritative receipt if Slack delivery fails.
+
+Manual apply validation can pass a `pr_allowlist` plus `approval_note` or
+`approval_issue_url`; the workflow records those values in the receipt and only
+acts on the allowlisted PRs.
+
 ## Merge Gate
 
 Every merged Dependabot PR must prove:

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -75,9 +75,10 @@ issue body, or a single referenced issue comment. Markers spread across multiple
 historical comments do not satisfy the authorization gate. `authorized_sha` or
 `authorized_run` must match the current workflow SHA or run ID, and approval
 packets loaded from `approval_issue_url` must come from a trusted approval repo
-and a trusted GitHub author whose login matches `approved_by`. Approval material
-must also record approver identity, timestamp, approved scope, and expected
-action per PR.
+and a trusted GitHub author whose login matches `approved_by`. Trusted approvers
+come from the explicit `ENT_DEPENDABOT_TRUSTED_APPROVERS` policy list; the
+workflow actor is not trusted implicitly. Approval material must also record
+approver identity, timestamp, approved scope, and expected action per PR.
 
 ## Merge Gate
 

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -80,6 +80,12 @@ come from the explicit `ENT_DEPENDABOT_TRUSTED_APPROVERS` policy list; the
 workflow actor is not trusted implicitly. Approval material must also record
 approver identity, timestamp, approved scope, and expected action per PR.
 
+Manual `workflow_dispatch` exposes a bounded 10-input surface. It includes
+`approval_issue_url` and `comment_report`; when `comment_report=true`, the report
+is posted to the default tracking issue `merglbot-public/docs#636`. Custom
+tracking issue routing remains available through the reusable `workflow_call`
+interface.
+
 ## Merge Gate
 
 Every merged Dependabot PR must prove:

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -82,9 +82,9 @@ approver identity, timestamp, approved scope, and expected action per PR.
 
 Manual `workflow_dispatch` exposes a bounded 10-input surface. It includes
 `approval_issue_url` and `comment_report`; when `comment_report=true`, the report
-is posted to the default tracking issue `merglbot-public/docs#636`. Custom
-tracking issue routing remains available through the reusable `workflow_call`
-interface.
+is posted to the default tracking issue `merglbot-public/docs#636`. Reusable
+`workflow_call` callers keep the same default fallback when `tracking_issue` is
+omitted, and can still override routing with an explicit `tracking_issue` value.
 
 ## Merge Gate
 

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -69,8 +69,12 @@ contains `approval_scope=full_queue`; `approval_note` or `approval_issue_url` is
 present; the approval material covers the current workflow SHA or run ID; and
 the approval material contains `expected_action=`. If `approval_issue_url` is
 used, the referenced packet must contain the approval scope, expected action, and
-covered workflow SHA or run ID in a durable form. Approval material must also
-record approver identity, timestamp, approved scope, and expected action per PR.
+covered workflow SHA or run ID in a durable form. All required markers must
+appear in one coherent approval packet: the `approval_note`, the referenced
+issue body, or a single referenced issue comment. Markers spread across multiple
+historical comments do not satisfy the authorization gate. Approval material must
+also record approver identity, timestamp, approved scope, and expected action per
+PR.
 
 ## Merge Gate
 

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -72,9 +72,12 @@ used, the referenced packet must contain the approval scope, expected action, an
 covered workflow SHA or run ID in a durable form. All required markers must
 appear in one coherent approval packet: the `approval_note`, the referenced
 issue body, or a single referenced issue comment. Markers spread across multiple
-historical comments do not satisfy the authorization gate. Approval material must
-also record approver identity, timestamp, approved scope, and expected action per
-PR.
+historical comments do not satisfy the authorization gate. `authorized_sha` or
+`authorized_run` must match the current workflow SHA or run ID, and approval
+packets loaded from `approval_issue_url` must come from a trusted approval repo
+and a trusted GitHub author whose login matches `approved_by`. Approval material
+must also record approver identity, timestamp, approved scope, and expected
+action per PR.
 
 ## Merge Gate
 

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -62,11 +62,15 @@ case may cause automatic PR/issue mutation retries.
 Manual apply validation can pass a `pr_allowlist` plus `approval_note` or
 `approval_issue_url`; the workflow records those values in the receipt and only
 acts on the allowlisted PRs. `pr_allowlist` accepts comma- or whitespace-separated
-`owner/repo#number` tokens or GitHub PR URLs; the approval note/packet must record
-approver identity, timestamp, approved scope, authorized run or commit, and
-expected action per PR. For `post_change_validation=true`, the workflow fails
-closed unless `pr_allowlist` is non-empty or the approval note explicitly says
-`approval_scope=full_queue`.
+`owner/repo#number` tokens or GitHub PR URLs. For
+`post_change_validation=true`, the workflow fails closed unless all of the
+following hold: `pr_allowlist` is non-empty or the approval material explicitly
+contains `approval_scope=full_queue`; `approval_note` or `approval_issue_url` is
+present; and the approval material covers the current workflow SHA or run ID. If
+`approval_issue_url` is used, the referenced packet must contain the approval
+scope and covered workflow SHA or run ID in a durable form. Approval material
+must also record approver identity, timestamp, approved scope, and expected
+action per PR.
 
 ## Merge Gate
 

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -66,11 +66,11 @@ acts on the allowlisted PRs. `pr_allowlist` accepts comma- or whitespace-separat
 `post_change_validation=true`, the workflow fails closed unless all of the
 following hold: `pr_allowlist` is non-empty or the approval material explicitly
 contains `approval_scope=full_queue`; `approval_note` or `approval_issue_url` is
-present; and the approval material covers the current workflow SHA or run ID. If
-`approval_issue_url` is used, the referenced packet must contain the approval
-scope and covered workflow SHA or run ID in a durable form. Approval material
-must also record approver identity, timestamp, approved scope, and expected
-action per PR.
+present; the approval material covers the current workflow SHA or run ID; and
+the approval material contains `expected_action=`. If `approval_issue_url` is
+used, the referenced packet must contain the approval scope, expected action, and
+covered workflow SHA or run ID in a durable form. Approval material must also
+record approver identity, timestamp, approved scope, and expected action per PR.
 
 ## Merge Gate
 

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -46,17 +46,25 @@ Platform policy authority remains in `merglbot-public/docs`:
 
 The reusable workflow posts a compact run summary to Slack when
 `slack_notify=true` and the `SLACK_DEPENDABOT_WEBHOOK_URL` secret is configured
-in `merglbot-core/github`. The secret value must never be printed or embedded in
-logs; channel routing is controlled by the Slack webhook configuration.
+as a GitHub Actions repository secret in `merglbot-core/github`, or as an
+organization secret explicitly scoped only to `merglbot-core/github`. The secret
+value must never be printed or embedded in logs; channel routing is controlled by
+the Slack webhook configuration.
 
 Slack messages include the run status, scanned repo count, merged/closed/blocked
 Dependabot PR counts, remaining Dependabot and non-Dependabot PR totals, open
 issue totals, top blocker reasons, and the GitHub Actions run URL. The JSON
-artifact remains the authoritative receipt if Slack delivery fails.
+artifact remains the authoritative receipt if Slack delivery fails. A Slack
+failure before mutations may block the run; a Slack failure after completed
+mutations must not cause automatic PR/issue mutation retries and should be
+reported as telemetry-degraded.
 
 Manual apply validation can pass a `pr_allowlist` plus `approval_note` or
 `approval_issue_url`; the workflow records those values in the receipt and only
-acts on the allowlisted PRs.
+acts on the allowlisted PRs. `pr_allowlist` accepts comma- or whitespace-separated
+`owner/repo#number` tokens or GitHub PR URLs; the approval note/packet must record
+approver identity, timestamp, approved scope, authorized run or commit, and
+expected action per PR.
 
 ## Merge Gate
 

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -341,11 +341,6 @@ def validate_apply_approval(mode: str, pr_allowlist: set[tuple[str, int]], appro
         for item in os.environ.get("ENT_DEPENDABOT_TRUSTED_APPROVERS", "milhul6").split(",")
         if item.strip()
     }
-    trusted_approvers.update(
-        actor.lower()
-        for actor in [os.environ.get("GITHUB_ACTOR", ""), os.environ.get("GITHUB_TRIGGERING_ACTOR", "")]
-        if actor
-    )
 
     def packet_missing_markers(author: str, packet: str) -> list[str]:
         fields = parse_approval_packet_fields(packet)

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -750,6 +750,8 @@ def process_repo(
 
         took_action = False
         for pr in prs:
+            if pr.number in seen_without_action:
+                continue
             if pr_allowlist and (pr.repo, pr.number) not in pr_allowlist:
                 repo_result["skipped_by_allowlist"].append(
                     {
@@ -762,8 +764,6 @@ def process_repo(
                     }
                 )
                 seen_without_action.add(pr.number)
-                continue
-            if pr.number in seen_without_action:
                 continue
             try:
                 receipt = process_pr(pr, mode=mode, output_dir=output_dir, allow_policy_alignment=allow_policy_alignment, workflow_url=workflow_url)

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -1108,8 +1108,16 @@ def self_test() -> int:
         ("merglbot-core/github", 1),
         ("merglbot-public/docs", 2),
     }
-    previous_env = {key: os.environ.get(key) for key in ["GITHUB_SHA", "GITHUB_RUN_ID", "GITHUB_ACTOR"]}
-    os.environ.update({"GITHUB_SHA": "abc", "GITHUB_RUN_ID": "12345", "GITHUB_ACTOR": "milhul6"})
+    previous_env = {
+        key: os.environ.get(key)
+        for key in ["GITHUB_SHA", "GITHUB_RUN_ID", "GITHUB_ACTOR", "GITHUB_TRIGGERING_ACTOR"]
+    }
+    os.environ.update({
+        "GITHUB_SHA": "abc",
+        "GITHUB_RUN_ID": "12345",
+        "GITHUB_ACTOR": "milhul6",
+        "GITHUB_TRIGGERING_ACTOR": "milhul6",
+    })
     try:
         validate_apply_approval(
             "apply",

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -276,6 +276,24 @@ def parse_pr_allowlist(raw: str) -> set[tuple[str, int]]:
     return allowed
 
 
+def validate_apply_approval(mode: str, pr_allowlist: set[tuple[str, int]], approval_note: str, approval_issue_url: str) -> None:
+    if mode != "apply":
+        return
+    normalized = approval_note.lower()
+    explicit_approval_lane = bool(pr_allowlist or approval_issue_url or "post_change_validation=true" in normalized)
+    if not explicit_approval_lane:
+        return
+    if not approval_note and not approval_issue_url:
+        raise GhError("apply approval requires approval_note or approval_issue_url")
+    if not pr_allowlist and "approval_scope=full_queue" not in normalized:
+        raise GhError("apply approval without pr_allowlist requires approval_scope=full_queue")
+    missing = [marker for marker in ["approved_by=", "approved_at="] if marker not in normalized]
+    if "authorized_sha=" not in normalized and "authorized_run=" not in normalized and not approval_issue_url:
+        missing.append("authorized_sha= or authorized_run=")
+    if missing:
+        raise GhError("apply approval metadata missing: " + ", ".join(missing))
+
+
 def pr_files(repo: str, number: int) -> list[str]:
     proc = run_cmd(["gh", "pr", "diff", str(number), "--repo", repo, "--name-only"])
     return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
@@ -919,6 +937,7 @@ def build_report(
             "approval_issue_url": approval_issue_url,
         },
         "slack_delivery": {"status": "not_requested"},
+        "telemetry_degraded": False,
         "repo_table": repo_table,
         "tracking_comment_url": tracking_comment_url,
         "telemetry_warnings": [warning for result in repo_results for warning in result.get("telemetry_warnings", [])],
@@ -959,7 +978,7 @@ def build_slack_payload(report: dict[str, Any], status: str) -> dict[str, Any]:
 
 def post_slack_report(webhook_url: str, report: dict[str, Any]) -> dict[str, Any]:
     if not webhook_url:
-        return {"status": "missing_webhook", "ok": False}
+        return {"status": "not_configured", "ok": True}
     payload = build_slack_payload(report, "ok" if report.get("ok") else "blocked")
     request = Request(
         webhook_url,
@@ -1020,6 +1039,12 @@ def self_test() -> int:
         ("merglbot-core/github", 1),
         ("merglbot-public/docs", 2),
     }
+    validate_apply_approval(
+        "apply",
+        {("merglbot-core/github", 1)},
+        "post_change_validation=true approved_by=milhul6 approved_at=2026-04-12T21:00:00Z authorized_sha=abc expected_action=merge",
+        "",
+    )
     assert report["remaining_dependabot_prs"] == 1
     assert "MERGLBOT" not in close_comment(
         PullRequest("o/r", 1, "x", "u", "dependabot[bot]", "a" * 40, "main", "dependabot/x", False, "CLEAN", utc_now()),
@@ -1060,6 +1085,7 @@ def main() -> int:
     args.output_dir.mkdir(parents=True, exist_ok=True)
     try:
         pr_allowlist = parse_pr_allowlist(args.pr_allowlist)
+        validate_apply_approval(args.mode, pr_allowlist, args.approval_note, args.approval_issue_url)
         all_repos = load_repo_scope(args.scope_file)
         if args.repo_scope == "single_repo":
             if not args.single_repo:
@@ -1103,9 +1129,7 @@ def main() -> int:
         if args.slack_notify:
             report["slack_delivery"] = post_slack_report(os.environ.get("SLACK_DEPENDABOT_WEBHOOK_URL", ""), report)
             if not report["slack_delivery"].get("ok"):
-                report["ok"] = False
-                report["final_verdict"] = "ENT_DEPENDABOT_WEEKLY_CLOSEOUT_BLOCKED"
-                report["remaining_blockers"].append(f"slack_delivery:{report['slack_delivery'].get('status')}")
+                report["telemetry_degraded"] = True
         summary = markdown_summary(report)
         if args.comment_report and args.tracking_issue:
             report["tracking_comment_url"] = post_tracking_report(args.tracking_issue, report, summary)

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -29,6 +29,7 @@ MERGLBOT_REVIEW_WAIT_SECONDS = int(os.environ.get("ENT_DEPENDABOT_REVIEW_WAIT_SE
 MERGLBOT_REVIEW_POLL_SECONDS = int(os.environ.get("ENT_DEPENDABOT_REVIEW_POLL_SECONDS", "60"))
 REBASE_WAIT_SECONDS = int(os.environ.get("ENT_DEPENDABOT_REBASE_WAIT_SECONDS", "600"))
 REBASE_POLL_SECONDS = int(os.environ.get("ENT_DEPENDABOT_REBASE_POLL_SECONDS", "60"))
+OPEN_ITEM_LIST_LIMIT = 1000
 
 DEPENDENCY_FILE_PATTERNS = [
     re.compile(pattern)
@@ -247,7 +248,7 @@ def list_open_prs(repo: str) -> list[dict[str, Any]]:
             "--state",
             "open",
             "--limit",
-            "200",
+            str(OPEN_ITEM_LIST_LIMIT),
             "--json",
             "number,title,url,author,headRefOid,isDraft,mergeStateStatus,updatedAt",
         ]
@@ -256,7 +257,7 @@ def list_open_prs(repo: str) -> list[dict[str, Any]]:
 
 
 def list_open_issues(repo: str) -> list[dict[str, Any]]:
-    data = gh_json(["issue", "list", "--repo", repo, "--state", "open", "--limit", "200", "--json", "number,title,url,author,updatedAt"])
+    data = gh_json(["issue", "list", "--repo", repo, "--state", "open", "--limit", str(OPEN_ITEM_LIST_LIMIT), "--json", "number,title,url,author,updatedAt"])
     return list(data)
 
 
@@ -1044,7 +1045,6 @@ def main() -> int:
     parser.add_argument("--comment-report", action="store_true")
     parser.add_argument("--tracking-issue", default="")
     parser.add_argument("--slack-notify", action="store_true")
-    parser.add_argument("--slack-webhook-url", default=os.environ.get("SLACK_DEPENDABOT_WEBHOOK_URL", ""))
     parser.add_argument("--pr-allowlist", default="")
     parser.add_argument("--approval-note", default="")
     parser.add_argument("--approval-issue-url", default="")
@@ -1101,7 +1101,7 @@ def main() -> int:
             workflow_url=args.workflow_url,
         )
         if args.slack_notify:
-            report["slack_delivery"] = post_slack_report(args.slack_webhook_url, report)
+            report["slack_delivery"] = post_slack_report(os.environ.get("SLACK_DEPENDABOT_WEBHOOK_URL", ""), report)
             if not report["slack_delivery"].get("ok"):
                 report["ok"] = False
                 report["final_verdict"] = "ENT_DEPENDABOT_WEEKLY_CLOSEOUT_BLOCKED"
@@ -1124,7 +1124,7 @@ def main() -> int:
             "remaining_blockers": [str(exc)],
         }
         if args.slack_notify:
-            failure["slack_delivery"] = post_slack_report(args.slack_webhook_url, failure)
+            failure["slack_delivery"] = post_slack_report(os.environ.get("SLACK_DEPENDABOT_WEBHOOK_URL", ""), failure)
         write_json(args.output_dir / "ent_dependabot_weekly_receipt.json", failure)
         print(json.dumps(failure, sort_keys=True))
         return 1

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -276,9 +276,10 @@ def parse_pr_allowlist(raw: str) -> set[tuple[str, int]]:
     return allowed
 
 
-def fetch_approval_issue_material(approval_issue_url: str) -> str:
+def approval_packet_candidates(approval_note: str, approval_issue_url: str) -> list[str]:
+    candidates = [approval_note] if approval_note.strip() else []
     if not approval_issue_url:
-        return ""
+        return candidates
     parsed = urlparse(approval_issue_url)
     if parsed.netloc != "github.com":
         raise GhError("approval_issue_url must be a github.com issue or pull request URL")
@@ -288,31 +289,43 @@ def fetch_approval_issue_material(approval_issue_url: str) -> str:
     owner, repo, _, number = parts[:4]
     issue = gh_api_json(f"repos/{owner}/{repo}/issues/{number}")
     comments = gh_api_json(f"repos/{owner}/{repo}/issues/{number}/comments?per_page=100")
-    material = [issue.get("title", ""), issue.get("body", "") or ""]
-    material.extend(comment.get("body", "") or "" for comment in comments)
-    return "\n".join(material)
+    issue_body = issue.get("body", "") or ""
+    if issue_body.strip():
+        candidates.append(issue_body)
+    candidates.extend(
+        comment.get("body", "") or ""
+        for comment in comments
+        if (comment.get("body", "") or "").strip()
+    )
+    return candidates
 
 
 def validate_apply_approval(mode: str, pr_allowlist: set[tuple[str, int]], approval_note: str, approval_issue_url: str) -> None:
     if mode != "apply":
         return
-    approval_material = "\n".join([approval_note, fetch_approval_issue_material(approval_issue_url)]).lower()
-    explicit_approval_lane = bool(pr_allowlist or approval_issue_url or "post_change_validation=true" in approval_material)
+    packets = [packet.lower() for packet in approval_packet_candidates(approval_note, approval_issue_url)]
+    combined_material = "\n".join(packets)
+    explicit_approval_lane = bool(pr_allowlist or approval_issue_url or "post_change_validation=true" in combined_material)
     if not explicit_approval_lane:
         return
-    if not approval_note and not approval_issue_url:
+    if not packets:
         raise GhError("apply approval requires approval_note or approval_issue_url")
-    if not pr_allowlist and "approval_scope=full_queue" not in approval_material:
-        raise GhError("apply approval without pr_allowlist requires approval_scope=full_queue")
-    missing = [
-        marker
-        for marker in ["approved_by=", "approved_at=", "expected_action="]
-        if marker not in approval_material
-    ]
-    if "authorized_sha=" not in approval_material and "authorized_run=" not in approval_material:
-        missing.append("authorized_sha= or authorized_run=")
-    if missing:
-        raise GhError("apply approval metadata missing: " + ", ".join(missing))
+
+    def packet_missing_markers(packet: str) -> list[str]:
+        missing = [
+            marker
+            for marker in ["approved_by=", "approved_at=", "expected_action="]
+            if marker not in packet
+        ]
+        if not pr_allowlist and "approval_scope=full_queue" not in packet:
+            missing.append("approval_scope=full_queue")
+        if "authorized_sha=" not in packet and "authorized_run=" not in packet:
+            missing.append("authorized_sha= or authorized_run=")
+        return missing
+
+    if not any(not packet_missing_markers(packet) for packet in packets):
+        unique_missing = sorted({marker for packet in packets for marker in packet_missing_markers(packet)})
+        raise GhError("apply approval metadata missing from one complete packet: " + ", ".join(unique_missing))
 
 
 def pr_files(repo: str, number: int) -> list[str]:

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -266,7 +266,7 @@ def parse_pr_allowlist(raw: str) -> set[tuple[str, int]]:
         return allowed
     tokens = [part.strip() for part in re.split(r"[\s,]+", raw) if part.strip()]
     for token in tokens:
-        match = re.search(r"github\.com/([^/]+/[^/]+)/pull/(\d+)$", token)
+        match = re.search(r"(?:https?://)?github\.com/([^/]+/[^/]+)/pull/(\d+)(?:[/?#].*)?$", token)
         if not match:
             match = re.search(r"^([^#\s]+/[^#\s]+)#(\d+)$", token)
         if not match:
@@ -932,7 +932,11 @@ def build_report(
 def build_slack_payload(report: dict[str, Any], status: str) -> dict[str, Any]:
     top_blockers = report.get("top_blocker_reasons") or []
     blocker_text = ", ".join(f"{item['reason']}={item['count']}" for item in top_blockers[:5]) or "none"
+    runtime_blockers = report.get("remaining_blockers") or []
+    if runtime_blockers:
+        blocker_text = ", ".join(str(item) for item in runtime_blockers[:5])
     workflow_url = report.get("workflow_url") or "not available"
+    error_line = f"\nError: `{report['error']}`" if report.get("error") else ""
     summary = (
         f"*ENT Dependabot Weekly Closeout* `{status}`\n"
         f"Mode: `{report.get('mode', 'unknown')}` | Repos: `{report.get('repos_scanned', 0)}`\n"
@@ -947,6 +951,7 @@ def build_slack_payload(report: dict[str, Any], status: str) -> dict[str, Any]:
         f"`{report.get('open_issues_total', 0)}` issues\n"
         f"Top blockers: {blocker_text}\n"
         f"Run: {workflow_url}"
+        f"{error_line}"
     )
     return {"text": summary}
 

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -1225,6 +1225,8 @@ def main() -> int:
         failure = {
             "ok": False,
             "final_verdict": "ENT_DEPENDABOT_WEEKLY_CLOSEOUT_BLOCKED",
+            "mode": args.mode,
+            "workflow_url": args.workflow_url,
             "generated_at": utc_now(),
             "error": str(exc),
             "slack_delivery": {"status": "not_requested"},

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -304,7 +304,11 @@ def validate_apply_approval(mode: str, pr_allowlist: set[tuple[str, int]], appro
         raise GhError("apply approval requires approval_note or approval_issue_url")
     if not pr_allowlist and "approval_scope=full_queue" not in approval_material:
         raise GhError("apply approval without pr_allowlist requires approval_scope=full_queue")
-    missing = [marker for marker in ["approved_by=", "approved_at="] if marker not in approval_material]
+    missing = [
+        marker
+        for marker in ["approved_by=", "approved_at=", "expected_action="]
+        if marker not in approval_material
+    ]
     if "authorized_sha=" not in approval_material and "authorized_run=" not in approval_material:
         missing.append("authorized_sha= or authorized_run=")
     if missing:

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -276,8 +276,12 @@ def parse_pr_allowlist(raw: str) -> set[tuple[str, int]]:
     return allowed
 
 
-def approval_packet_candidates(approval_note: str, approval_issue_url: str) -> list[str]:
-    candidates = [approval_note] if approval_note.strip() else []
+ApprovalPacket = tuple[str, str]
+
+
+def approval_packet_candidates(approval_note: str, approval_issue_url: str) -> list[ApprovalPacket]:
+    actor = os.environ.get("GITHUB_TRIGGERING_ACTOR") or os.environ.get("GITHUB_ACTOR") or ""
+    candidates: list[ApprovalPacket] = [(actor, approval_note)] if approval_note.strip() else []
     if not approval_issue_url:
         return candidates
     parsed = urlparse(approval_issue_url)
@@ -287,44 +291,80 @@ def approval_packet_candidates(approval_note: str, approval_issue_url: str) -> l
     if len(parts) < 4 or parts[2] not in {"issues", "pull"}:
         raise GhError("approval_issue_url must point to a GitHub issue or pull request")
     owner, repo, _, number = parts[:4]
+    repo_slug = f"{owner}/{repo}".lower()
+    trusted_repos = {
+        item.strip().lower()
+        for item in os.environ.get("ENT_DEPENDABOT_APPROVAL_REPOS", "merglbot-core/github,merglbot-public/docs").split(",")
+        if item.strip()
+    }
+    if repo_slug not in trusted_repos:
+        raise GhError(f"approval_issue_url must point to a trusted approval repo: {', '.join(sorted(trusted_repos))}")
     issue = gh_api_json(f"repos/{owner}/{repo}/issues/{number}")
     comments = gh_api_json(f"repos/{owner}/{repo}/issues/{number}/comments?per_page=100")
     issue_body = issue.get("body", "") or ""
+    issue_author = ((issue.get("user") or {}).get("login") or "").lower()
     if issue_body.strip():
-        candidates.append(issue_body)
-    candidates.extend(
-        comment.get("body", "") or ""
-        for comment in comments
-        if (comment.get("body", "") or "").strip()
-    )
+        candidates.append((issue_author, issue_body))
+    for comment in comments:
+        body = comment.get("body", "") or ""
+        if body.strip():
+            author = ((comment.get("user") or {}).get("login") or "").lower()
+            candidates.append((author, body))
     return candidates
+
+
+def parse_approval_packet_fields(packet: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for match in re.finditer(
+        r"(?im)(approved_by|approved_at|expected_action|approval_scope|authorized_sha|authorized_run)\s*=\s*`?([^`\s]+)",
+        packet,
+    ):
+        fields[match.group(1).lower()] = match.group(2).strip().strip("`")
+    return fields
 
 
 def validate_apply_approval(mode: str, pr_allowlist: set[tuple[str, int]], approval_note: str, approval_issue_url: str) -> None:
     if mode != "apply":
         return
-    packets = [packet.lower() for packet in approval_packet_candidates(approval_note, approval_issue_url)]
-    combined_material = "\n".join(packets)
+    packets = approval_packet_candidates(approval_note, approval_issue_url)
+    combined_material = "\n".join(packet.lower() for _, packet in packets)
     explicit_approval_lane = bool(pr_allowlist or approval_issue_url or "post_change_validation=true" in combined_material)
     if not explicit_approval_lane:
         return
     if not packets:
         raise GhError("apply approval requires approval_note or approval_issue_url")
 
-    def packet_missing_markers(packet: str) -> list[str]:
-        missing = [
-            marker
-            for marker in ["approved_by=", "approved_at=", "expected_action="]
-            if marker not in packet
-        ]
-        if not pr_allowlist and "approval_scope=full_queue" not in packet:
+    current_sha = os.environ.get("GITHUB_SHA", "").lower()
+    current_run = os.environ.get("GITHUB_RUN_ID", "")
+    trusted_approvers = {
+        item.strip().lower()
+        for item in os.environ.get("ENT_DEPENDABOT_TRUSTED_APPROVERS", "milhul6").split(",")
+        if item.strip()
+    }
+    trusted_approvers.update(
+        actor.lower()
+        for actor in [os.environ.get("GITHUB_ACTOR", ""), os.environ.get("GITHUB_TRIGGERING_ACTOR", "")]
+        if actor
+    )
+
+    def packet_missing_markers(author: str, packet: str) -> list[str]:
+        fields = parse_approval_packet_fields(packet)
+        missing = [marker for marker in ["approved_by", "approved_at", "expected_action"] if not fields.get(marker)]
+        approved_by = fields.get("approved_by", "").lower()
+        if not author or author.lower() not in trusted_approvers:
+            missing.append("trusted_author")
+        if approved_by and author and approved_by != author.lower():
+            missing.append("approved_by_matches_author")
+        if not pr_allowlist and fields.get("approval_scope", "").lower() != "full_queue":
             missing.append("approval_scope=full_queue")
-        if "authorized_sha=" not in packet and "authorized_run=" not in packet:
-            missing.append("authorized_sha= or authorized_run=")
+        sha_ok = bool(current_sha and fields.get("authorized_sha", "").lower() == current_sha)
+        run_ok = bool(current_run and fields.get("authorized_run", "") == current_run)
+        if not sha_ok and not run_ok:
+            missing.append("authorized_sha/current or authorized_run/current")
         return missing
 
-    if not any(not packet_missing_markers(packet) for packet in packets):
-        unique_missing = sorted({marker for packet in packets for marker in packet_missing_markers(packet)})
+    if not any(not packet_missing_markers(author, packet) for author, packet in packets):
+        unique_missing = sorted({marker for author, packet in packets for marker in packet_missing_markers(author, packet)})
         raise GhError("apply approval metadata missing from one complete packet: " + ", ".join(unique_missing))
 
 
@@ -1073,12 +1113,21 @@ def self_test() -> int:
         ("merglbot-core/github", 1),
         ("merglbot-public/docs", 2),
     }
-    validate_apply_approval(
-        "apply",
-        {("merglbot-core/github", 1)},
-        "post_change_validation=true approved_by=milhul6 approved_at=2026-04-12T21:00:00Z authorized_sha=abc expected_action=merge",
-        "",
-    )
+    previous_env = {key: os.environ.get(key) for key in ["GITHUB_SHA", "GITHUB_RUN_ID", "GITHUB_ACTOR"]}
+    os.environ.update({"GITHUB_SHA": "abc", "GITHUB_RUN_ID": "12345", "GITHUB_ACTOR": "milhul6"})
+    try:
+        validate_apply_approval(
+            "apply",
+            {("merglbot-core/github", 1)},
+            "post_change_validation=true approved_by=milhul6 approved_at=2026-04-12T21:00:00Z authorized_sha=abc expected_action=merge",
+            "",
+        )
+    finally:
+        for key, value in previous_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
     assert report["remaining_dependabot_prs"] == 1
     assert "MERGLBOT" not in close_comment(
         PullRequest("o/r", 1, "x", "u", "dependabot[bot]", "a" * 40, "main", "dependabot/x", False, "CLEAN", utc_now()),

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from urllib.request import Request, urlopen
 
 
@@ -276,19 +276,36 @@ def parse_pr_allowlist(raw: str) -> set[tuple[str, int]]:
     return allowed
 
 
+def fetch_approval_issue_material(approval_issue_url: str) -> str:
+    if not approval_issue_url:
+        return ""
+    parsed = urlparse(approval_issue_url)
+    if parsed.netloc != "github.com":
+        raise GhError("approval_issue_url must be a github.com issue or pull request URL")
+    parts = [part for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) < 4 or parts[2] not in {"issues", "pull"}:
+        raise GhError("approval_issue_url must point to a GitHub issue or pull request")
+    owner, repo, _, number = parts[:4]
+    issue = gh_api_json(f"repos/{owner}/{repo}/issues/{number}")
+    comments = gh_api_json(f"repos/{owner}/{repo}/issues/{number}/comments?per_page=100")
+    material = [issue.get("title", ""), issue.get("body", "") or ""]
+    material.extend(comment.get("body", "") or "" for comment in comments)
+    return "\n".join(material)
+
+
 def validate_apply_approval(mode: str, pr_allowlist: set[tuple[str, int]], approval_note: str, approval_issue_url: str) -> None:
     if mode != "apply":
         return
-    normalized = approval_note.lower()
-    explicit_approval_lane = bool(pr_allowlist or approval_issue_url or "post_change_validation=true" in normalized)
+    approval_material = "\n".join([approval_note, fetch_approval_issue_material(approval_issue_url)]).lower()
+    explicit_approval_lane = bool(pr_allowlist or approval_issue_url or "post_change_validation=true" in approval_material)
     if not explicit_approval_lane:
         return
     if not approval_note and not approval_issue_url:
         raise GhError("apply approval requires approval_note or approval_issue_url")
-    if not pr_allowlist and "approval_scope=full_queue" not in normalized:
+    if not pr_allowlist and "approval_scope=full_queue" not in approval_material:
         raise GhError("apply approval without pr_allowlist requires approval_scope=full_queue")
-    missing = [marker for marker in ["approved_by=", "approved_at="] if marker not in normalized]
-    if "authorized_sha=" not in normalized and "authorized_run=" not in normalized and not approval_issue_url:
+    missing = [marker for marker in ["approved_by=", "approved_at="] if marker not in approval_material]
+    if "authorized_sha=" not in approval_material and "authorized_run=" not in approval_material:
         missing.append("authorized_sha= or authorized_run=")
     if missing:
         raise GhError("apply approval metadata missing: " + ", ".join(missing))

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
+from urllib.request import Request, urlopen
 
 
 DEPENDABOT_LOGINS = {"dependabot[bot]", "app/dependabot"}
@@ -234,6 +235,44 @@ def list_dependabot_prs(repo: str) -> list[PullRequest]:
             )
         )
     return prs
+
+
+def list_open_prs(repo: str) -> list[dict[str, Any]]:
+    data = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,url,author,headRefOid,isDraft,mergeStateStatus,updatedAt",
+        ]
+    )
+    return list(data)
+
+
+def list_open_issues(repo: str) -> list[dict[str, Any]]:
+    data = gh_json(["issue", "list", "--repo", repo, "--state", "open", "--limit", "200", "--json", "number,title,url,author,updatedAt"])
+    return list(data)
+
+
+def parse_pr_allowlist(raw: str) -> set[tuple[str, int]]:
+    allowed: set[tuple[str, int]] = set()
+    if not raw.strip():
+        return allowed
+    tokens = [part.strip() for part in re.split(r"[\s,]+", raw) if part.strip()]
+    for token in tokens:
+        match = re.search(r"github\.com/([^/]+/[^/]+)/pull/(\d+)$", token)
+        if not match:
+            match = re.search(r"^([^#\s]+/[^#\s]+)#(\d+)$", token)
+        if not match:
+            raise GhError(f"invalid pr_allowlist token: {token}")
+        allowed.add((match.group(1), int(match.group(2))))
+    return allowed
 
 
 def pr_files(repo: str, number: int) -> list[str]:
@@ -626,17 +665,52 @@ def process_repo(
     max_prs_per_repo: int,
     allow_policy_alignment: bool,
     workflow_url: str,
+    pr_allowlist: set[tuple[str, int]],
 ) -> dict[str, Any]:
+    telemetry_warnings: list[str] = []
+    try:
+        open_prs = list_open_prs(repo)
+    except Exception as exc:
+        return {
+            "repo": repo,
+            "ok": False,
+            "open_prs_before": 0,
+            "open_issues_before": 0,
+            "dependabot_prs_before": 0,
+            "non_dependabot_prs_before": 0,
+            "merged": [],
+            "closed": [],
+            "blocked": [],
+            "would_merge": [],
+            "would_close": [],
+            "skipped_by_allowlist": [],
+            "warnings": [f"list_open_prs_failed:{exc}"],
+        }
+    try:
+        open_issues = list_open_issues(repo)
+    except Exception as exc:
+        open_issues = []
+        telemetry_warnings.append(f"list_open_issues_failed:{exc}")
+    open_dependabot_prs = [
+        item
+        for item in open_prs
+        if ((item.get("author") or {}).get("login") or "") in DEPENDABOT_LOGINS
+    ]
     repo_result: dict[str, Any] = {
         "repo": repo,
         "ok": True,
-        "dependabot_prs_before": 0,
+        "open_prs_before": len(open_prs),
+        "open_issues_before": len(open_issues),
+        "dependabot_prs_before": len(open_dependabot_prs),
+        "non_dependabot_prs_before": len(open_prs) - len(open_dependabot_prs),
         "merged": [],
         "closed": [],
         "blocked": [],
         "would_merge": [],
         "would_close": [],
+        "skipped_by_allowlist": [],
         "warnings": [],
+        "telemetry_warnings": telemetry_warnings,
     }
     processed = 0
     seen_without_action: set[int] = set()
@@ -657,6 +731,19 @@ def process_repo(
 
         took_action = False
         for pr in prs:
+            if pr_allowlist and (pr.repo, pr.number) not in pr_allowlist:
+                repo_result["skipped_by_allowlist"].append(
+                    {
+                        "repo": pr.repo,
+                        "pr_number": pr.number,
+                        "url": pr.url,
+                        "action": "skipped",
+                        "classification": "SKIPPED_NOT_IN_USER_APPROVED_ALLOWLIST",
+                        "head_sha": pr.head_sha,
+                    }
+                )
+                seen_without_action.add(pr.number)
+                continue
             if pr.number in seen_without_action:
                 continue
             try:
@@ -723,70 +810,163 @@ def post_tracking_report(tracking_issue: str, report: dict[str, Any], summary_ma
 def markdown_summary(report: dict[str, Any]) -> str:
     lines = [
         f"- Mode: `{report['mode']}`",
+        f"- Status: `{report['final_verdict']}`",
         f"- Repos scanned: `{report['repos_scanned']}`",
+        f"- Open PRs: `{report['open_prs_total']}` (`{report['open_dependabot_prs_total']}` Dependabot / `{report['open_non_dependabot_prs_total']}` non-Dependabot)",
+        f"- Open issues: `{report['open_issues_total']}`",
         f"- Dependabot PRs before: `{report['dependabot_prs_before']}`",
         f"- Merged: `{len(report['merged_prs'])}`",
         f"- Closed: `{len(report['closed_prs'])}`",
         f"- Blocked: `{len(report['blocked_prs'])}`",
+        f"- Telemetry warnings: `{len(report.get('telemetry_warnings', []))}`",
+        f"- Slack delivery: `{report.get('slack_delivery', {}).get('status', 'not_requested')}`",
         "",
-        "| Repo | Before | Merged | Closed | Blocked | Would merge | Would close |",
-        "|---|---:|---:|---:|---:|---:|---:|",
+        "| Repo | PRs | Dependabot | Non-Dependabot | Issues | Merged | Closed | Blocked | Would merge | Would close | Skipped |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for row in report["repo_table"]:
         lines.append(
-            "| {repo} | {before} | {merged} | {closed} | {blocked} | {would_merge} | {would_close} |".format(
+            "| {repo} | {open_prs} | {before} | {non_dependabot} | {issues} | {merged} | {closed} | {blocked} | {would_merge} | {would_close} | {skipped} |".format(
                 repo=row["repo"],
+                open_prs=row["open_prs_before"],
                 before=row["dependabot_prs_before"],
+                non_dependabot=row["non_dependabot_prs_before"],
+                issues=row["open_issues_before"],
                 merged=row["merged"],
                 closed=row["closed"],
                 blocked=row["blocked"],
                 would_merge=row["would_merge"],
                 would_close=row["would_close"],
+                skipped=row["skipped_by_allowlist"],
             )
         )
     return "\n".join(lines)
 
 
-def build_report(mode: str, repos: list[str], repo_results: list[dict[str, Any]], tracking_comment_url: str | None = None) -> dict[str, Any]:
+def blocker_summary(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    counts: dict[str, int] = {}
+    for item in items:
+        for blocker in item.get("blockers", []):
+            key = str(blocker).split(":", 1)[0]
+            counts[key] = counts.get(key, 0) + 1
+    return [{"reason": key, "count": value} for key, value in sorted(counts.items(), key=lambda pair: (-pair[1], pair[0]))[:10]]
+
+
+def build_report(
+    mode: str,
+    repos: list[str],
+    repo_results: list[dict[str, Any]],
+    *,
+    pr_allowlist: set[tuple[str, int]],
+    approval_note: str,
+    approval_issue_url: str,
+    workflow_url: str,
+    tracking_comment_url: str | None = None,
+) -> dict[str, Any]:
     merged = [item for result in repo_results for item in result.get("merged", [])]
     closed = [item for result in repo_results for item in result.get("closed", [])]
     blocked = [item for result in repo_results for item in result.get("blocked", [])]
     would_merge = [item for result in repo_results for item in result.get("would_merge", [])]
     would_close = [item for result in repo_results for item in result.get("would_close", [])]
+    skipped_by_allowlist = [item for result in repo_results for item in result.get("skipped_by_allowlist", [])]
     repo_table = [
         {
             "repo": result["repo"],
+            "open_prs_before": result["open_prs_before"],
+            "open_issues_before": result["open_issues_before"],
             "dependabot_prs_before": result["dependabot_prs_before"],
+            "non_dependabot_prs_before": result["non_dependabot_prs_before"],
             "merged": len(result.get("merged", [])),
             "closed": len(result.get("closed", [])),
             "blocked": len(result.get("blocked", [])),
             "would_merge": len(result.get("would_merge", [])),
             "would_close": len(result.get("would_close", [])),
+            "skipped_by_allowlist": len(result.get("skipped_by_allowlist", [])),
             "warnings": result.get("warnings", []),
+            "telemetry_warnings": result.get("telemetry_warnings", []),
         }
         for result in repo_results
     ]
+    open_prs_total = sum(row["open_prs_before"] for row in repo_table)
+    open_dependabot_prs_total = sum(row["dependabot_prs_before"] for row in repo_table)
     report = {
         "ok": True,
         "final_verdict": "ENT_DEPENDABOT_WEEKLY_CLOSEOUT_COMPLETE",
         "generated_at": utc_now(),
         "mode": mode,
+        "workflow_url": workflow_url,
         "repos_scanned": len(repos),
-        "dependabot_prs_before": sum(row["dependabot_prs_before"] for row in repo_table),
+        "open_prs_total": open_prs_total,
+        "open_dependabot_prs_total": open_dependabot_prs_total,
+        "open_non_dependabot_prs_total": open_prs_total - open_dependabot_prs_total,
+        "open_issues_total": sum(row["open_issues_before"] for row in repo_table),
+        "dependabot_prs_before": open_dependabot_prs_total,
         "merged_prs": merged,
         "closed_prs": closed,
         "blocked_prs": blocked,
         "would_merge_prs": would_merge,
         "would_close_prs": would_close,
-        "remaining_dependabot_prs": len(blocked) + (len(would_merge) if mode == "dry-run" else 0) + (len(would_close) if mode == "dry-run" else 0),
+        "skipped_by_allowlist_prs": skipped_by_allowlist,
+        "remaining_dependabot_prs": len(blocked)
+        + len(skipped_by_allowlist)
+        + (len(would_merge) if mode == "dry-run" else 0)
+        + (len(would_close) if mode == "dry-run" else 0),
+        "top_blocker_reasons": blocker_summary(blocked),
+        "approval": {
+            "pr_allowlist": [f"{repo}#{number}" for repo, number in sorted(pr_allowlist)],
+            "approval_note": approval_note,
+            "approval_issue_url": approval_issue_url,
+        },
+        "slack_delivery": {"status": "not_requested"},
         "repo_table": repo_table,
         "tracking_comment_url": tracking_comment_url,
+        "telemetry_warnings": [warning for result in repo_results for warning in result.get("telemetry_warnings", [])],
         "remaining_blockers": [warning for result in repo_results for warning in result.get("warnings", [])],
     }
     if report["remaining_blockers"]:
         report["ok"] = False
         report["final_verdict"] = "ENT_DEPENDABOT_WEEKLY_CLOSEOUT_BLOCKED"
     return report
+
+
+def build_slack_payload(report: dict[str, Any], status: str) -> dict[str, Any]:
+    top_blockers = report.get("top_blocker_reasons") or []
+    blocker_text = ", ".join(f"{item['reason']}={item['count']}" for item in top_blockers[:5]) or "none"
+    workflow_url = report.get("workflow_url") or "not available"
+    summary = (
+        f"*ENT Dependabot Weekly Closeout* `{status}`\n"
+        f"Mode: `{report.get('mode', 'unknown')}` | Repos: `{report.get('repos_scanned', 0)}`\n"
+        f"Dependabot PRs: `{report.get('dependabot_prs_before', 0)}` before, "
+        f"`{len(report.get('merged_prs', []))}` merged, "
+        f"`{len(report.get('closed_prs', []))}` closed, "
+        f"`{len(report.get('blocked_prs', []))}` blocked, "
+        f"`{report.get('remaining_dependabot_prs', 0)}` remaining\n"
+        f"Open backlog: `{report.get('open_prs_total', 0)}` PRs "
+        f"(`{report.get('open_dependabot_prs_total', 0)}` Dependabot / "
+        f"`{report.get('open_non_dependabot_prs_total', 0)}` non-Dependabot), "
+        f"`{report.get('open_issues_total', 0)}` issues\n"
+        f"Top blockers: {blocker_text}\n"
+        f"Run: {workflow_url}"
+    )
+    return {"text": summary}
+
+
+def post_slack_report(webhook_url: str, report: dict[str, Any]) -> dict[str, Any]:
+    if not webhook_url:
+        return {"status": "missing_webhook", "ok": False}
+    payload = build_slack_payload(report, "ok" if report.get("ok") else "blocked")
+    request = Request(
+        webhook_url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=15) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            return {"status": "sent", "ok": 200 <= response.status < 300, "http_status": response.status, "response": body[:120]}
+    except Exception as exc:
+        return {"status": "post_failed", "ok": False, "error": exc.__class__.__name__}
 
 
 def self_test() -> int:
@@ -809,7 +989,10 @@ def self_test() -> int:
             {
                 "repo": "merglbot-core/github",
                 "ok": True,
+                "open_prs_before": 2,
+                "open_issues_before": 3,
                 "dependabot_prs_before": 1,
+                "non_dependabot_prs_before": 1,
                 "merged": [],
                 "closed": [],
                 "blocked": [],
@@ -818,9 +1001,19 @@ def self_test() -> int:
                 "warnings": [],
             }
         ],
+        pr_allowlist=set(),
+        approval_note="",
+        approval_issue_url="",
+        workflow_url="https://github.com/o/r/actions/runs/1",
     )
     assert report["repos_scanned"] == 1
     assert report["dependabot_prs_before"] == 1
+    assert report["open_non_dependabot_prs_total"] == 1
+    assert build_slack_payload(report, "ok")["text"].count("Dependabot") >= 2
+    assert parse_pr_allowlist("merglbot-core/github#1 https://github.com/merglbot-public/docs/pull/2") == {
+        ("merglbot-core/github", 1),
+        ("merglbot-public/docs", 2),
+    }
     assert report["remaining_dependabot_prs"] == 1
     assert "MERGLBOT" not in close_comment(
         PullRequest("o/r", 1, "x", "u", "dependabot[bot]", "a" * 40, "main", "dependabot/x", False, "CLEAN", utc_now()),
@@ -845,6 +1038,11 @@ def main() -> int:
     parser.add_argument("--allow-policy-alignment", action="store_true")
     parser.add_argument("--comment-report", action="store_true")
     parser.add_argument("--tracking-issue", default="")
+    parser.add_argument("--slack-notify", action="store_true")
+    parser.add_argument("--slack-webhook-url", default=os.environ.get("SLACK_DEPENDABOT_WEBHOOK_URL", ""))
+    parser.add_argument("--pr-allowlist", default="")
+    parser.add_argument("--approval-note", default="")
+    parser.add_argument("--approval-issue-url", default="")
     parser.add_argument("--workflow-url", default=os.environ.get("GITHUB_SERVER_URL", "") + "/" + os.environ.get("GITHUB_REPOSITORY", "") + "/actions/runs/" + os.environ.get("GITHUB_RUN_ID", ""))
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
@@ -856,6 +1054,7 @@ def main() -> int:
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
     try:
+        pr_allowlist = parse_pr_allowlist(args.pr_allowlist)
         all_repos = load_repo_scope(args.scope_file)
         if args.repo_scope == "single_repo":
             if not args.single_repo:
@@ -884,9 +1083,24 @@ def main() -> int:
                     max_prs_per_repo=args.max_prs_per_repo,
                     allow_policy_alignment=args.allow_policy_alignment,
                     workflow_url=args.workflow_url,
+                    pr_allowlist=pr_allowlist,
                 )
             )
-        report = build_report(args.mode, repos, repo_results)
+        report = build_report(
+            args.mode,
+            repos,
+            repo_results,
+            pr_allowlist=pr_allowlist,
+            approval_note=args.approval_note,
+            approval_issue_url=args.approval_issue_url,
+            workflow_url=args.workflow_url,
+        )
+        if args.slack_notify:
+            report["slack_delivery"] = post_slack_report(args.slack_webhook_url, report)
+            if not report["slack_delivery"].get("ok"):
+                report["ok"] = False
+                report["final_verdict"] = "ENT_DEPENDABOT_WEEKLY_CLOSEOUT_BLOCKED"
+                report["remaining_blockers"].append(f"slack_delivery:{report['slack_delivery'].get('status')}")
         summary = markdown_summary(report)
         if args.comment_report and args.tracking_issue:
             report["tracking_comment_url"] = post_tracking_report(args.tracking_issue, report, summary)
@@ -901,8 +1115,11 @@ def main() -> int:
             "final_verdict": "ENT_DEPENDABOT_WEEKLY_CLOSEOUT_BLOCKED",
             "generated_at": utc_now(),
             "error": str(exc),
+            "slack_delivery": {"status": "not_requested"},
             "remaining_blockers": [str(exc)],
         }
+        if args.slack_notify:
+            failure["slack_delivery"] = post_slack_report(args.slack_webhook_url, failure)
         write_json(args.output_dir / "ent_dependabot_weekly_receipt.json", failure)
         print(json.dumps(failure, sort_keys=True))
         return 1


### PR DESCRIPTION
## Summary
- add Slack telemetry to the ENT Dependabot reusable closeout workflow
- add user-approved apply metadata inputs (`pr_allowlist`, approval notes) and receipt fields
- extend weekly receipt with Dependabot/non-Dependabot backlog segmentation, open issue totals, top blocker reasons, and Slack delivery status
- add fail-closed Slack delivery handling and fallback notification when the workflow crashes before writing a receipt

## Validation
- `python3 -m py_compile scripts/dependabot/ent_dependabot_closeout.py`
- `python3 scripts/dependabot/ent_dependabot_closeout.py --self-test`
- `actionlint .github/workflows/ent-dependabot-autonomous-closeout.yml .github/workflows/ent-dependabot-weekly.yml .github/workflows/ci.yml`
- `python3 scripts/dependabot/ent_dependabot_closeout.py --mode dry-run --repo-scope single_repo --single-repo merglbot-public/docs --output-dir tmp/ent-dependabot-slack-single --pr-allowlist 'merglbot-public/docs#999' --approval-note 'local no-write smoke'`
- `python3 scripts/dependabot/ent_dependabot_closeout.py --mode dry-run --repo-scope all --output-dir tmp/ent-dependabot-slack-full-dry-run`

Full dry-run result: 42 repos scanned, 117 Dependabot PRs, 140 non-Dependabot PRs, 183 open issues, 0 writes, 0 global blockers. One non-blocking telemetry warning: `merglbot-extractors/ruzovyslon-forecast-exporter` has issues disabled.

## Safety
- no Slack webhook value is logged or written to artifacts
- Slack delivery failure is reported in the receipt without hiding the GitHub Actions artifact truth
- apply still requires current-head Merglbot approval, required checks, optional Cursor no-current-head-bug signal, and exact-head squash merge
- no admin bypass, no direct main push, no Terraform/deploy/runtime mutation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds Slack webhook posting and new apply-mode approval/allowlist gates to an automated workflow that can merge/close PRs; mistakes could change what gets mutated or leak noisy telemetry, though the webhook secret is not logged and failures are best-effort.
> 
> **Overview**
> Adds **best-effort Slack telemetry** to the ENT Dependabot closeout run (new `slack_notify` input + `SLACK_DEPENDABOT_WEBHOOK_URL`), including a Slack fallback message if the workflow fails before writing the receipt.
> 
> Introduces **user-approved apply controls** via `pr_allowlist`, `approval_note`, and `approval_issue_url`: apply runs can be restricted to allowlisted PRs and can require a trusted, SHA/run-bound approval packet (parsed from the note or a trusted GitHub issue/comment) before proceeding.
> 
> Expands the weekly receipt/report with additional telemetry (open PR/issue totals, Dependabot vs non-Dependabot split, skipped-by-allowlist counts, top blocker reasons, telemetry warnings, and Slack delivery status), and wires the weekly caller to pass the new inputs/defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb83b15ca6995ed477cb951a4c3216fec887ef9e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->