### PR TITLE
fix(ent-scope): set persist-credentials: false on checkout

### DIFF
--- a/.github/workflows/ent-scope-refresh.yml
+++ b/.github/workflows/ent-scope-refresh.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout merglbot-core/github (self)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false  # App token used for push, not github-actions[bot]
 
       - name: Get installation token for merglbot-public (read docs)
         id: public_token

--- a/.github/workflows/pr-assistant-auto-deploy.yml
+++ b/.github/workflows/pr-assistant-auto-deploy.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout merglbot-core/github (self)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false  # App token used for push, not github-actions[bot]
 
       - name: Get installation token (all allowed orgs)
         id: app_token


### PR DESCRIPTION
Second fix for smoke run failure in ent-scope-refresh apply mode. actions/checkout@v6 default persist-credentials: true writes http.extraheader that overrides App token URL auth, forcing git push to still use github-actions[bot]. Setting persist-credentials: false avoids this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that affects how authentication headers are configured during checkout; the main risk is accidental impact to downstream git operations if a step expected persisted credentials.
> 
> **Overview**
> Ensures the `ENT Scope Refresh` and `PR Assistant Auto-Deploy` workflows check out this repo with `persist-credentials: false`, preventing `actions/checkout@v6` from writing auth headers that override the GitHub App token used later for `git push`/PR creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf57d9158cdc755770eef7ec2ce0cca4a41906c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->