### PR TITLE
fix(pr-assistant): align token normalization digit handling

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1779,7 +1779,7 @@ jobs:
               | tr '[:upper:]' '[:lower:]' \
               | tr ' ' '_' \
               | tr -d '\r' \
-              | sed -E 's/[^a-z_]+//g; s/^_+//; s/_+$//; s/_{2,}/_/g'
+              | sed -E 's/[^a-z0-9_]+//g; s/^_+//; s/_+$//; s/_{2,}/_/g'
           }
 
           DOCUMENTATION_OBLIGATION_STATE="unknown"


### PR DESCRIPTION
## Summary
- align PR Assistant v3 bash token normalization with the Python verifier by preserving digits
- prevents spurious visible-vs-marker verdict mismatches for tokens containing digits

## Validation
- git diff --check
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- actionlint .github/workflows/merglbot-pr-assistant-v3-on-demand.yml
- bash normalization smoke: review v4 failed -> review_v4_failed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line change to workflow string normalization that only broadens allowed characters (digits) in derived metadata tokens.
> 
> **Overview**
> Updates `normalize_machine_token` in the PR Assistant v3 on-demand workflow to **preserve digits** when normalizing extracted review/metadata fields (changing the filter from `[^a-z_]` to `[^a-z0-9_]`). This aligns normalization behavior with the verifier and prevents mismatches for tokens containing numbers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5314429513cda14ade232ca61a097e1f7b2abd7b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->