### PR TITLE
fix(pr-assistant): satisfy strict verifier ruff rule

### DIFF
--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -30,8 +30,7 @@ def gh_json(args: list[str]) -> Any:
         ["gh", *args],
         check=False,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
     )
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or f"gh {' '.join(args)} failed")


### PR DESCRIPTION
## Summary
- switch PR Assistant receipt verifier subprocess capture to capture_output=True
- keeps propagated verifier compatible with stricter target repo Ruff rules

## Validation
- git diff --check
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- python3 -m py_compile scripts/pr-assistant/verify-review-receipt.py
- /tmp/pr-assistant-v4-rollout/venv-ruff/bin/ruff check scripts/pr-assistant/verify-review-receipt.py
- actionlint .github/workflows/merglbot-pr-assistant-v3-on-demand.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to subprocess invocation that preserves behavior while improving lint compatibility; failures would only affect the receipt-verification script output.
> 
> **Overview**
> Updates `scripts/pr-assistant/verify-review-receipt.py` to capture `gh` command stdout/stderr via `subprocess.run(..., capture_output=True)` instead of explicitly setting `stdout`/`stderr` pipes.
> 
> This is a non-functional refactor intended to satisfy stricter Ruff linting in target repos while keeping error handling and JSON parsing behavior the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523c0fbd628839af136ce19ac1b31e854f14bebd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->