### PR TITLE
fix(ent-scope): client_id rename + governance notice

### DIFF
--- a/.github/workflows/ent-scope-refresh.yml
+++ b/.github/workflows/ent-scope-refresh.yml
@@ -226,6 +226,20 @@ jobs:
                   continue
               print(f"  {org}: ✅ App installed (installation_id={inst['id']}, repository_selection={sel})")
 
+          # Print App's own client_id for governance (public identifier, not a secret)
+          req_app = urllib.request.Request(
+              "https://api.github.com/app",
+              headers={
+                  "Authorization": f"Bearer {bearer}",
+                  "Accept": "application/vnd.github+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+                  "User-Agent": "merglbot-ent-scope-refresh",
+              },
+          )
+          with urllib.request.urlopen(req_app, timeout=30) as resp:
+              app_info = json.loads(resp.read())
+          print(f"::notice ::App identity: slug={app_info.get('slug')}, app_id={app_info.get('id')}, client_id={app_info.get('client_id')}")
+
           # Also list installations in orgs OUTSIDE the allowlist (should be empty)
           out_of_scope = set(by_org.keys()) - allowed_orgs
           if out_of_scope:

--- a/.github/workflows/ent-scope-refresh.yml
+++ b/.github/workflows/ent-scope-refresh.yml
@@ -41,7 +41,7 @@ jobs:
         id: public_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1 (SHA pin; bump via governance PR)
         with:
-          app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
+          client-id: ${{ secrets.ENT_DEPENDABOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
           owner: merglbot-public
           repositories: docs
@@ -60,7 +60,7 @@ jobs:
         id: all_orgs_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
+          client-id: ${{ secrets.ENT_DEPENDABOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
           owner: merglbot-core
 

--- a/.github/workflows/pr-assistant-auto-deploy.yml
+++ b/.github/workflows/pr-assistant-auto-deploy.yml
@@ -38,7 +38,7 @@ jobs:
         id: public_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
+          client-id: ${{ secrets.ENT_DEPENDABOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
           owner: merglbot-public
           repositories: docs
@@ -47,7 +47,7 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ secrets.ENT_DEPENDABOT_APP_ID }}
+          client-id: ${{ secrets.ENT_DEPENDABOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
           owner: merglbot-core
 


### PR DESCRIPTION
Resolves the `app-id deprecated → use client-id` warning across `ent-scope-refresh.yml` + `pr-assistant-auto-deploy.yml`. Requires new org secret `ENT_DEPENDABOT_APP_CLIENT_ID` (created 2026-04-18 with value `Iv23li0I464zgGGWBO20`, captured from App's own `/app` endpoint via JWT in smoke run [24611813044](https://github.com/merglbot-core/github/actions/runs/24611813044)).

Also adds a `::notice ::App identity: ...` annotation to each audit run for governance (slug + app_id + client_id visible in run summary). Follow-up to [docs#636 cosmetic gaps](https://github.com/merglbot-public/docs/issues/636#issuecomment-4274343751).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates GitHub Actions authentication inputs and introduces a new required secret, which can break scheduled/auto-deploy workflows if misconfigured. Otherwise changes are limited to workflow plumbing and adds a non-secret governance notice.
> 
> **Overview**
> Replaces `actions/create-github-app-token` usage from `app-id` to `client-id` in `ent-scope-refresh.yml` and `pr-assistant-auto-deploy.yml`, requiring the new org secret `ENT_DEPENDABOT_APP_CLIENT_ID`.
> 
> Adds a governance annotation to `ent-scope-refresh.yml` that calls `/app` with an App JWT and emits a `::notice` containing the App `slug`, `app_id`, and `client_id` in workflow logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cdcc2fc6b49e59b42178e30d7dcbfca0ea82040. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->