### PR TITLE
docs: mirror Dependabot app merge permission

### DIFF
--- a/docs/ent-dependabot-github-app-setup.md
+++ b/docs/ent-dependabot-github-app-setup.md
@@ -42,10 +42,16 @@ Required:
 - `Actions`: read-only
 - `Checks`: read-only
 - `Commit statuses`: read-only
-- `Contents`: read-only
+- `Contents`: read and write
 - `Issues`: read and write
 - `Metadata`: read-only
 - `Pull requests`: read and write
+
+`Contents: read and write` is required for the merge-capable apply lane. Dry-run
+and close-only paths do not need contents writes, but the app identity must be
+able to perform an exact-head PR merge when all gates pass. Branch protection,
+required checks, Merglbot current-head review, Cursor/no-bug evidence, and
+`--match-head-commit` remain mandatory.
 
 Do not grant `Administration` for the first live apply. Branch protection or
 ruleset alignment must remain a separate, explicitly approved expansion.


### PR DESCRIPTION
## Summary

- mirror the canonical ENT Dependabot GitHub App setup permission update in `merglbot-core/github`
- document that `Contents: read and write` is needed for merge-capable apply runs
- keep the no-Administration first-apply boundary unchanged

## Validation

- `rg -n "Contents|merge-capable|match-head" docs/ent-dependabot-github-app-setup.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change, but it alters the recommended GitHub App permission set; risk is limited to operators potentially granting broader `Contents` access than before.
> 
> **Overview**
> Updates the ENT Dependabot GitHub App setup doc to require `Contents: read and write` (instead of read-only) so the merge-capable apply lane can perform exact-head PR merges.
> 
> Adds a short clarification that dry-run/close-only paths don’t need content writes, and reiterates the existing guardrails (no `Administration` on first apply, branch protection/required checks, and `--match-head-commit`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d76242e65b01a7263a3c0c0aebc3ab0d97d14bdb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->