### PR TITLE
fix(auto-deploy): add separate public_token to fetch allowlist

### DIFF
--- a/.github/workflows/pr-assistant-auto-deploy.yml
+++ b/.github/workflows/pr-assistant-auto-deploy.yml
@@ -34,6 +34,15 @@ jobs:
         with:
           persist-credentials: false  # App token used for push, not github-actions[bot]
 
+      - name: Get installation token for merglbot-public (docs read)
+        id: public_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        with:
+          app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
+          owner: merglbot-public
+          repositories: docs
+
       - name: Get installation token (all allowed orgs)
         id: app_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
@@ -44,7 +53,7 @@ jobs:
 
       - name: Fetch canonical ENT_ORG_ALLOWLIST.md
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ steps.public_token.outputs.token }}
         run: |
           set -euo pipefail
           mkdir -p .ent-scope


### PR DESCRIPTION
pr-assistant-auto-deploy.yml used a merglbot-core scoped App token to fetch ENT_ORG_ALLOWLIST.md from merglbot-public/docs, which failed. Add a dedicated public_token step mirroring ent-scope-refresh.yml.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub Actions authentication by introducing a second GitHub App token and changing which token is used to fetch `ENT_ORG_ALLOWLIST.md`; misconfiguration could break deployments or broaden access if scoped incorrectly.
> 
> **Overview**
> Fixes `pr-assistant-auto-deploy.yml` failing to read `merglbot-public/docs/ENT_ORG_ALLOWLIST.md` by adding a dedicated `public_token` (scoped to `merglbot-public`/`docs`) and switching the allowlist fetch step to use it.
> 
> Keeps the existing `app_token` for subsequent org-scope operations (resolving scope, probing repos, and opening PRs), separating cross-org read access from deployment actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3af7185f9e20e783dd08710780c0a033c812c519. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->