### PR TITLE
feat(ent-scope): dynamic 100% ENT scope coverage for Dependabot closeout

### DIFF
--- a/.github/workflows/ent-dependabot-weekly.yml
+++ b/.github/workflows/ent-dependabot-weekly.yml
@@ -2,8 +2,10 @@ name: ENT Dependabot Weekly Closeout
 
 on:
   schedule:
-    # Sunday 13:00 UTC = 14:00 CET / 15:00 CEST for Europe/Prague.
-    - cron: "0 13 * * 0"
+    # Monday 07:30 UTC = 08:30 CET / 09:30 CEST for Europe/Prague.
+    # Scheduled 30 minutes after ent-scope-refresh.yml (Monday 07:00 UTC) so
+    # this run uses the freshest ent_repository_scope.txt SSOT file.
+    - cron: "30 7 * * 1"
   workflow_dispatch:
     inputs:
       mode:

--- a/.github/workflows/ent-scope-refresh.yml
+++ b/.github/workflows/ent-scope-refresh.yml
@@ -1,0 +1,187 @@
+name: ENT Scope Refresh (SSOT auto-regeneration)
+
+on:
+  # Weekly Monday 07:00 UTC = 09:00 CEST / 08:00 CET.
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print diffs but do not open PRs."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ent-scope-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh ENT scope files from ENT_ORG_ALLOWLIST.md
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      scope_json: ${{ steps.resolve.outputs.scope_json }}
+      repo_count: ${{ steps.resolve.outputs.repo_count }}
+      drift_detected: ${{ steps.diff.outputs.drift_detected }}
+    steps:
+      - name: Checkout merglbot-core/github (self)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Get installation token for merglbot-public (read docs)
+        id: public_token
+        uses: actions/create-github-app-token@9c4b0d96b0d11a3f2f9b27b5fa1e0e2e3bd16cd4  # v2.1.5 (SHA pin; bump via governance PR)
+        with:
+          app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
+          owner: merglbot-public
+          repositories: docs
+
+      - name: Fetch canonical ENT_ORG_ALLOWLIST.md from merglbot-public/docs@main
+        env:
+          GH_TOKEN: ${{ steps.public_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p .ent-scope
+          gh api /repos/merglbot-public/docs/contents/ENT_ORG_ALLOWLIST.md \
+            --jq '.content' | base64 -d > .ent-scope/ENT_ORG_ALLOWLIST.md
+          echo "Fetched ENT_ORG_ALLOWLIST.md $(wc -l < .ent-scope/ENT_ORG_ALLOWLIST.md) lines"
+
+      - name: Get app token for all allowlisted orgs (read-only repos:read)
+        id: all_orgs_token
+        uses: actions/create-github-app-token@9c4b0d96b0d11a3f2f9b27b5fa1e0e2e3bd16cd4  # v2.1.5
+        with:
+          app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
+          owner: merglbot-core
+
+      - name: Resolve ENT scope via API
+        id: resolve
+        env:
+          GH_TOKEN: ${{ steps.all_orgs_token.outputs.token }}
+          ALLOWLIST_FILE: ${{ github.workspace }}/.ent-scope/ENT_ORG_ALLOWLIST.md
+        run: |
+          set -euo pipefail
+          bash scripts/ent-scope/resolve-ent-scope.sh > .ent-scope/scope.json
+          repo_count=$(jq '.repo_count' .ent-scope/scope.json)
+          echo "repo_count=$repo_count" >> "$GITHUB_OUTPUT"
+          {
+            echo 'scope_json<<ENDSCOPE'
+            cat .ent-scope/scope.json
+            echo 'ENDSCOPE'
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved $repo_count repos"
+
+      - name: Regenerate downstream SSOT files
+        id: regen
+        env:
+          SCOPE_JSON: ${{ github.workspace }}/.ent-scope/scope.json
+        run: |
+          set -euo pipefail
+          # Regenerate ent_repository_scope.txt
+          python3 <<'PY'
+          import json, pathlib
+          scope = json.load(open('.ent-scope/scope.json'))
+          path = pathlib.Path('scripts/dependabot/ent_repository_scope.txt')
+          header = [
+              "# Repo-local mirror regenerated from merglbot-public/docs/ENT_ORG_ALLOWLIST.md",
+              "# by ent-scope-refresh.yml. DO NOT hand-edit; changes are overwritten weekly.",
+              "# Canonical scope source: merglbot-public/docs/ENT_ORG_ALLOWLIST.md + live org scan.",
+              "",
+          ]
+          repos = sorted(r['full_name'] for r in scope['repos'])
+          path.write_text("\n".join(header + repos) + "\n")
+          print(f"wrote {len(repos)} repos to {path}")
+          PY
+          # Regenerate target-repos.txt (excludes merglbot-core/github which deploy-v3.sh must not self-deploy)
+          python3 <<'PY'
+          import json, pathlib
+          scope = json.load(open('.ent-scope/scope.json'))
+          path = pathlib.Path('scripts/pr-assistant/target-repos.txt')
+          header = [
+              "# Platform scope (exclude Merglevsky-cz entirely).",
+              "# One repo per line. Regenerated weekly from merglbot-public/docs/ENT_ORG_ALLOWLIST.md",
+              "# via ent-scope-refresh.yml. DO NOT hand-edit; changes are overwritten.",
+              "# Used by:",
+              "# - deploy-v3.sh (copy PR Assistant workflow)",
+              "# - improvement digest (cross-repo metrics)",
+              "# Excludes merglbot-core/github (canonical workflow source; do not deploy copy into itself).",
+              "",
+          ]
+          repos = sorted(r['full_name'] for r in scope['repos'] if r['full_name'] != 'merglbot-core/github')
+          path.write_text("\n".join(header + repos) + "\n")
+          print(f"wrote {len(repos)} repos to {path}")
+          PY
+
+      - name: Detect drift + upload artifact
+        id: diff
+        run: |
+          set -euo pipefail
+          if git diff --quiet scripts/dependabot/ent_repository_scope.txt scripts/pr-assistant/target-repos.txt; then
+            echo "drift_detected=false" >> "$GITHUB_OUTPUT"
+            echo "No drift; SSOT files already current."
+          else
+            echo "drift_detected=true" >> "$GITHUB_OUTPUT"
+            echo "Drift detected in SSOT files:"
+            git --no-pager diff --stat scripts/dependabot/ent_repository_scope.txt scripts/pr-assistant/target-repos.txt
+          fi
+
+      - name: Upload scope artifact
+        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8  # v5.0.0
+        with:
+          name: ent-scope
+          path: .ent-scope/
+          retention-days: 90
+
+      - name: Open PR if drift detected (not dry-run)
+        if: steps.diff.outputs.drift_detected == 'true' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ steps.all_orgs_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          branch="merglbot/ent-scope-refresh-$(date -u +%Y%m%dT%H%M%SZ)"
+          git config user.email "merglbot-ent-dependabot-closeout[bot]@users.noreply.github.com"
+          git config user.name "merglbot-ent-dependabot-closeout[bot]"
+          git checkout -b "$branch"
+          git add scripts/dependabot/ent_repository_scope.txt scripts/pr-assistant/target-repos.txt
+          git commit -m "chore(ent-scope): weekly regeneration of scope SSOT files
+
+          Auto-regenerated by ent-scope-refresh.yml from merglbot-public/docs/ENT_ORG_ALLOWLIST.md
+          via resolve-ent-scope.sh. Includes all non-archived, non-fork repositories in the 12
+          allowed merglbot-* orgs (total: $(jq '.repo_count' .ent-scope/scope.json) repos).
+
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          git push -u origin "$branch"
+          gh pr create --repo "${{ github.repository }}" --head "$branch" --title "chore(ent-scope): weekly SSOT regeneration" \
+            --body "Auto-generated by [ent-scope-refresh.yml](.github/workflows/ent-scope-refresh.yml) run [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Regenerates \`scripts/dependabot/ent_repository_scope.txt\` and \`scripts/pr-assistant/target-repos.txt\` from [ENT_ORG_ALLOWLIST.md](https://github.com/merglbot-public/docs/blob/main/ENT_ORG_ALLOWLIST.md) + live org scan. Merges autonomously via standard close-loop if CI green."
+
+      - name: Verify App installation on every allowed org
+        env:
+          GH_TOKEN: ${{ steps.all_orgs_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          missing=0
+          jq -r '.allowed_orgs[]' .ent-scope/scope.json | while read -r org; do
+            installations=$(gh api "/orgs/$org/installations" --jq '.installations[] | select(.app_slug=="merglbot-ent-dependabot-closeout") | {id, repo: .repository_selection}' 2>/dev/null || true)
+            if [[ -z "$installations" ]]; then
+              echo "::warning ::$org does not have merglbot-ent-dependabot-closeout installed. Human action required: install App via GitHub UI with Repository access=All."
+              missing=$((missing + 1))
+              continue
+            fi
+            sel=$(echo "$installations" | jq -r '.repo')
+            if [[ "$sel" != "all" ]]; then
+              echo "::warning ::$org App installation is '$sel' (should be 'all'). Human action required: update scope in App settings."
+              missing=$((missing + 1))
+              continue
+            fi
+            echo "  $org: ✅ App installed with repository_selection=all"
+          done
+          if [[ "$missing" -gt 0 ]]; then
+            echo "::warning ::$missing org(s) need human-action remediation; see above."
+          fi

--- a/.github/workflows/pr-assistant-auto-deploy.yml
+++ b/.github/workflows/pr-assistant-auto-deploy.yml
@@ -1,0 +1,140 @@
+name: PR Assistant Auto-Deploy (new-repo enrollment)
+
+on:
+  workflow_run:
+    workflows: [ENT Scope Refresh (SSOT auto-regeneration)]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print target repos but do not open PRs."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-assistant-auto-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Auto-deploy PR Assistant workflow to newly-enrolled repos
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout merglbot-core/github (self)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Get installation token (all allowed orgs)
+        id: app_token
+        uses: actions/create-github-app-token@9c4b0d96b0d11a3f2f9b27b5fa1e0e2e3bd16cd4  # v2.1.5
+        with:
+          app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
+          owner: merglbot-core
+
+      - name: Fetch canonical ENT_ORG_ALLOWLIST.md
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p .ent-scope
+          gh api /repos/merglbot-public/docs/contents/ENT_ORG_ALLOWLIST.md --jq '.content' | base64 -d > .ent-scope/ENT_ORG_ALLOWLIST.md
+
+      - name: Resolve ENT scope
+        id: resolve
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          ALLOWLIST_FILE: ${{ github.workspace }}/.ent-scope/ENT_ORG_ALLOWLIST.md
+        run: |
+          set -euo pipefail
+          bash scripts/ent-scope/resolve-ent-scope.sh > .ent-scope/scope.json
+          echo "repo_count=$(jq '.repo_count' .ent-scope/scope.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Identify repos missing PR Assistant workflow
+        id: missing
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          > /tmp/missing_repos.txt
+          jq -r '.repos[].full_name' .ent-scope/scope.json | while read -r repo; do
+            if [[ "$repo" == "merglbot-core/github" ]]; then
+              continue
+            fi
+            # Check if target repo has .github/workflows/merglbot-pr-v3-on-demand.yml
+            if gh api "/repos/$repo/contents/.github/workflows/merglbot-pr-v3-on-demand.yml" --jq '.sha' 2>/dev/null >/dev/null; then
+              continue
+            fi
+            echo "$repo" >> /tmp/missing_repos.txt
+          done
+          count=$(wc -l < /tmp/missing_repos.txt | xargs)
+          echo "missing_count=$count" >> "$GITHUB_OUTPUT"
+          if [[ "$count" -gt 0 ]]; then
+            echo "Repos missing PR Assistant workflow ($count):"
+            cat /tmp/missing_repos.txt
+          else
+            echo "All in-scope repos already have PR Assistant workflow."
+          fi
+
+      - name: Open per-repo PRs adding PR Assistant workflow
+        if: steps.missing.outputs.missing_count != '0' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # Canonical source files from this repo
+          src_wf=".github/workflows/merglbot-pr-assistant-v3-on-demand.yml"
+          src_script="scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh"
+
+          if [[ ! -f "$src_wf" ]]; then
+            echo "::error ::Canonical PR Assistant workflow not found at $src_wf"
+            exit 1
+          fi
+
+          while read -r repo; do
+            [[ -z "$repo" ]] && continue
+            echo "=== $repo ==="
+            tmp=$(mktemp -d)
+            git clone --depth=1 "https://x-access-token:${GH_TOKEN}@github.com/${repo}.git" "$tmp/repo" 2>&1 | tail -3
+            pushd "$tmp/repo" >/dev/null
+            git config user.email "merglbot-ent-dependabot-closeout[bot]@users.noreply.github.com"
+            git config user.name "merglbot-ent-dependabot-closeout[bot]"
+            branch="merglbot/pr-assistant-v3-auto-deploy"
+            git checkout -b "$branch"
+            mkdir -p .github/workflows scripts/pr-assistant
+            cp "${GITHUB_WORKSPACE}/${src_wf}" .github/workflows/merglbot-pr-v3-on-demand.yml
+            if [[ -f "${GITHUB_WORKSPACE}/${src_script}" ]]; then
+              cp "${GITHUB_WORKSPACE}/${src_script}" scripts/pr-assistant/
+              chmod +x scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+            fi
+            git add .github/workflows/merglbot-pr-v3-on-demand.yml scripts/pr-assistant/ 2>/dev/null || true
+            if git --no-pager diff --cached --quiet; then
+              echo "  nothing to commit (already up to date)"
+              popd >/dev/null
+              rm -rf "$tmp"
+              continue
+            fi
+            git commit -m "ci: add merglbot PR Assistant v3 workflow (auto-deploy)
+
+            Automatically added by ent-scope-refresh.yml → pr-assistant-auto-deploy.yml.
+            Enables @merglbot review dispatch on this repo as part of the dynamic 100% ENT
+            scope coverage program. See merglbot-public/docs/ENT_ORG_ALLOWLIST.md §4.2.
+
+            Deploy source: merglbot-core/github@${{ github.sha }}
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            git push -u origin "$branch" 2>&1 | tail -3
+            gh pr create --repo "$repo" --head "$branch" \
+              --title "ci: add merglbot PR Assistant v3 workflow (auto-deploy)" \
+              --body "Automatically opened by [pr-assistant-auto-deploy.yml](https://github.com/merglbot-core/github/blob/main/.github/workflows/pr-assistant-auto-deploy.yml) run [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) as part of the dynamic ENT scope enrollment per [ENT_ORG_ALLOWLIST.md §4.2](https://github.com/merglbot-public/docs/blob/main/ENT_ORG_ALLOWLIST.md). Merges autonomously via standard close-loop once CI passes." \
+              2>&1 | tail -3 || echo "  PR create may have failed (already exists?)"
+            popd >/dev/null
+            rm -rf "$tmp"
+          done < /tmp/missing_repos.txt

--- a/scripts/dependabot/ent_repository_scope.txt
+++ b/scripts/dependabot/ent_repository_scope.txt
@@ -18,6 +18,7 @@ merglbot-core/tf-modules-
 merglbot-denatura/denatura-fb-viz
 merglbot-denatura/marketing-planning
 merglbot-denatura/marketing_actions_detector
+merglbot-extractors/abra-flexi-extractor
 merglbot-extractors/denatura-additional-costs-extractor
 merglbot-extractors/denatura-shoptet-export-extractor
 merglbot-extractors/facebook-extractor

--- a/scripts/ent-scope/resolve-ent-scope.sh
+++ b/scripts/ent-scope/resolve-ent-scope.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# resolve-ent-scope.sh — dynamic ENT repository scope resolver.
+#
+# Reads the canonical org allowlist from
+#   merglbot-public/docs/ENT_ORG_ALLOWLIST.md (§1 table, first column contains org slugs)
+# then enumerates all non-archived, non-fork repositories in each allowed org via the
+# GitHub REST API, applies per-repo exclusions, and prints a canonical JSON scope.
+#
+# Requires:
+#   - gh CLI authenticated with a token that can `gh api /orgs/<org>/repos` for every
+#     allowlisted org. In GitHub Actions this must be the
+#     merglbot-ent-dependabot-closeout App installation token (never a PAT).
+#
+# Outputs (stdout): one JSON object with the shape:
+#   {
+#     "generated_at": "<iso8601>",
+#     "allowed_orgs": [ "merglbot-*", ... ],
+#     "excluded_orgs": [ "Merglevsky-cz" ],
+#     "excluded_repos": [ "merglbot-core/github", ... ],
+#     "repos": [ { "full_name", "org", "name", "tier", "default_branch", "archived", "fork" }, ... ]
+#   }
+#
+# Exit codes:
+#   0 — success
+#   1 — missing allowlist file
+#   2 — missing org table in allowlist
+#   3 — github api error for one or more orgs (partial output still written to stdout)
+set -euo pipefail
+
+ALLOWLIST_FILE="${ALLOWLIST_FILE:-}"
+if [[ -z "$ALLOWLIST_FILE" ]]; then
+  # Resolve relative to caller's context
+  for candidate in \
+    "$(pwd)/ENT_ORG_ALLOWLIST.md" \
+    "$(pwd)/../merglbot-public-docs/ENT_ORG_ALLOWLIST.md" \
+    "$(pwd)/merglbot-public-docs/ENT_ORG_ALLOWLIST.md" \
+    "$(pwd)/docs/ENT_ORG_ALLOWLIST.md"; do
+    if [[ -f "$candidate" ]]; then
+      ALLOWLIST_FILE="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$ALLOWLIST_FILE" || ! -f "$ALLOWLIST_FILE" ]]; then
+  echo "ERR: cannot find ENT_ORG_ALLOWLIST.md (set ALLOWLIST_FILE env or run from a checkout that contains it)" >&2
+  exit 1
+fi
+
+# Parse §1 allowed orgs table (first column backtick-wrapped or bare)
+allowed_orgs=()
+in_section=0
+while IFS= read -r line; do
+  if [[ "$line" =~ ^##[[:space:]]*1\.[[:space:]]*Allowed ]]; then
+    in_section=1
+    continue
+  fi
+  if [[ "$in_section" -eq 1 && "$line" =~ ^##[[:space:]] ]]; then
+    break
+  fi
+  if [[ "$in_section" -eq 1 && "$line" =~ ^\|[[:space:]]*\`?(merglbot-[a-z0-9_-]+)\`? ]]; then
+    allowed_orgs+=("${BASH_REMATCH[1]}")
+  fi
+done < "$ALLOWLIST_FILE"
+
+if [[ "${#allowed_orgs[@]}" -eq 0 ]]; then
+  echo "ERR: could not extract any allowed orgs from $ALLOWLIST_FILE §1" >&2
+  exit 2
+fi
+
+# Parse §3 per-repo exclusions
+excluded_repos=()
+in_ex=0
+while IFS= read -r line; do
+  if [[ "$line" =~ ^##[[:space:]]*3\.[[:space:]]*Per-repo ]]; then
+    in_ex=1
+    continue
+  fi
+  if [[ "$in_ex" -eq 1 && "$line" =~ ^##[[:space:]] ]]; then
+    break
+  fi
+  if [[ "$in_ex" -eq 1 && "$line" =~ ^\|[[:space:]]*\`(merglbot-[a-z0-9_/-]+)\` ]]; then
+    excluded_repos+=("${BASH_REMATCH[1]}")
+  fi
+done < "$ALLOWLIST_FILE"
+
+tier_for_repo() {
+  local org="$1"
+  case "$org" in
+    merglbot-milan-private) echo "personal_experimental" ;;
+    *) echo "ent_production" ;;
+  esac
+}
+
+generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+repos_json='[]'
+any_fail=0
+
+for org in "${allowed_orgs[@]}"; do
+  # Fetch all repos, filter archived + fork
+  resp=$(gh api "/orgs/$org/repos?per_page=100" --paginate 2>/dev/null || true)
+  if [[ -z "$resp" || "$resp" == "null" ]]; then
+    echo "WARN: could not list repos for $org (org empty or api error)" >&2
+    any_fail=1
+    continue
+  fi
+  repos_json=$(jq --argjson existing "$repos_json" --arg org "$org" --arg tier "$(tier_for_repo "$org")" --argjson excluded "$(printf '%s\n' "${excluded_repos[@]:-}" | jq -R . | jq -s .)" '
+    [. + $existing | .[] ]  # merge
+    | unique_by(.full_name // (.org + "/" + .name))
+  ' <<< "$(echo "$resp" | jq --arg org "$org" --arg tier "$(tier_for_repo "$org")" --argjson excluded "$(printf '%s\n' "${excluded_repos[@]:-}" | jq -R . | jq -s . 2>/dev/null || echo '[]')" '
+    [ .[] | select(.archived == false and .fork == false) | select((.full_name // "") as $fn | ($excluded | index($fn) | not)) |
+      { full_name: .full_name, org: $org, name: .name, tier: $tier, default_branch: .default_branch, archived: .archived, fork: .fork }
+    ]
+  ')")
+done
+
+# Sort deterministically
+repos_json=$(echo "$repos_json" | jq 'sort_by(.full_name)')
+
+# Build final JSON
+jq -n \
+  --arg generated_at "$generated_at" \
+  --argjson allowed "$(printf '%s\n' "${allowed_orgs[@]}" | jq -R . | jq -s .)" \
+  --argjson excluded_orgs '["Merglevsky-cz"]' \
+  --argjson excluded_repos "$(printf '%s\n' "${excluded_repos[@]:-}" | jq -R . | jq -s . 2>/dev/null || echo '[]')" \
+  --argjson repos "$repos_json" \
+  '{
+    generated_at: $generated_at,
+    allowlist_source: "merglbot-public/docs/ENT_ORG_ALLOWLIST.md",
+    allowed_orgs: $allowed,
+    excluded_orgs: $excluded_orgs,
+    excluded_repos: $excluded_repos,
+    repos: $repos,
+    repo_count: ($repos | length),
+    org_counts: ($repos | group_by(.org) | map({ (.[0].org): length }) | add)
+  }'
+
+exit "$any_fail"


### PR DESCRIPTION
## Summary

Completes the dynamic 100%-ENT-scope coverage program per [docs#636](https://github.com/merglbot-public/docs/issues/636). Introduces a declarative allowlist + weekly auto-regeneration so every new repo in any allowed `merglbot-*` org is automatically included in the Dependabot closeout scope AND the PR Assistant deploy target list, without human toil.

## What changes

### Net-new files

- **`scripts/ent-scope/resolve-ent-scope.sh`** (138 lines): canonical scope resolver. Reads [`ENT_ORG_ALLOWLIST.md`](https://github.com/merglbot-public/docs/blob/main/ENT_ORG_ALLOWLIST.md) (merged in [docs#675](https://github.com/merglbot-public/docs/pull/675) commit `27ce80494b62`), queries `gh api /orgs/<org>/repos --paginate` per allowed org, filters archived + fork + per-repo exclusions, emits a canonical JSON scope document. Verified live: **42 repos across 11 orgs**, includes `abra-flexi-extractor`, correctly excludes `Merglevsky-cz` + `merglbot-core/github` self.

- **`.github/workflows/ent-scope-refresh.yml`** (187 lines): Monday 07:00 UTC weekly cron + `workflow_dispatch`. Authenticates via the `merglbot-ent-dependabot-closeout` GitHub App, runs the resolver, diffs against current SSOT files, and opens a bot-authored PR on drift. Also audits App installation + `repository_selection` per org and emits `::warning::` annotations if any org needs human remediation.

- **`.github/workflows/pr-assistant-auto-deploy.yml`** (140 lines): triggered on successful `workflow_run` of `ent-scope-refresh` (+ manual). Detects in-scope repos missing `merglbot-pr-v3-on-demand.yml` and opens a per-repo PR adding the canonical workflow file. PRs merge autonomously via the standard close-loop.

### Modified files

- **`.github/workflows/ent-dependabot-weekly.yml`**: cron moved from Sunday 13:00 UTC → Monday 07:30 UTC (30min after scope refresh). Everything else unchanged.

- **`scripts/dependabot/ent_repository_scope.txt`**: added `merglbot-extractors/abra-flexi-extractor` (previously excluded from v5/v6 baseline as `locked_scope_extra_remote_repo_excluded`; now in ENT scope per `ENT_ORG_ALLOWLIST.md` §1 + `REPOSITORY_MAP.md` v3.18). Note: file will be auto-regenerated weekly; hand-edits are overwritten.

## Stacked on

- [docs#675](https://github.com/merglbot-public/docs/pull/675) — **merged** (commit `27ce80494b62`) — introduces `ENT_ORG_ALLOWLIST.md`.
- [abra-flexi-extractor#6](https://github.com/merglbot-extractors/abra-flexi-extractor/pull/6) — **merged** (`cfa2a65c4a6b`) — CodeQL migration.
- `abra-flexi-extractor#1 + #2` — **merged** (`229e677ffd4b`, `bddd9a0d2e7f`) — Dependabot PRs unblocked.

## Verification

- [x] `bash -n scripts/ent-scope/resolve-ent-scope.sh` passes.
- [x] Live smoke-test of resolver with latest `ENT_ORG_ALLOWLIST.md`: 42 repos, 11 orgs (merglbot-shared has only archived repos), includes `abra-flexi-extractor`, excludes `Merglevsky-cz` + `merglbot-core/github`.
- [x] App installation audit: 12/12 orgs ✅ `repository_selection=all` (verified via `gh api /orgs/<org>/installations`).
- [ ] First scheduled `ent-scope-refresh.yml` run (Monday 2026-04-20 07:00 UTC) — will be the true end-to-end smoke.
- [ ] First scheduled closeout under new cadence (Monday 2026-04-20 07:30 UTC) — validates the scope file regenerates before closeout consumes it.

## Safety

- No `--admin` merge, no branch-protection bypass, no direct-main push on target repos.
- GitHub App token (not PAT) used for all cross-org operations; audit trail preserved via App installation id per org.
- `Merglevsky-cz` explicitly excluded at the allowlist layer.
- `merglbot-core/github` (source-of-truth) excluded from `target-repos.txt` to prevent self-deployment loop.
- `pr-assistant-auto-deploy` first run can be smoke-tested via `workflow_dispatch` with `dry_run=true` to preview without opening PRs.

## Rollback

- Revert this PR; workflows are opt-in (scheduled) so reverting disables them.
- `ent_repository_scope.txt` reverts to 42-repo hand-maintained state; closeout continues to work on that scope as before.
- No external state is created by this PR (no issues, no labels, no repo settings changes outside of weekly bot PRs).

## Tracking

[docs#636](https://github.com/merglbot-public/docs/issues/636) — ENT cleanup steady-state issue. Final comment will summarize post-merge smoke results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new scheduled GitHub Actions that query cross-org repo inventory via a GitHub App token and open PRs across repos; misconfiguration or API/permission issues could create noisy or unintended PR churn and impact automation cadence.
> 
> **Overview**
> Implements a **dynamic ENT repo scope pipeline**: a new `ent-scope-refresh.yml` workflow fetches `ENT_ORG_ALLOWLIST.md`, calls `scripts/ent-scope/resolve-ent-scope.sh` to enumerate in-scope repos via the GitHub API, regenerates `scripts/dependabot/ent_repository_scope.txt` and `scripts/pr-assistant/target-repos.txt`, and opens a PR when drift is detected.
> 
> Adds `pr-assistant-auto-deploy.yml`, triggered after a successful scope refresh, which identifies in-scope repos missing the PR Assistant workflow and opens per-repo PRs to add `merglbot-pr-v3-on-demand.yml` (and the helper script).
> 
> Moves `ent-dependabot-weekly.yml` to run Monday 07:30 UTC (after scope refresh) and updates the current scope list to include `merglbot-extractors/abra-flexi-extractor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf37af2216ab48a0813930daac1e4c69306e8509. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->