### PR TITLE
fix(ent-scope): pin create-github-app-token to real v3.1.1 SHA

### DIFF
--- a/.github/workflows/ent-scope-refresh.yml
+++ b/.github/workflows/ent-scope-refresh.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get installation token for merglbot-public (read docs)
         id: public_token
-        uses: actions/create-github-app-token@9c4b0d96b0d11a3f2f9b27b5fa1e0e2e3bd16cd4  # v2.1.5 (SHA pin; bump via governance PR)
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1 (SHA pin; bump via governance PR)
         with:
           app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
           private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Get app token for all allowlisted orgs (read-only repos:read)
         id: all_orgs_token
-        uses: actions/create-github-app-token@9c4b0d96b0d11a3f2f9b27b5fa1e0e2e3bd16cd4  # v2.1.5
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
           app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
           private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/pr-assistant-auto-deploy.yml
+++ b/.github/workflows/pr-assistant-auto-deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get installation token (all allowed orgs)
         id: app_token
-        uses: actions/create-github-app-token@9c4b0d96b0d11a3f2f9b27b5fa1e0e2e3bd16cd4  # v2.1.5
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
           app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
           private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Fixes broken SHA pin introduced in [#448](https://github.com/merglbot-core/github/pull/448) (`9c4b0d9...` was a placeholder, not a real tag). Updates to the real `v3.1.1` SHA (`1b10c78c7865c340bc4f6099eb2f838309f1e8c3`) per `gh api /repos/actions/create-github-app-token/tags`. Unblocks the ent-scope-refresh + pr-assistant-auto-deploy workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that updates an action SHA pin; behavior should be unchanged aside from unblocking previously failing runs due to an invalid ref.
> 
> **Overview**
> Updates the `ent-scope-refresh` and `pr-assistant-auto-deploy` GitHub Actions workflows to pin `actions/create-github-app-token` to the correct `v3.1.1` commit SHA (`1b10c78…`) instead of the previously invalid placeholder SHA.
> 
> This should restore successful token generation and unblock the dependent automation workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e7d1c41f57c83437e81787edb476a78e46209f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->