### PR TITLE
fix(ent-scope): use App token for git push in scope-refresh

### DIFF
--- a/.github/workflows/ent-scope-refresh.yml
+++ b/.github/workflows/ent-scope-refresh.yml
@@ -26,6 +26,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       scope_json: ${{ steps.resolve.outputs.scope_json }}
       repo_count: ${{ steps.resolve.outputs.repo_count }}
@@ -148,6 +149,8 @@ jobs:
           branch="merglbot/ent-scope-refresh-$(date -u +%Y%m%dT%H%M%SZ)"
           git config user.email "merglbot-ent-dependabot-closeout[bot]@users.noreply.github.com"
           git config user.name "merglbot-ent-dependabot-closeout[bot]"
+          # Use App installation token for push (default github-actions[bot] token can't push)
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git checkout -b "$branch"
           git add scripts/dependabot/ent_repository_scope.txt scripts/pr-assistant/target-repos.txt
           git commit -m "chore(ent-scope): weekly regeneration of scope SSOT files


### PR DESCRIPTION
Fixes `403 denied to github-actions[bot]` in the Open-PR step of ent-scope-refresh.yml (smoke run [24611090593](https://github.com/merglbot-core/github/actions/runs/24611090593)). Rewrites origin URL to use the merglbot-ent-dependabot-closeout App installation token for git push.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a scheduled GitHub Actions workflow to push branches using a GitHub App installation token, which affects CI authentication and write access but is narrowly scoped to the PR-opening step.
> 
> **Overview**
> Fixes the `ent-scope-refresh.yml` workflow’s drift-PR creation by granting job-level `pull-requests: read` and rewriting the `origin` remote URL to use the GitHub App installation token (`GH_TOKEN`) before `git push`, avoiding `github-actions[bot]` 403s when publishing the regeneration branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e389aea610b0330f92224bf0d7782b818f5886. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->