### PR TITLE
fix(pr-assistant): wrap verifier self-test assertion

### DIFF
--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -231,7 +231,10 @@ def self_test() -> int:
     )
     assert extract_zaver_field(mismatched_body, "Verdict") == "approved_for_closeout"
     mismatched_markers = parse_markers(mismatched_body)
-    assert mismatched_markers["MERGLBOT_REVIEW_VERDICT"] != extract_zaver_field(mismatched_body, "Verdict")
+    assert mismatched_markers["MERGLBOT_REVIEW_VERDICT"] != extract_zaver_field(
+        mismatched_body,
+        "Verdict",
+    )
     failed = parse_markers(
         "\n".join(
             [


### PR DESCRIPTION
## Summary
- wrap the review receipt verifier self-test assertion under 100 columns
- unblock repos whose Python CI runs ruff E501 against the copied verifier
- no behavior change intended

## Verification
- git diff --check
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- python3 -m py_compile scripts/pr-assistant/verify-review-receipt.py
- actionlint .github/workflows/merglbot-pr-assistant-v3-on-demand.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only reformats a `self_test` assertion to avoid line-length lint failures, with no runtime logic changes.
> 
> **Overview**
> Adjusts `scripts/pr-assistant/verify-review-receipt.py` by wrapping a long `assert` in `self_test()` across multiple lines to stay under common 100/120 column limits (e.g., Ruff `E501`).
> 
> No functional behavior is intended to change; this is a formatting-only tweak to reduce CI lint failures when the verifier is copied into repos with stricter style checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a72b6161bbe1cd4cab350c59be9a72a99e254a26. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->