### PR TITLE
ci: restore beta binauthz attestation command

### DIFF
--- a/.github/workflows/reusable-build-attest.yml
+++ b/.github/workflows/reusable-build-attest.yml
@@ -308,6 +308,8 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        with:
+          install_components: beta
 
       - name: Create Binary Authorization Attestation
         id: attest
@@ -323,7 +325,7 @@ jobs:
           # sign-and-create does not reliably surface the occurrence name on stdout,
           # so only use a scoped list lookup when creation succeeded but stdout is empty.
           set +e
-          ATTESTATION_ID_RAW="$(gcloud container binauthz attestations sign-and-create \
+          ATTESTATION_ID_RAW="$(gcloud beta container binauthz attestations sign-and-create \
             --project=merglbot-artifacts \
             --artifact-url="$IMAGE_DIGEST" \
             --attestor="$ATTESTOR" \
@@ -343,7 +345,7 @@ jobs:
           fi
 
           if [ "$NEEDS_ATTESTATION_LIST" -eq 1 ]; then
-            ATTESTATION_ID_RAW="$(gcloud container binauthz attestations list \
+            ATTESTATION_ID_RAW="$(gcloud beta container binauthz attestations list \
               --project=merglbot-artifacts \
               --attestor="$ATTESTOR" \
               --artifact-url="$IMAGE_DIGEST" \


### PR DESCRIPTION
## Summary

Restores the beta Binary Authorization attestation path in `reusable-build-attest.yml`.

The AADC ads-analytics-sync image build on `merglbot-core/platform@a9cfc713f36c4b6a6221d537c0c13192a0a12005` succeeded through build, push, Trivy, SARIF, and provenance, but failed in the attestation job because the merged reusable workflow calls:

```bash
gcloud container binauthz attestations sign-and-create
```

Current gcloud exposes `sign-and-create` only under `gcloud beta container binauthz attestations`. The last known successful ads-analytics-sync image build used the beta component and beta command.

## What changed

- Install the `beta` gcloud component in the attestation job.
- Use `gcloud beta container binauthz attestations sign-and-create`.
- Use `gcloud beta container binauthz attestations list` for the already-scoped fallback path.
- Keep the current fail-closed behavior after failed `sign-and-create`; this does not bypass attestation.

## AADC autonomous-merge authorization receipt

- Program: Admin Ads Data Catalog v1 / AADC C08 closeout repair
- Exact repo/PR scope: `merglbot-core/github`, this PR only
- Authorization source: Milan Merglevsky, delegated program owner in the active AADC closeout thread
- Expiry: this AADC v1 closeout wave only; void after C08 terminal result or explicit revocation
- Revocation path: explicit user instruction in the active thread or orchestrator checkpoint
- Branch updates/rebases: allowed on this PR branch only when required for mergeability/current-head evidence
- Merge method: exact-head squash only, no `--admin`, no direct push, no branch-protection bypass
- Post-merge verification: verify PR state `MERGED`, base `main`, merge commit SHA, protected checks stable, then repin/retry the AADC ads-analytics-sync image workflow on the merged reusable workflow commit

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reusable-build-attest.yml"); puts "yaml ok"'`
- `git diff --check`
- `gcloud beta container binauthz attestations sign-and-create --help`

## Runtime evidence

- Failed platform image run: `https://github.com/merglbot-core/platform/actions/runs/24557838459`
- Failure: `gcloud.container.binauthz.attestations` has no `sign-and-create`; `gcloud beta container binauthz attestations sign-and-create` exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow command selection and component install, with fail-closed behavior preserved if attestation creation fails.
> 
> **Overview**
> Restores working Binary Authorization attestation creation in `.github/workflows/reusable-build-attest.yml` by installing the Cloud SDK `beta` component and invoking `gcloud beta container binauthz attestations sign-and-create`.
> 
> Updates the fallback lookup to use `gcloud beta ... attestations list` as well, keeping the existing fail-closed behavior when `sign-and-create` exits non-zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f46fc8202c0cb22db1a4f8616f8f412b72ce698. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->