### PR TITLE
Fix Dependabot closeout merge-state gating

### DIFF
--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -996,6 +996,10 @@ def process_pr(
             write_json(output_dir / "policy" / f"{pr.repo.replace('/', '__')}-failed.json", alignment)
             return receipt
         refreshed = refresh_pr(pr.repo, pr.number)
+        if refreshed.head_sha != receipt.head_sha:
+            receipt.blockers.append("head_changed_after_policy_alignment")
+            receipt.head_sha = refreshed.head_sha
+            return receipt
     elif refreshed.merge_state == MERGE_REVIEW_GATE_STATE:
         receipt.blockers.append("review_required_policy_alignment_disabled")
         return receipt

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -357,6 +357,15 @@ class ItemReceipt:
     post_merge: dict[str, Any] | None = None
 
 
+def reject_if_head_changed(receipt: ItemReceipt, refreshed: PullRequest, blocker: str) -> bool:
+    """Fail closed when a refreshed PR snapshot no longer matches reviewed head."""
+    if refreshed.head_sha == receipt.head_sha:
+        return False
+    receipt.blockers.append(blocker)
+    receipt.head_sha = refreshed.head_sha
+    return True
+
+
 def list_dependabot_prs(repo: str) -> list[PullRequest]:
     data = gh_json(
         [
@@ -983,9 +992,7 @@ def process_pr(
         return receipt
 
     refreshed = refresh_pr(pr.repo, pr.number)
-    if refreshed.head_sha != receipt.head_sha:
-        receipt.blockers.append("head_changed_after_review")
-        receipt.head_sha = refreshed.head_sha
+    if reject_if_head_changed(receipt, refreshed, "head_changed_after_review"):
         return receipt
 
     if refreshed.merge_state == MERGE_REVIEW_GATE_STATE and allow_policy_alignment:
@@ -996,9 +1003,7 @@ def process_pr(
             write_json(output_dir / "policy" / f"{pr.repo.replace('/', '__')}-failed.json", alignment)
             return receipt
         refreshed = refresh_pr(pr.repo, pr.number)
-        if refreshed.head_sha != receipt.head_sha:
-            receipt.blockers.append("head_changed_after_policy_alignment")
-            receipt.head_sha = refreshed.head_sha
+        if reject_if_head_changed(receipt, refreshed, "head_changed_after_policy_alignment"):
             return receipt
     elif refreshed.merge_state == MERGE_REVIEW_GATE_STATE:
         receipt.classification = "BLOCKED_MERGE_STATE"

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -1001,6 +1001,7 @@ def process_pr(
             receipt.head_sha = refreshed.head_sha
             return receipt
     elif refreshed.merge_state == MERGE_REVIEW_GATE_STATE:
+        receipt.classification = "BLOCKED_MERGE_STATE"
         receipt.blockers.append("review_required_policy_alignment_disabled")
         return receipt
 

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -36,6 +36,8 @@ REBASE_POLL_SECONDS = int(os.environ.get("ENT_DEPENDABOT_REBASE_POLL_SECONDS", "
 OPEN_ITEM_LIST_LIMIT = 1000
 APP_TOKEN_CACHE: dict[str, tuple[str, datetime]] = {}
 REPO_LOCAL_SCOPE_FILE = Path(__file__).with_name("ent_repository_scope.txt")
+MERGE_READY_STATES = {"CLEAN", "HAS_HOOKS"}
+MERGE_REVIEW_GATE_STATE = "REVIEW_REQUIRED"
 
 DEPENDENCY_FILE_PATTERNS = [
     re.compile(pattern)
@@ -986,15 +988,21 @@ def process_pr(
         receipt.head_sha = refreshed.head_sha
         return receipt
 
-    if refreshed.merge_state == "REVIEW_REQUIRED" and allow_policy_alignment:
+    if refreshed.merge_state == MERGE_REVIEW_GATE_STATE and allow_policy_alignment:
         alignment = align_review_gate(pr.repo, output_dir, apply=apply)
         receipt.evidence.append(f"policy_alignment={alignment.get('ok')}")
         if not alignment.get("ok"):
             receipt.blockers.extend([f"policy_alignment:{blocker}" for blocker in alignment.get("blockers", [])])
             write_json(output_dir / "policy" / f"{pr.repo.replace('/', '__')}-failed.json", alignment)
             return receipt
-    elif refreshed.merge_state == "REVIEW_REQUIRED":
+        refreshed = refresh_pr(pr.repo, pr.number)
+    elif refreshed.merge_state == MERGE_REVIEW_GATE_STATE:
         receipt.blockers.append("review_required_policy_alignment_disabled")
+        return receipt
+
+    if refreshed.merge_state not in MERGE_READY_STATES:
+        receipt.classification = "BLOCKED_MERGE_STATE"
+        receipt.blockers.append(f"merge_state:{refreshed.merge_state}")
         return receipt
 
     if not apply:
@@ -1354,6 +1362,8 @@ merglbot-core/agents-orchestrator
     assert classify_change_scope(["requirements-dev.txt"])[0] is True
     assert classify_change_scope([".github/workflows/ci.yml"])[0] is False
     assert classify_change_scope(["terraform/main.tf"])[0] is False
+    assert "DIRTY" not in MERGE_READY_STATES
+    assert MERGE_REVIEW_GATE_STATE not in MERGE_READY_STATES
     report = build_report(
         "dry-run",
         ["merglbot-core/github"],


### PR DESCRIPTION
## Summary

- block Dependabot closeout merge attempts when GitHub reports a non-mergeable state such as DIRTY/BLOCKED/UNKNOWN
- refresh merge state after any review-gate policy check before dry-run/action classification
- add self-test assertions so REVIEW_REQUIRED and DIRTY are not treated as merge-ready

## Verification

- `python3 -m py_compile scripts/dependabot/ent_dependabot_closeout.py`
- `python3 scripts/dependabot/ent_dependabot_closeout.py --self-test`

## Context

Post-merge dry-run of the dispatch/update-branch quickfix found `merglbot-core/platform#118` with green checks and current-head Merglbot receipt but `mergeStateStatus=DIRTY`. The engine incorrectly reported it as `would_merge`; this PR makes that fail closed as `BLOCKED_MERGE_STATE`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge eligibility logic for the autonomous Dependabot closeout, which could block or allow merges differently across repos if merge-state handling is incorrect.
> 
> **Overview**
> Tightens the Dependabot closeout merge decision to **fail closed** when GitHub reports a non-mergeable `mergeStateStatus` (only treating `CLEAN`/`HAS_HOOKS` as merge-ready), classifying others as `BLOCKED_MERGE_STATE`.
> 
> When encountering `REVIEW_REQUIRED`, the script now optionally runs policy alignment and then **re-refreshes** PR state before proceeding, preventing stale merge-state from being used for dry-run/action classification. Adds self-test assertions to ensure `DIRTY` and `REVIEW_REQUIRED` are not considered merge-ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27337c196a75957e2fa173c00f0fdcbc2c09c73. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->