### PR TITLE
Plan ENT Dependabot autonomous fix loops

### DIFF
--- a/.github/workflows/ent-dependabot-autonomous-closeout.yml
+++ b/.github/workflows/ent-dependabot-autonomous-closeout.yml
@@ -68,6 +68,31 @@ on:
         required: false
         type: string
         default: maximum_autonomy_v2
+      autonomous_fix_loop:
+        description: "Classify fixable Merglbot/Cursor/CI blockers as autonomous PR close-loop candidates instead of terminal blockers."
+        required: false
+        type: boolean
+        default: false
+      orchestrator_fix_handoff:
+        description: "Record that fix-loop candidates are intended for orchestrator per-PR close-loop handoff."
+        required: false
+        type: boolean
+        default: false
+      max_fix_iterations:
+        description: "Maximum same-branch fix iterations allowed by the orchestrator close-loop contract."
+        required: false
+        type: number
+        default: 5
+      max_review_iterations:
+        description: "Maximum review rerun iterations allowed by the orchestrator close-loop contract."
+        required: false
+        type: number
+        default: 5
+      fix_profile:
+        description: "Autonomous fix profile. dependabot_safe_v1 permits only same-branch dependency/workflow-ref scoped fixes."
+        required: false
+        type: string
+        default: dependabot_safe_v1
   workflow_dispatch:
     inputs:
       mode:
@@ -159,6 +184,11 @@ jobs:
           INPUT_APPROVAL_NOTE: ${{ inputs.approval_note || '' }}
           INPUT_APPROVAL_ISSUE_URL: ${{ inputs.approval_issue_url || '' }}
           INPUT_VALIDATOR_PROFILE: ${{ inputs.validator_profile || 'maximum_autonomy_v2' }}
+          INPUT_AUTONOMOUS_FIX_LOOP: ${{ inputs.autonomous_fix_loop && 'true' || 'false' }}
+          INPUT_ORCHESTRATOR_FIX_HANDOFF: ${{ inputs.orchestrator_fix_handoff && 'true' || 'false' }}
+          INPUT_MAX_FIX_ITERATIONS: ${{ inputs.max_fix_iterations || 5 }}
+          INPUT_MAX_REVIEW_ITERATIONS: ${{ inputs.max_review_iterations || 5 }}
+          INPUT_FIX_PROFILE: ${{ inputs.fix_profile || 'dependabot_safe_v1' }}
           ENT_DEPENDABOT_APP_ID: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
           ENT_DEPENDABOT_APP_PRIVATE_KEY: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
           SLACK_DEPENDABOT_WEBHOOK_URL: ${{ secrets.SLACK_DEPENDABOT_WEBHOOK_URL }}
@@ -182,6 +212,11 @@ jobs:
           APPROVAL_NOTE="$INPUT_APPROVAL_NOTE"
           APPROVAL_ISSUE_URL="$INPUT_APPROVAL_ISSUE_URL"
           VALIDATOR_PROFILE="$INPUT_VALIDATOR_PROFILE"
+          AUTONOMOUS_FIX_LOOP="$INPUT_AUTONOMOUS_FIX_LOOP"
+          ORCHESTRATOR_FIX_HANDOFF="$INPUT_ORCHESTRATOR_FIX_HANDOFF"
+          MAX_FIX_ITERATIONS="$INPUT_MAX_FIX_ITERATIONS"
+          MAX_REVIEW_ITERATIONS="$INPUT_MAX_REVIEW_ITERATIONS"
+          FIX_PROFILE="$INPUT_FIX_PROFILE"
 
           ARGS=(
             --mode "$MODE"
@@ -194,6 +229,9 @@ jobs:
             --approval-note "$APPROVAL_NOTE"
             --approval-issue-url "$APPROVAL_ISSUE_URL"
             --validator-profile "$VALIDATOR_PROFILE"
+            --max-fix-iterations "$MAX_FIX_ITERATIONS"
+            --max-review-iterations "$MAX_REVIEW_ITERATIONS"
+            --fix-profile "$FIX_PROFILE"
           )
 
           if [ -n "$SINGLE_REPO" ]; then
@@ -207,6 +245,12 @@ jobs:
           fi
           if [ "$SLACK_NOTIFY" = "true" ] && [ -n "${SLACK_DEPENDABOT_WEBHOOK_URL:-}" ]; then
             ARGS+=(--slack-notify)
+          fi
+          if [ "$AUTONOMOUS_FIX_LOOP" = "true" ]; then
+            ARGS+=(--autonomous-fix-loop)
+          fi
+          if [ "$ORCHESTRATOR_FIX_HANDOFF" = "true" ]; then
+            ARGS+=(--orchestrator-fix-handoff)
           fi
 
           mkdir -p reports/ent-dependabot-weekly

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1719,15 +1719,26 @@ jobs:
             local field_name="$1"
             awk -v field_name="$field_name" '
               BEGIN { IGNORECASE = 1; in_zaver = 0 }
-              /^##[[:space:]]+Zaver[[:space:]]*$/ { in_zaver = 1; next }
               /^##[[:space:]]+/ {
+                header = $0
+                gsub(/^[#[:space:]]+/, "", header)
+                gsub(/[*_`[:space:]]/, "", header)
+                if (tolower(header) == "zaver" || tolower(header) == "závěr") {
+                  in_zaver = 1
+                  next
+                }
                 if (in_zaver) {
                   exit
                 }
               }
-              in_zaver && tolower($0) ~ ("^" tolower(field_name) ":[[:space:]]*") {
-                print
-                exit
+              in_zaver {
+                line = $0
+                gsub(/^[[:space:]>-]*/, "", line)
+                gsub(/[*_`]/, "", line)
+                if (tolower(line) ~ ("^" tolower(field_name) ":[[:space:]]*")) {
+                  print line
+                  exit
+                }
               }
             ' final_review.txt 2>/dev/null || true
           }
@@ -1740,7 +1751,18 @@ jobs:
               printf '%s\n' "$zaver_line"
               return 0
             fi
-            grep -im1 "^${field_name}:" final_review.txt 2>/dev/null || true
+            awk -v field_name="$field_name" '
+              BEGIN { IGNORECASE = 1 }
+              {
+                line = $0
+                gsub(/^[[:space:]>-]*/, "", line)
+                gsub(/[*_`]/, "", line)
+                if (tolower(line) ~ ("^" tolower(field_name) ":[[:space:]]*")) {
+                  print line
+                  exit
+                }
+              }
+            ' final_review.txt 2>/dev/null || true
           }
 
           normalize_machine_token() {
@@ -2184,7 +2206,22 @@ jobs:
           LOW_COUNT=$(count_section_checkboxes "Low Priority")
           
           VERDICT="UNKNOWN"
-          VERDICT_LINE=$(grep -im1 '^Verdict:' final_review.txt 2>/dev/null || true)
+          extract_review_field_line() {
+            local field_name="$1"
+            awk -v field_name="$field_name" '
+              BEGIN { IGNORECASE = 1 }
+              {
+                line = $0
+                gsub(/^[[:space:]>-]*/, "", line)
+                gsub(/[*_`]/, "", line)
+                if (tolower(line) ~ ("^" tolower(field_name) ":[[:space:]]*")) {
+                  print line
+                  exit
+                }
+              }
+            ' final_review.txt 2>/dev/null || true
+          }
+          VERDICT_LINE=$(extract_review_field_line 'Verdict' || true)
           if [ -n "$VERDICT_LINE" ]; then
             VERDICT_VALUE_RAW=$(printf '%s' "$VERDICT_LINE" | sed -E 's/^Verdict:[[:space:]]*//I')
             VERDICT_VALUE_CLEAN="$(printf '%s' "$VERDICT_VALUE_RAW" | tr -d '\r' | tr '_' ' ' | sed -E 's/[`*]+//g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1734,7 +1734,7 @@ jobs:
               in_zaver {
                 line = $0
                 gsub(/^[[:space:]>-]*/, "", line)
-                gsub(/[*_`]/, "", line)
+                gsub(/[*`]/, "", line)
                 if (tolower(line) ~ ("^" tolower(field_name) ":[[:space:]]*")) {
                   print line
                   exit
@@ -1756,7 +1756,7 @@ jobs:
               {
                 line = $0
                 gsub(/^[[:space:]>-]*/, "", line)
-                gsub(/[*_`]/, "", line)
+                gsub(/[*`]/, "", line)
                 if (tolower(line) ~ ("^" tolower(field_name) ":[[:space:]]*")) {
                   print line
                   exit
@@ -2213,7 +2213,7 @@ jobs:
               {
                 line = $0
                 gsub(/^[[:space:]>-]*/, "", line)
-                gsub(/[*_`]/, "", line)
+                gsub(/[*`]/, "", line)
                 if (tolower(line) ~ ("^" tolower(field_name) ":[[:space:]]*")) {
                   print line
                   exit

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -65,6 +65,16 @@ Platform policy authority remains in `merglbot-public/docs`:
   `workflow_dispatch` on the PR head ref with `expected_head_sha`. The legacy
   `@merglbot review --light` comment path is not used by the ENT weekly apply
   lane because GitHub App comments do not carry a trusted author association.
+- When `autonomous_fix_loop=true`, current-head Merglbot `changes_required`,
+  Cursor blockers, and real CI failures are not treated as final closeout
+  blockers in dry-run. They are classified as `WOULD_START_AUTONOMOUS_FIX_LOOP`
+  or `WOULD_HEAL_REQUIRED_CHECKS` with a findings ledger and the expected
+  prompt-library close-loop contract. The write-capable fix loop is deliberately
+  a separate orchestrator lane: it may push only minimal commits to the existing
+  Dependabot branch, must rerun Merglbot/Cursor/current-head gates after every
+  new head, and may merge only through squash `--match-head-commit` after
+  post-fix approval. This follows `Autonomous PR Close-Loop v1` and
+  `MERGLBOT_PR_REVIEW_AUTONOMOUS_AUTOMERGE_V1`.
 - Behind PRs are updated through GitHub's pull request `update-branch` API with
   `expected_head_sha`. The lane no longer relies on `@dependabot rebase`
   comments, because Dependabot rejects that command from actors without push
@@ -135,6 +145,12 @@ is posted to the default tracking issue `merglbot-public/docs#636`. Reusable
 omitted, and can still override routing with an explicit `tracking_issue` value.
 Reusable callers may pass `validator_profile`; manual dispatch uses the default
 `maximum_autonomy_v2` profile to stay within GitHub's 10-input limit.
+Reusable callers may also enable `autonomous_fix_loop`,
+`orchestrator_fix_handoff`, `max_fix_iterations`, `max_review_iterations`, and
+`fix_profile=dependabot_safe_v1` when they want a planning receipt for the
+orchestrator PR close-loop waves. Those inputs are intentionally kept off manual
+`workflow_dispatch` to preserve GitHub's 10-input limit and do not by themselves
+perform semantic code edits inside GitHub Actions.
 
 ## Merge Gate
 
@@ -150,6 +166,11 @@ Every merged Dependabot PR must prove:
 - Cursor Bugbot has a current-head pass when available, or the receipt records
   that Cursor was absent/neutral/skipping and not required,
 - the merge uses squash with `--match-head-commit`.
+
+If a close-loop lane pushed a fix commit, the final merge gate must additionally
+prove that the newest Merglbot receipt covers the post-fix head and that the
+stale-findings ledger was closed by a new head or a documented false-positive
+rationale. Same-head "no new findings" is not sufficient.
 
 ## Policy Alignment
 

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -138,6 +138,7 @@ def fix_loop_control_errors(
     max_fix_iterations: int,
     max_review_iterations: int,
 ) -> list[str]:
+    """Return fail-closed configuration errors for the autonomous fix-loop lane."""
     errors: list[str] = []
     if not 1 <= max_fix_iterations <= MAX_FIX_LOOP_ITERATION_CAP:
         errors.append(f"--max-fix-iterations must be 1..{MAX_FIX_LOOP_ITERATION_CAP}")
@@ -1252,6 +1253,7 @@ def is_current_head_merglbot_terminal_blocker(payload: dict[str, Any], head_sha:
 
 
 def merglbot_findings_ledger(payload: dict[str, Any], head_sha: str) -> list[dict[str, Any]]:
+    """Build an audit ledger entry from the latest current-head Merglbot receipt."""
     blockers = payload.get("blockers")
     blocker_list = blockers if isinstance(blockers, list) else []
     return [
@@ -1269,6 +1271,7 @@ def merglbot_findings_ledger(payload: dict[str, Any], head_sha: str) -> list[dic
 
 
 def cursor_findings_ledger(status: str | None, head_sha: str | None) -> list[dict[str, Any]]:
+    """Build Cursor Bugbot ledger entries only when the current head is not clean."""
     if not status:
         return []
     if status in {"cursor_pass", "cursor_absent_not_required", "cursor_no_current_bug_signal"}:
@@ -1291,6 +1294,7 @@ def mark_fix_loop_candidate(
     max_fix_iterations: int,
     max_review_iterations: int,
 ) -> None:
+    """Mark a PR receipt as a safe candidate for the orchestrator fix loop."""
     receipt.action = "would_start_fix_loop"
     receipt.classification = classification
     receipt.would_start_fix_loop = True

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -51,6 +51,7 @@ MERGE_REVIEW_GATE_STATE = "REVIEW_REQUIRED"
 TERMINAL_MERGLBOT_REVIEW_BLOCKERS = {"review_not_approved_for_closeout"}
 DEFAULT_VALIDATOR_PROFILE = "maximum_autonomy_v2"
 VALIDATOR_PROFILES = {"strict_lockfile_v1", DEFAULT_VALIDATOR_PROFILE}
+MAX_FIX_LOOP_ITERATION_CAP = 10
 PACKAGE_JSON_DEPENDENCY_KEYS = {
     "dependencies",
     "devDependencies",
@@ -128,6 +129,23 @@ SENSITIVE_FILE_PATTERNS = [
 
 class GhError(RuntimeError):
     pass
+
+
+def fix_loop_control_errors(
+    *,
+    autonomous_fix_loop: bool,
+    orchestrator_fix_handoff: bool,
+    max_fix_iterations: int,
+    max_review_iterations: int,
+) -> list[str]:
+    errors: list[str] = []
+    if not 1 <= max_fix_iterations <= MAX_FIX_LOOP_ITERATION_CAP:
+        errors.append(f"--max-fix-iterations must be 1..{MAX_FIX_LOOP_ITERATION_CAP}")
+    if not 1 <= max_review_iterations <= MAX_FIX_LOOP_ITERATION_CAP:
+        errors.append(f"--max-review-iterations must be 1..{MAX_FIX_LOOP_ITERATION_CAP}")
+    if orchestrator_fix_handoff and not autonomous_fix_loop:
+        errors.append("--orchestrator-fix-handoff requires --autonomous-fix-loop")
+    return errors
 
 
 def utc_now() -> str:
@@ -2454,6 +2472,24 @@ merglbot-core/agents-orchestrator
     assert fix_receipt.action == "would_start_fix_loop"
     assert fix_receipt.would_start_fix_loop is True
     assert fix_receipt.terminal_close_loop_verdict == "PENDING_AUTONOMOUS_FIX_LOOP"
+    assert not fix_loop_control_errors(
+        autonomous_fix_loop=True,
+        orchestrator_fix_handoff=True,
+        max_fix_iterations=5,
+        max_review_iterations=5,
+    )
+    assert "--max-fix-iterations must be 1..10" in fix_loop_control_errors(
+        autonomous_fix_loop=True,
+        orchestrator_fix_handoff=True,
+        max_fix_iterations=999,
+        max_review_iterations=5,
+    )
+    assert "--orchestrator-fix-handoff requires --autonomous-fix-loop" in fix_loop_control_errors(
+        autonomous_fix_loop=False,
+        orchestrator_fix_handoff=True,
+        max_fix_iterations=5,
+        max_review_iterations=5,
+    )
     assert validate_change_scope(
         "merglbot-core/github",
         1,
@@ -2587,6 +2623,14 @@ def main() -> int:
         return self_test()
     if not args.mode:
         parser.error("--mode is required unless --self-test is used")
+    fix_loop_errors = fix_loop_control_errors(
+        autonomous_fix_loop=args.autonomous_fix_loop,
+        orchestrator_fix_handoff=args.orchestrator_fix_handoff,
+        max_fix_iterations=args.max_fix_iterations,
+        max_review_iterations=args.max_review_iterations,
+    )
+    if fix_loop_errors:
+        parser.error("; ".join(fix_loop_errors))
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
     try:

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -423,6 +423,15 @@ class ItemReceipt:
     superseded_by: str | None = None
     close_reopen_condition: str | None = None
     required_check_diagnostics: list[dict[str, Any]] = field(default_factory=list)
+    would_start_fix_loop: bool = False
+    would_heal_required_checks: bool = False
+    fix_iterations: int = 0
+    review_iterations: int = 0
+    fix_commits: list[str] = field(default_factory=list)
+    merglbot_findings_ledger: list[dict[str, Any]] = field(default_factory=list)
+    cursor_findings_ledger: list[dict[str, Any]] = field(default_factory=list)
+    ci_healing_actions: list[dict[str, Any]] = field(default_factory=list)
+    terminal_close_loop_verdict: str | None = None
 
 
 def reject_if_head_changed(receipt: ItemReceipt, refreshed: PullRequest, blocker: str) -> bool:
@@ -1098,6 +1107,57 @@ def required_checks(repo: str, number: int) -> tuple[bool, list[dict[str, Any]],
     return len(blockers) == 0, checks, blockers, diagnostics
 
 
+def required_check_healing_actions(diagnostics: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Map required-check diagnostics to the next safe autonomous action.
+
+    This function only plans actions. The actual write-capable close-loop lane
+    must re-read PR head/check truth immediately before rerunning checks or
+    pushing fixes.
+    """
+    actions: list[dict[str, Any]] = []
+    for item in diagnostics:
+        category = str(item.get("category") or "")
+        name = str(item.get("name") or "unknown")
+        reason = str(item.get("reason") or "")
+        if category in {
+            "stale_or_pending_analysis_context",
+            "stale_or_pending_security_context",
+            "pending_or_never_emits",
+            "skipped_analysis_context",
+            "skipped_or_neutral",
+        }:
+            actions.append(
+                {
+                    "check": name,
+                    "action": "diagnose_or_rerun_required_check",
+                    "category": category,
+                    "reason": reason,
+                    "requires_snapshot": True,
+                }
+            )
+        elif category == "check_failed_real":
+            actions.append(
+                {
+                    "check": name,
+                    "action": "start_minimal_pr_branch_fix_loop",
+                    "category": category,
+                    "reason": reason,
+                    "requires_same_pr_branch": True,
+                }
+            )
+        else:
+            actions.append(
+                {
+                    "check": name,
+                    "action": "classify_before_mutation",
+                    "category": category,
+                    "reason": reason,
+                    "fail_closed": True,
+                }
+            )
+    return actions
+
+
 def all_checks(repo: str, number: int) -> list[dict[str, Any]]:
     proc = run_cmd(
         [
@@ -1171,6 +1231,55 @@ def is_current_head_merglbot_terminal_blocker(payload: dict[str, Any], head_sha:
     if verdict in {"approved_for_closeout", "approved"} and status == "success":
         return False
     return bool(terminal_blockers) or verdict in {"changes_required", "blocked", "needs_work"} or status in {"blocked", "failed"}
+
+
+def merglbot_findings_ledger(payload: dict[str, Any], head_sha: str) -> list[dict[str, Any]]:
+    blockers = payload.get("blockers")
+    blocker_list = blockers if isinstance(blockers, list) else []
+    return [
+        {
+            "source": "merglbot",
+            "head_sha": head_sha,
+            "review_head_sha": payload.get("review_head_sha") or payload.get("head_sha"),
+            "verdict": payload.get("verdict"),
+            "status": payload.get("status"),
+            "comment_url": payload.get("comment_url"),
+            "blockers": [str(item) for item in blocker_list],
+            "next_action": "minimal_same_branch_fix_then_rerun_merglbot",
+        }
+    ]
+
+
+def cursor_findings_ledger(status: str | None, head_sha: str | None) -> list[dict[str, Any]]:
+    if not status:
+        return []
+    if status in {"cursor_pass", "cursor_absent_not_required", "cursor_no_current_bug_signal"}:
+        return []
+    return [
+        {
+            "source": "cursor",
+            "head_sha": head_sha,
+            "status": status,
+            "next_action": "minimal_same_branch_fix_then_rerun_cursor_or_recheck_current_head_summary",
+        }
+    ]
+
+
+def mark_fix_loop_candidate(
+    receipt: ItemReceipt,
+    *,
+    classification: str,
+    evidence: str,
+    max_fix_iterations: int,
+    max_review_iterations: int,
+) -> None:
+    receipt.action = "would_start_fix_loop"
+    receipt.classification = classification
+    receipt.would_start_fix_loop = True
+    receipt.terminal_close_loop_verdict = "PENDING_AUTONOMOUS_FIX_LOOP"
+    receipt.evidence.append(evidence)
+    receipt.evidence.append(f"max_fix_iterations={max_fix_iterations}")
+    receipt.evidence.append(f"max_review_iterations={max_review_iterations}")
 
 
 def find_merglbot_review_workflow(repo: str) -> dict[str, Any]:
@@ -1468,6 +1577,9 @@ def process_pr(
     workflow_url: str,
     validator_profile: str,
     sibling_prs: list[PullRequest],
+    autonomous_fix_loop: bool,
+    max_fix_iterations: int,
+    max_review_iterations: int,
 ) -> ItemReceipt:
     apply = mode == "apply"
     receipt = ItemReceipt(repo=pr.repo, pr_number=pr.number, url=pr.url, action="blocked", classification="BLOCKED", head_sha=pr.head_sha)
@@ -1531,6 +1643,25 @@ def process_pr(
     checks_ok, checks, check_blockers, check_diagnostics = required_checks(pr.repo, pr.number)
     receipt.required_check_diagnostics.extend(check_diagnostics)
     if not checks_ok:
+        receipt.ci_healing_actions.extend(required_check_healing_actions(check_diagnostics))
+        if not apply and autonomous_fix_loop:
+            receipt.would_heal_required_checks = True
+            if any(item.get("action") == "start_minimal_pr_branch_fix_loop" for item in receipt.ci_healing_actions):
+                mark_fix_loop_candidate(
+                    receipt,
+                    classification="WOULD_START_AUTONOMOUS_FIX_LOOP",
+                    evidence="Required checks include real failures; close-loop lane should apply a minimal same-branch fix and rerun gates.",
+                    max_fix_iterations=max_fix_iterations,
+                    max_review_iterations=max_review_iterations,
+                )
+            else:
+                receipt.action = "would_heal_required_checks"
+                receipt.classification = "WOULD_HEAL_REQUIRED_CHECKS"
+                receipt.terminal_close_loop_verdict = "PENDING_REQUIRED_CHECK_HEALING"
+                receipt.evidence.append("Required checks appear stale/pending/skipped; close-loop lane should rerun/diagnose before treating as a hard blocker.")
+            receipt.blockers.extend([f"required_check:{blocker}" for blocker in check_blockers])
+            receipt.evidence.append(f"required_checks={len(checks)}")
+            return receipt
         receipt.blockers.extend([f"required_check:{blocker}" for blocker in check_blockers])
         receipt.evidence.append(f"required_checks={len(checks)}")
         return receipt
@@ -1541,6 +1672,17 @@ def process_pr(
     if not merglbot.get("ok"):
         if not apply:
             if is_current_head_merglbot_terminal_blocker(merglbot, refreshed.head_sha):
+                receipt.merglbot_findings_ledger.extend(merglbot_findings_ledger(merglbot, refreshed.head_sha))
+                if autonomous_fix_loop:
+                    mark_fix_loop_candidate(
+                        receipt,
+                        classification="WOULD_START_AUTONOMOUS_FIX_LOOP",
+                        evidence="Merglbot current-head review is terminal and not approved; close-loop lane should apply a minimal same-branch fix and rerun Merglbot.",
+                        max_fix_iterations=max_fix_iterations,
+                        max_review_iterations=max_review_iterations,
+                    )
+                    receipt.blockers.extend([f"merglbot:{blocker}" for blocker in merglbot.get("blockers", [])])
+                    return receipt
                 receipt.classification = "BLOCKED_MERGLBOT_CHANGES_REQUIRED"
                 receipt.evidence.append("Merglbot current-head review is terminal and not approved for closeout")
                 receipt.blockers.extend([f"merglbot:{blocker}" for blocker in merglbot.get("blockers", [])])
@@ -1554,12 +1696,24 @@ def process_pr(
         if verdict in {"changes_required", "blocked", "needs_work"} or "review_not_approved_for_closeout" in [str(item) for item in merglbot.get("blockers", [])]:
             receipt.classification = "BLOCKED_MERGLBOT_CHANGES_REQUIRED"
             receipt.evidence.append("Merglbot current-head review returned changes_required or non-approved closeout verdict")
+            receipt.merglbot_findings_ledger.extend(merglbot_findings_ledger(merglbot, refreshed.head_sha))
         receipt.blockers.extend([f"merglbot:{blocker}" for blocker in merglbot.get("blockers", [])])
         return receipt
 
     cursor_ok, cursor = cursor_status(pr.repo, pr.number)
     receipt.cursor_status = cursor
     if not cursor_ok:
+        receipt.cursor_findings_ledger.extend(cursor_findings_ledger(cursor, refreshed.head_sha))
+        if not apply and autonomous_fix_loop:
+            mark_fix_loop_candidate(
+                receipt,
+                classification="WOULD_START_AUTONOMOUS_FIX_LOOP",
+                evidence="Cursor current-head signal is blocking; close-loop lane should apply a minimal same-branch fix and rerun/recheck Cursor.",
+                max_fix_iterations=max_fix_iterations,
+                max_review_iterations=max_review_iterations,
+            )
+            receipt.blockers.append(cursor)
+            return receipt
         receipt.blockers.append(cursor)
         return receipt
 
@@ -1614,6 +1768,9 @@ def process_repo(
     workflow_url: str,
     pr_allowlist: set[tuple[str, int]],
     validator_profile: str,
+    autonomous_fix_loop: bool,
+    max_fix_iterations: int,
+    max_review_iterations: int,
 ) -> dict[str, Any]:
     telemetry_warnings: list[str] = []
     try:
@@ -1633,6 +1790,8 @@ def process_repo(
             "would_close": [],
             "would_update_branch": [],
             "would_dispatch_review": [],
+            "would_start_fix_loop": [],
+            "would_heal_required_checks": [],
             "skipped_by_allowlist": [],
             "warnings": [f"list_open_prs_failed:{exc}"],
         }
@@ -1660,6 +1819,8 @@ def process_repo(
         "would_close": [],
         "would_update_branch": [],
         "would_dispatch_review": [],
+        "would_start_fix_loop": [],
+        "would_heal_required_checks": [],
         "skipped_by_allowlist": [],
         "warnings": [],
         "telemetry_warnings": telemetry_warnings,
@@ -1707,6 +1868,9 @@ def process_repo(
                     workflow_url=workflow_url,
                     validator_profile=validator_profile,
                     sibling_prs=prs,
+                    autonomous_fix_loop=autonomous_fix_loop,
+                    max_fix_iterations=max_fix_iterations,
+                    max_review_iterations=max_review_iterations,
                 )
             except GhError as exc:
                 receipt = ItemReceipt(
@@ -1736,6 +1900,10 @@ def process_repo(
                 repo_result["would_update_branch"].append(receipt.__dict__)
             elif key == "would_dispatch_review":
                 repo_result["would_dispatch_review"].append(receipt.__dict__)
+            elif key == "would_start_fix_loop":
+                repo_result["would_start_fix_loop"].append(receipt.__dict__)
+            elif key == "would_heal_required_checks":
+                repo_result["would_heal_required_checks"].append(receipt.__dict__)
             else:
                 repo_result["blocked"].append(receipt.__dict__)
             seen_without_action.add(pr.number)
@@ -1780,6 +1948,8 @@ def tracking_comment_receipt(report: dict[str, Any], *, minimal: bool = False) -
         "would_close_count": len(report.get("would_close_prs", [])),
         "would_update_branch_count": len(report.get("would_update_branch_prs", [])),
         "would_dispatch_review_count": len(report.get("would_dispatch_review_prs", [])),
+        "would_start_fix_loop_count": len(report.get("would_start_fix_loop_prs", [])),
+        "would_heal_required_checks_count": len(report.get("would_heal_required_checks_prs", [])),
         "remaining_dependabot_prs": report.get("remaining_dependabot_prs"),
         "top_blocker_reasons": report.get("top_blocker_reasons", [])[:TRACKING_RECEIPT_ITEM_LIMIT],
         "telemetry_warnings_count": len(report.get("telemetry_warnings", [])),
@@ -1870,15 +2040,17 @@ def markdown_summary(report: dict[str, Any]) -> str:
         f"- Blocked: `{len(report['blocked_prs'])}`",
         f"- Would update branch: `{len(report.get('would_update_branch_prs', []))}`",
         f"- Would dispatch Merglbot review: `{len(report.get('would_dispatch_review_prs', []))}`",
+        f"- Would start autonomous fix loop: `{len(report.get('would_start_fix_loop_prs', []))}`",
+        f"- Would heal required checks: `{len(report.get('would_heal_required_checks_prs', []))}`",
         f"- Telemetry warnings: `{len(report.get('telemetry_warnings', []))}`",
         f"- Slack delivery: `{report.get('slack_delivery', {}).get('status', 'not_requested')}`",
         "",
-        "| Repo | PRs | Dependabot | Non-Dependabot | Issues | Merged | Closed | Blocked | Would merge | Would close | Would update | Would review | Skipped |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| Repo | PRs | Dependabot | Non-Dependabot | Issues | Merged | Closed | Blocked | Would merge | Would close | Would update | Would review | Would fix | Would heal checks | Skipped |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for row in report["repo_table"]:
         lines.append(
-            "| {repo} | {open_prs} | {before} | {non_dependabot} | {issues} | {merged} | {closed} | {blocked} | {would_merge} | {would_close} | {would_update} | {would_review} | {skipped} |".format(
+            "| {repo} | {open_prs} | {before} | {non_dependabot} | {issues} | {merged} | {closed} | {blocked} | {would_merge} | {would_close} | {would_update} | {would_review} | {would_fix} | {would_heal_checks} | {skipped} |".format(
                 repo=row["repo"],
                 open_prs=row["open_prs_before"],
                 before=row["dependabot_prs_before"],
@@ -1891,6 +2063,8 @@ def markdown_summary(report: dict[str, Any]) -> str:
                 would_close=row["would_close"],
                 would_update=row.get("would_update_branch", 0),
                 would_review=row.get("would_dispatch_review", 0),
+                would_fix=row.get("would_start_fix_loop", 0),
+                would_heal_checks=row.get("would_heal_required_checks", 0),
                 skipped=row["skipped_by_allowlist"],
             )
         )
@@ -1925,6 +2099,8 @@ def build_report(
     would_close = [item for result in repo_results for item in result.get("would_close", [])]
     would_update_branch = [item for result in repo_results for item in result.get("would_update_branch", [])]
     would_dispatch_review = [item for result in repo_results for item in result.get("would_dispatch_review", [])]
+    would_start_fix_loop = [item for result in repo_results for item in result.get("would_start_fix_loop", [])]
+    would_heal_required_checks = [item for result in repo_results for item in result.get("would_heal_required_checks", [])]
     skipped_by_allowlist = [item for result in repo_results for item in result.get("skipped_by_allowlist", [])]
     repo_table = [
         {
@@ -1940,6 +2116,8 @@ def build_report(
             "would_close": len(result.get("would_close", [])),
             "would_update_branch": len(result.get("would_update_branch", [])),
             "would_dispatch_review": len(result.get("would_dispatch_review", [])),
+            "would_start_fix_loop": len(result.get("would_start_fix_loop", [])),
+            "would_heal_required_checks": len(result.get("would_heal_required_checks", [])),
             "skipped_by_allowlist": len(result.get("skipped_by_allowlist", [])),
             "warnings": result.get("warnings", []),
             "telemetry_warnings": result.get("telemetry_warnings", []),
@@ -1968,13 +2146,17 @@ def build_report(
         "would_close_prs": would_close,
         "would_update_branch_prs": would_update_branch,
         "would_dispatch_review_prs": would_dispatch_review,
+        "would_start_fix_loop_prs": would_start_fix_loop,
+        "would_heal_required_checks_prs": would_heal_required_checks,
         "skipped_by_allowlist_prs": skipped_by_allowlist,
         "remaining_dependabot_prs": len(blocked)
         + len(skipped_by_allowlist)
         + (len(would_merge) if mode == "dry-run" else 0)
         + (len(would_close) if mode == "dry-run" else 0)
         + (len(would_update_branch) if mode == "dry-run" else 0)
-        + (len(would_dispatch_review) if mode == "dry-run" else 0),
+        + (len(would_dispatch_review) if mode == "dry-run" else 0)
+        + (len(would_start_fix_loop) if mode == "dry-run" else 0)
+        + (len(would_heal_required_checks) if mode == "dry-run" else 0),
         "top_blocker_reasons": blocker_summary(blocked),
         "approval": {
             "pr_allowlist": [f"{repo}#{number}" for repo, number in sorted(pr_allowlist)],
@@ -2011,6 +2193,8 @@ def build_slack_payload(report: dict[str, Any], status: str) -> dict[str, Any]:
         f"`{len(report.get('blocked_prs', []))}` blocked, "
         f"`{len(report.get('would_update_branch_prs', []))}` would-update, "
         f"`{len(report.get('would_dispatch_review_prs', []))}` would-review, "
+        f"`{len(report.get('would_start_fix_loop_prs', []))}` would-fix, "
+        f"`{len(report.get('would_heal_required_checks_prs', []))}` would-heal-checks, "
         f"`{report.get('remaining_dependabot_prs', 0)}` remaining\n"
         f"Open backlog: `{report.get('open_prs_total', 0)}` PRs "
         f"(`{report.get('open_dependabot_prs_total', 0)}` Dependabot / "
@@ -2240,6 +2424,36 @@ merglbot-core/agents-orchestrator
     assert classify_required_check_blocker({"name": "Analyze (actions)", "bucket": "pending"})["category"] == "stale_or_pending_analysis_context"
     assert classify_required_check_blocker({"name": "ci", "bucket": "fail"})["category"] == "check_failed_real"
     assert classify_required_check_blocker({"name": "codeql / Analyze (javascript)", "bucket": "skipping"})["category"] == "skipped_analysis_context"
+    healing = required_check_healing_actions([
+        classify_required_check_blocker({"name": "ci", "bucket": "fail"}),
+        classify_required_check_blocker({"name": "Analyze (actions)", "bucket": "pending"}),
+    ])
+    assert healing[0]["action"] == "start_minimal_pr_branch_fix_loop"
+    assert healing[1]["action"] == "diagnose_or_rerun_required_check"
+    ledger = merglbot_findings_ledger(
+        {
+            "ok": False,
+            "review_head_sha": "a" * 40,
+            "current_head_match": True,
+            "verdict": "changes_required",
+            "status": "blocked",
+            "comment_url": "https://github.com/o/r/pull/1#issuecomment-1",
+            "blockers": ["review_not_approved_for_closeout"],
+        },
+        "a" * 40,
+    )
+    assert ledger[0]["next_action"] == "minimal_same_branch_fix_then_rerun_merglbot"
+    fix_receipt = ItemReceipt("o/r", 1, "u", "blocked", "BLOCKED", head_sha="a" * 40)
+    mark_fix_loop_candidate(
+        fix_receipt,
+        classification="WOULD_START_AUTONOMOUS_FIX_LOOP",
+        evidence="test",
+        max_fix_iterations=5,
+        max_review_iterations=5,
+    )
+    assert fix_receipt.action == "would_start_fix_loop"
+    assert fix_receipt.would_start_fix_loop is True
+    assert fix_receipt.terminal_close_loop_verdict == "PENDING_AUTONOMOUS_FIX_LOOP"
     assert validate_change_scope(
         "merglbot-core/github",
         1,
@@ -2360,6 +2574,11 @@ def main() -> int:
     parser.add_argument("--approval-note", default="")
     parser.add_argument("--approval-issue-url", default="")
     parser.add_argument("--validator-profile", choices=sorted(VALIDATOR_PROFILES), default=DEFAULT_VALIDATOR_PROFILE)
+    parser.add_argument("--autonomous-fix-loop", action="store_true")
+    parser.add_argument("--orchestrator-fix-handoff", action="store_true")
+    parser.add_argument("--max-fix-iterations", type=int, default=5)
+    parser.add_argument("--max-review-iterations", type=int, default=5)
+    parser.add_argument("--fix-profile", choices=["dependabot_safe_v1"], default="dependabot_safe_v1")
     parser.add_argument("--workflow-url", default=os.environ.get("GITHUB_SERVER_URL", "") + "/" + os.environ.get("GITHUB_REPOSITORY", "") + "/actions/runs/" + os.environ.get("GITHUB_RUN_ID", ""))
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
@@ -2411,6 +2630,9 @@ def main() -> int:
                         workflow_url=args.workflow_url,
                         pr_allowlist=pr_allowlist,
                         validator_profile=args.validator_profile,
+                        autonomous_fix_loop=args.autonomous_fix_loop,
+                        max_fix_iterations=args.max_fix_iterations,
+                        max_review_iterations=args.max_review_iterations,
                     )
                 )
         report = build_report(
@@ -2423,6 +2645,14 @@ def main() -> int:
             workflow_url=args.workflow_url,
             validator_profile=args.validator_profile,
         )
+        report["autonomous_fix_loop"] = {
+            "enabled": bool(args.autonomous_fix_loop),
+            "orchestrator_fix_handoff": bool(args.orchestrator_fix_handoff),
+            "fix_profile": args.fix_profile,
+            "max_fix_iterations": args.max_fix_iterations,
+            "max_review_iterations": args.max_review_iterations,
+            "contract": "Autonomous PR Close-Loop v1 + MERGLBOT_PR_REVIEW_AUTONOMOUS_AUTOMERGE_V1",
+        }
         if args.slack_notify:
             report["slack_delivery"] = post_slack_report(os.environ.get("SLACK_DEPENDABOT_WEBHOOK_URL", ""), report)
             if not report["slack_delivery"].get("ok"):


### PR DESCRIPTION
## Summary
- add reusable workflow inputs for autonomous fix-loop planning via workflow_call
- classify current-head Merglbot/Cursor/real CI blockers as fix-loop candidates in dry-run instead of terminal blockers
- add receipt fields for findings ledgers, CI healing actions, iteration caps, and close-loop verdicts
- document the prompt-library autonomous close-loop contract and exact-head merge requirements

## Verification
- python3 -m py_compile scripts/dependabot/ent_dependabot_closeout.py
- python3 scripts/dependabot/ent_dependabot_closeout.py --self-test
- actionlint .github/workflows/ent-dependabot-autonomous-closeout.yml
- dry-run single_repo merglbot-core/github with autonomous_fix_loop + handoff
- dry-run single_repo merglbot-core/fb-viz-api confirms PRs #58/#55 become WOULD_START_AUTONOMOUS_FIX_LOOP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dry-run classification and reporting for Dependabot PR blockers (CI/Merglbot/Cursor), which could alter operational decisions and downstream automation; no write-capable fixing is added in this PR.
> 
> **Overview**
> When enabled via new reusable-workflow inputs, the weekly closeout can *plan* an autonomous PR close-loop by classifying current-head **Merglbot `changes_required`**, **Cursor blockers**, and **required-check failures/drift** as `WOULD_START_AUTONOMOUS_FIX_LOOP` / `WOULD_HEAL_REQUIRED_CHECKS` in `dry-run` rather than treating them as terminal blockers.
> 
> The closeout receipt/report format is extended with fix-loop metadata (iteration caps, terminal close-loop verdict), per-signal findings ledgers (`merglbot_findings_ledger`, `cursor_findings_ledger`), and planned CI healing actions derived from required-check diagnostics; repo/run summaries and Slack telemetry now include the new would-fix / would-heal counts.
> 
> Docs and the reusable workflow (`workflow_call` only) are updated to describe and pass through the new inputs (`autonomous_fix_loop`, `orchestrator_fix_handoff`, `max_fix_iterations`, `max_review_iterations`, `fix_profile`) while keeping manual `workflow_dispatch` within GitHub’s 10-input limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a27af64c2c70de4cb362b546501e5330d1a686. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->