### PR TITLE
chore(pr-assistant): sync rollout targets with v3.19 inventory

### DIFF
--- a/scripts/pr-assistant/repo-policy-manifest.json
+++ b/scripts/pr-assistant/repo-policy-manifest.json
@@ -222,6 +222,17 @@
       "notes": ""
     },
     {
+      "repo": "merglbot-extractors/abra-flexi-extractor",
+      "enabled": true,
+      "rollout_tier": "client",
+      "admission_state": "baseline_only",
+      "human_merge_only": true,
+      "deploy_mode": "copy_target",
+      "expected_workflow": ".github/workflows/merglbot-pr-v3-on-demand.yml",
+      "expected_step1": "scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh",
+      "notes": ""
+    },
+    {
       "repo": "merglbot-extractors/denatura-additional-costs-extractor",
       "enabled": true,
       "rollout_tier": "client",
@@ -355,6 +366,17 @@
     },
     {
       "repo": "merglbot-proteinaco/btf-viz",
+      "enabled": true,
+      "rollout_tier": "client",
+      "admission_state": "baseline_only",
+      "human_merge_only": true,
+      "deploy_mode": "copy_target",
+      "expected_workflow": ".github/workflows/merglbot-pr-v3-on-demand.yml",
+      "expected_step1": "scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh",
+      "notes": ""
+    },
+    {
+      "repo": "merglbot-proteinaco/proteinaco-forecast-exporter",
       "enabled": true,
       "rollout_tier": "client",
       "admission_state": "baseline_only",

--- a/scripts/pr-assistant/target-repos.txt
+++ b/scripts/pr-assistant/target-repos.txt
@@ -32,6 +32,7 @@ merglbot-denatura/denatura-fb-viz
 merglbot-denatura/marketing-planning
 merglbot-denatura/marketing_actions_detector
 
+merglbot-extractors/abra-flexi-extractor
 merglbot-extractors/denatura-additional-costs-extractor
 merglbot-extractors/denatura-shoptet-export-extractor
 merglbot-extractors/facebook-extractor
@@ -49,6 +50,7 @@ merglbot-proteinaco/abc_product_material_analysis
 merglbot-proteinaco/basket-analysis
 merglbot-proteinaco/btf-legacy-implementation
 merglbot-proteinaco/btf-viz
+merglbot-proteinaco/proteinaco-forecast-exporter
 merglbot-proteinaco/proteinaco-web
 merglbot-proteinaco/viz-api
 


### PR DESCRIPTION
## Summary
- sync PR Assistant rollout manifest from live GitHub inventory / v3.19 SSOT coverage
- add missing active copy-target repos: merglbot-extractors/abra-flexi-extractor and merglbot-proteinaco/proteinaco-forecast-exporter
- regenerate target-repos.txt to 43 copy targets

## Verification
- GITHUB_TOKEN=$(gh auth token) python3 scripts/pr-assistant/repo-policy-manifest.py verify-enterprise-inventory
- python3 scripts/pr-assistant/repo-policy-manifest.py verify-manifest --target-list scripts/pr-assistant/target-repos.txt
- python3 scripts/pr-assistant/repo-policy-manifest.py sync-target-repos --check
- python3 -m py_compile scripts/pr-assistant/repo-policy-manifest.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only updates rollout inventory/manifest data and the derived `target-repos.txt`, with no runtime code changes.
> 
> **Overview**
> Updates PR Assistant rollout configuration to include two additional copy-deploy targets: `merglbot-extractors/abra-flexi-extractor` and `merglbot-proteinaco/proteinaco-forecast-exporter`.
> 
> Regenerates `scripts/pr-assistant/target-repos.txt` so the enabled copy-target list stays in sync with `repo-policy-manifest.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b790ab1d8b4d70f608763dd987a898e4451cea7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->