### PR TITLE
chore(ci): bump actions/upload-artifact v5 -> v7 (Node 24)

### DIFF
--- a/.github/workflows/ent-scope-refresh.yml
+++ b/.github/workflows/ent-scope-refresh.yml
@@ -136,7 +136,7 @@ jobs:
           fi
 
       - name: Upload scope artifact
-        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8  # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ent-scope
           path: .ent-scope/


### PR DESCRIPTION
Resolves Node 20 deprecation warning in ent-scope-refresh.yml smoke runs. v7.0.1 SHA pin. Backward-compatible with current usage. Follow-up to [docs#636 cosmetic gaps](https://github.com/merglbot-public/docs/issues/636#issuecomment-4274343751).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the pinned `actions/upload-artifact` version used in `ent-scope-refresh.yml`, with no changes to workflow logic or permissions.
> 
> **Overview**
> Updates `.github/workflows/ent-scope-refresh.yml` to pin `actions/upload-artifact` to **v7.0.1** (from **v5.0.0**) when uploading the `ent-scope` artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36710af25291de516578867e36c04a6e82045cf5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->