### PR TITLE
Fail fast on terminal Dependabot Merglbot blockers

### DIFF
--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -42,6 +42,7 @@ APP_TOKEN_CACHE: dict[str, tuple[str, datetime]] = {}
 REPO_LOCAL_SCOPE_FILE = Path(__file__).with_name("ent_repository_scope.txt")
 MERGE_READY_STATES = {"CLEAN", "HAS_HOOKS"}
 MERGE_REVIEW_GATE_STATE = "REVIEW_REQUIRED"
+TERMINAL_MERGLBOT_REVIEW_BLOCKERS = {"review_not_approved_for_closeout"}
 DEFAULT_VALIDATOR_PROFILE = "maximum_autonomy_v2"
 VALIDATOR_PROFILES = {"strict_lockfile_v1", DEFAULT_VALIDATOR_PROFILE}
 PACKAGE_JSON_DEPENDENCY_KEYS = {
@@ -932,10 +933,14 @@ def is_current_head_merglbot_terminal_blocker(payload: dict[str, Any], head_sha:
     verdict = str(payload.get("verdict") or "").strip().lower()
     status = str(payload.get("status") or "").strip().lower()
     blockers = payload.get("blockers")
-    has_blockers = isinstance(blockers, list) and len(blockers) > 0
+    terminal_blockers = [
+        str(blocker)
+        for blocker in (blockers if isinstance(blockers, list) else [])
+        if str(blocker) in TERMINAL_MERGLBOT_REVIEW_BLOCKERS
+    ]
     if verdict in {"approved_for_closeout", "approved"} and status == "success":
         return False
-    return has_blockers or verdict in {"changes_required", "blocked", "needs_work"} or status in {"blocked", "failure"}
+    return bool(terminal_blockers) or verdict in {"changes_required", "blocked", "needs_work"} or status in {"blocked", "failure"}
 
 
 def find_merglbot_review_workflow(repo: str) -> dict[str, Any]:
@@ -1859,6 +1864,17 @@ merglbot-core/agents-orchestrator
             "verdict": "changes_required",
             "status": "blocked",
             "blockers": ["review_not_approved_for_closeout"],
+        },
+        "a" * 40,
+    ) is False
+    assert is_current_head_merglbot_terminal_blocker(
+        {
+            "ok": False,
+            "review_head_sha": "a" * 40,
+            "current_head_match": True,
+            "verdict": "pending",
+            "status": "pending",
+            "blockers": ["review_pending"],
         },
         "a" * 40,
     ) is False

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -921,6 +921,23 @@ def merglbot_dispatch_inputs(number: int, head_sha: str) -> dict[str, str]:
     }
 
 
+def is_current_head_merglbot_terminal_blocker(payload: dict[str, Any], head_sha: str) -> bool:
+    if payload.get("ok"):
+        return False
+    review_head = payload.get("review_head_sha") or payload.get("head_sha")
+    if review_head != head_sha:
+        return False
+    if payload.get("current_head_match") is False:
+        return False
+    verdict = str(payload.get("verdict") or "").strip().lower()
+    status = str(payload.get("status") or "").strip().lower()
+    blockers = payload.get("blockers")
+    has_blockers = isinstance(blockers, list) and len(blockers) > 0
+    if verdict in {"approved_for_closeout", "approved"} and status == "success":
+        return False
+    return has_blockers or verdict in {"changes_required", "blocked", "needs_work"} or status in {"blocked", "failure"}
+
+
 def find_merglbot_review_workflow(repo: str) -> dict[str, Any]:
     workflows = gh_api_json(repo_endpoint(repo, "actions/workflows?per_page=100"))
     for workflow in workflows.get("workflows", []):
@@ -982,6 +999,8 @@ def wait_for_merglbot(repo: str, number: int, head_ref: str, head_sha: str, *, a
     first = verify_merglbot(repo, number)
     if first.get("ok"):
         return first
+    if is_current_head_merglbot_terminal_blocker(first, head_sha):
+        return first
     if not apply:
         return first
     try:
@@ -1003,6 +1022,8 @@ def wait_for_merglbot(repo: str, number: int, head_ref: str, head_sha: str, *, a
         latest = verify_merglbot(repo, number)
         latest["dispatch"] = dispatch
         if latest.get("ok"):
+            return latest
+        if is_current_head_merglbot_terminal_blocker(latest, head_sha):
             return latest
     latest.setdefault("blockers", []).append("merglbot_review_poll_timeout")
     latest["dispatch"] = dispatch
@@ -1819,6 +1840,39 @@ merglbot-core/agents-orchestrator
         "diff_scope": "auto",
         "expected_head_sha": "a" * 40,
     }
+    assert is_current_head_merglbot_terminal_blocker(
+        {
+            "ok": False,
+            "review_head_sha": "a" * 40,
+            "current_head_match": True,
+            "verdict": "changes_required",
+            "status": "blocked",
+            "blockers": ["review_not_approved_for_closeout"],
+        },
+        "a" * 40,
+    ) is True
+    assert is_current_head_merglbot_terminal_blocker(
+        {
+            "ok": False,
+            "review_head_sha": "b" * 40,
+            "current_head_match": False,
+            "verdict": "changes_required",
+            "status": "blocked",
+            "blockers": ["review_not_approved_for_closeout"],
+        },
+        "a" * 40,
+    ) is False
+    assert is_current_head_merglbot_terminal_blocker(
+        {
+            "ok": True,
+            "review_head_sha": "a" * 40,
+            "current_head_match": True,
+            "verdict": "approved_for_closeout",
+            "status": "success",
+            "blockers": [],
+        },
+        "a" * 40,
+    ) is False
     assert request_update_branch("merglbot-core/github", 1, "b" * 40, apply=False)["blockers"] == ["update_branch_required"]
     assert validate_change_scope(
         "merglbot-core/github",

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -940,7 +940,7 @@ def is_current_head_merglbot_terminal_blocker(payload: dict[str, Any], head_sha:
     ]
     if verdict in {"approved_for_closeout", "approved"} and status == "success":
         return False
-    return bool(terminal_blockers) or verdict in {"changes_required", "blocked", "needs_work"} or status in {"blocked", "failure"}
+    return bool(terminal_blockers) or verdict in {"changes_required", "blocked", "needs_work"} or status in {"blocked", "failed"}
 
 
 def find_merglbot_review_workflow(repo: str) -> dict[str, Any]:
@@ -1878,6 +1878,17 @@ merglbot-core/agents-orchestrator
         },
         "a" * 40,
     ) is False
+    assert is_current_head_merglbot_terminal_blocker(
+        {
+            "ok": False,
+            "review_head_sha": "a" * 40,
+            "current_head_match": True,
+            "verdict": "",
+            "status": "failed",
+            "blockers": [],
+        },
+        "a" * 40,
+    ) is True
     assert is_current_head_merglbot_terminal_blocker(
         {
             "ok": True,


### PR DESCRIPTION
## Summary\n\n- stop polling when a current-head Merglbot receipt already contains a terminal blocker such as changes_required\n- keep stale/missing receipt behavior unchanged so apply still dispatches a fresh review\n- add self-test coverage for terminal blocker, stale mismatch, and approved receipt cases\n\n## Verification\n\n- python3 -m py_compile scripts/dependabot/ent_dependabot_closeout.py\n- python3 scripts/dependabot/ent_dependabot_closeout.py --self-test\n- git diff --check\n\n## Runtime context\n\nDuring the post-permission Dependabot apply smoke, GitHub App workflow_dispatch started working and created Merglbot run 24444669788 for merglbot-core/dataform#77. That PR returned a current-head changes_required receipt, but the engine would otherwise wait the full polling window. This PR makes that blocker immediate and auditable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Dependabot closeout automation to stop dispatching/polling Merglbot reviews when the current head already has a terminal blocked receipt, which could alter apply-lane behavior and reduce retries. Risk is limited to review orchestration flow and is covered by added self-tests.
> 
> **Overview**
> **Dependabot closeout now short-circuits on terminal Merglbot blockers.** A new `is_current_head_merglbot_terminal_blocker` helper detects when a non-OK Merglbot receipt for the *current* `head_sha` is already blocked (e.g., `changes_required`/`blocked`/`failure`) and returns immediately.
> 
> `wait_for_merglbot` uses this check to stop early both before dispatching a new workflow review and during polling, while keeping stale/mismatched receipts eligible for dispatch/retry. Self-test coverage is added for terminal-blocked, stale/mismatch, and approved receipt scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c94eb1be6fe2151added17dda458574df9d3aa4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->