### PR TITLE
feat(pr-assistant): add v3/v4 conflict guard to canonical workflow

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -118,11 +118,20 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    # v3/v4 conflict guard:
+    # - Skip when PR Assistant v4 is the promoted command owner for this repo
+    #   (repo/org var MERGLBOT_PR_ASSISTANT_V3_DISABLED=true).
+    # - Skip when the trigger is @merglbot review-v4 (v4 canary owns that command).
+    # - Otherwise respond to @merglbot review as before.
     if: |
-      (github.event_name == 'issue_comment' && 
-       github.event.issue.pull_request && 
-       contains(github.event.comment.body, '@merglbot review')) ||
-      github.event_name == 'workflow_dispatch'
+      vars.MERGLBOT_PR_ASSISTANT_V3_DISABLED != 'true' &&
+      (
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request &&
+         contains(github.event.comment.body, '@merglbot review') &&
+         !contains(github.event.comment.body, '@merglbot review-v4')) ||
+        github.event_name == 'workflow_dispatch'
+      )
     outputs:
       pr_number: ${{ steps.get_pr.outputs.pr_number }}
       should_run: ${{ steps.get_pr.outputs.should_run }}


### PR DESCRIPTION
## Summary

Adds a narrow conflict guard to the canonical PR Assistant v3 workflow so it:
1. Does **not** react to `@merglbot review-v4` (v4 canary owns that command), and
2. Can be centrally disabled per repo once PR Assistant v4 is promoted as the `@merglbot review` owner.

## Change

Single `if:` guard on the `check-trigger` job:

```yaml
if: |
  vars.MERGLBOT_PR_ASSISTANT_V3_DISABLED != 'true' &&
  (
    (github.event_name == 'issue_comment' &&
     github.event.issue.pull_request &&
     contains(github.event.comment.body, '@merglbot review') &&
     !contains(github.event.comment.body, '@merglbot review-v4')) ||
    github.event_name == 'workflow_dispatch'
  )
```

## Rationale

- **Substring-match footgun fix**: The previous guard used `contains(body, '@merglbot review')`, which also matched `@merglbot review-v4`. Without this fix, v4 canary commands would trigger duplicate v3 + v4 runs.
- **Central disable switch**: `vars.MERGLBOT_PR_ASSISTANT_V3_DISABLED` lets any repo disable v3 once v4 is the authoritative owner of `@merglbot review`, without editing the workflow file.

## Rollout note (explicit)

- This edit is to the **canonical source** in `merglbot-core/github`.
- Each consumer repo has a **COPY** (`merglbot-pr-v3-on-demand.yml`) produced by `scripts/pr-assistant/deploy-v3.sh`.
- **After merge**: a separate ops step re-runs the deploy script to propagate the guard to all 41 consumer repos. That deploy is explicitly out of scope of this PR.
- Until consumer copies are re-synced, v3 will still substring-match `@merglbot review-v4` in those repos and produce duplicate runs. The `vars.MERGLBOT_PR_ASSISTANT_V3_DISABLED` path still works for per-repo emergency disable of v3 routing once v4 ownership is proven.

## Acceptance target per in-scope repo after rollout + v4 promotion

- Exactly **one command owner** for `@merglbot review`.
- Exactly **one PR-head Check Run** per accepted review comment.
- **No duplicate** v3/v4 execution.

## Related PRs (same program)

- Docs: [merglbot-public/docs#704](https://github.com/merglbot-public/docs/pull/704)
- Platform service: [merglbot-core/platform#177](https://github.com/merglbot-core/platform/pull/177)
- Infra: [merglbot-core/infra#665](https://github.com/merglbot-core/infra/pull/665)
- Prompt asset: [merglbot-core/agents-orchestrator#481](https://github.com/merglbot-core/agents-orchestrator/pull/481)

## Validation

- [x] `actionlint` clean on the canonical workflow.
- [ ] Merglbot PR Assistant v3 current-head `approved_for_closeout`.
- [ ] Cursor Bugbot current-head pass / no-bug or evidence-backed not-applicable.
- [ ] Required CI checks green.

## Closeout mode

`READY_FOR_HUMAN_MERGE` — workflow/security-sensitive PR in canonical CI host.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Actions `if:` gate for the PR Assistant v3 workflow, which can prevent the review workflow from running if misconfigured (repo var set) or if trigger matching is incorrect. Impact is limited to CI automation behavior (no application runtime changes).
> 
> **Overview**
> Adds a **v3/v4 conflict guard** to the `check-trigger` job in `.github/workflows/merglbot-pr-assistant-v3-on-demand.yml`.
> 
> The workflow now **skips v3** when `vars.MERGLBOT_PR_ASSISTANT_V3_DISABLED == 'true'` and avoids the substring-match footgun by ensuring `@merglbot review-v4` comments **do not** trigger the v3 `@merglbot review` handler, while keeping `workflow_dispatch` support unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53f0eb3282a6432b8c6b10918e31dd1450eba067. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->