### PR TITLE
fix(pr-assistant): address review receipt guard findings

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -2233,12 +2233,17 @@ jobs:
             local field_name="$1"
             awk -v field_name="$field_name" '
               BEGIN { IGNORECASE = 1; in_zaver = 0 }
-              /^##[[:space:]]+(Zaver|Závěr)[[:space:]]*$/ {
-                in_zaver = 1
-                next
-              }
-              /^##[[:space:]]/ {
-                if (in_zaver) exit
+              /^##[[:space:]]+/ {
+                header = $0
+                gsub(/^[#[:space:]]+/, "", header)
+                gsub(/[*_`[:space:]]/, "", header)
+                if (tolower(header) == "zaver" || tolower(header) == "závěr") {
+                  in_zaver = 1
+                  next
+                }
+                if (in_zaver) {
+                  exit
+                }
                 next
               }
               {

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1744,9 +1744,9 @@ jobs:
                 line = $0
                 gsub(/^[[:space:]>-]*/, "", line)
                 n = split(line, parts, ":")
-                key = parts[1]
-                gsub(/[*_`]/, "", key)
-                if (n >= 2 && tolower(key) == tolower(field_name)) {
+                field_label = parts[1]
+                gsub(/[*_`]/, "", field_label)
+                if (n >= 2 && tolower(field_label) == tolower(field_name)) {
                   sub(/^[^:]*:[[:space:]]*/, "", line)
                   print field_name ": " line
                   exit
@@ -1769,9 +1769,9 @@ jobs:
                 line = $0
                 gsub(/^[[:space:]>-]*/, "", line)
                 n = split(line, parts, ":")
-                key = parts[1]
-                gsub(/[*_`]/, "", key)
-                if (n >= 2 && tolower(key) == tolower(field_name)) {
+                field_label = parts[1]
+                gsub(/[*_`]/, "", field_label)
+                if (n >= 2 && tolower(field_label) == tolower(field_name)) {
                   sub(/^[^:]*:[[:space:]]*/, "", line)
                   print field_name ": " line
                   exit
@@ -2246,9 +2246,9 @@ jobs:
                 line = $0
                 gsub(/^[[:space:]>-]*/, "", line)
                 n = split(line, parts, ":")
-                key = parts[1]
-                gsub(/[*_`]/, "", key)
-                if (n >= 2 && tolower(key) == tolower(field_name)) {
+                field_label = parts[1]
+                gsub(/[*_`]/, "", field_label)
+                if (n >= 2 && tolower(field_label) == tolower(field_name)) {
                   sub(/^[^:]*:[[:space:]]*/, "", line)
                   print field_name ": " line
                   exit

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1743,9 +1743,12 @@ jobs:
               in_zaver {
                 line = $0
                 gsub(/^[[:space:]>-]*/, "", line)
-                gsub(/[*`]/, "", line)
-                if (tolower(line) ~ ("^" tolower(field_name) ":[[:space:]]*")) {
-                  print line
+                n = split(line, parts, ":")
+                key = parts[1]
+                gsub(/[*_`]/, "", key)
+                if (n >= 2 && tolower(key) == tolower(field_name)) {
+                  sub(/^[^:]*:[[:space:]]*/, "", line)
+                  print field_name ": " line
                   exit
                 }
               }
@@ -1765,9 +1768,12 @@ jobs:
               {
                 line = $0
                 gsub(/^[[:space:]>-]*/, "", line)
-                gsub(/[*`]/, "", line)
-                if (tolower(line) ~ ("^" tolower(field_name) ":[[:space:]]*")) {
-                  print line
+                n = split(line, parts, ":")
+                key = parts[1]
+                gsub(/[*_`]/, "", key)
+                if (n >= 2 && tolower(key) == tolower(field_name)) {
+                  sub(/^[^:]*:[[:space:]]*/, "", line)
+                  print field_name ": " line
                   exit
                 }
               }
@@ -1777,7 +1783,7 @@ jobs:
           normalize_machine_token() {
             printf '%s' "$1" \
               | tr '[:upper:]' '[:lower:]' \
-              | tr ' ' '_' \
+              | sed -E 's/[[:space:]-]+/_/g' \
               | tr -d '\r' \
               | sed -E 's/[^a-z0-9_]+//g; s/^_+//; s/_+$//; s/_{2,}/_/g'
           }
@@ -1858,10 +1864,18 @@ jobs:
             esac
           fi
           case "$DOCUMENTATION_OBLIGATION_STATE" in
-            satisfied|not_required|unknown) ;;
+            satisfied|not_required) ;;
+            missing|unknown)
+              if [ "$REVIEW_VERDICT" = "approved_for_closeout" ]; then
+                REVIEW_VERDICT="blocked_missing_authority"
+              fi
+              ;;
             *)
               echo "::warning::Unexpected DOCUMENTATION_OBLIGATION_STATE='${DOCUMENTATION_OBLIGATION_STATE}', normalizing to unknown advisory metadata."
               DOCUMENTATION_OBLIGATION_STATE="unknown"
+              if [ "$REVIEW_VERDICT" = "approved_for_closeout" ]; then
+                REVIEW_VERDICT="blocked_missing_authority"
+              fi
               ;;
           esac
           FOLLOW_UP_ID="pr-${PR_NUM}-review-${GITHUB_RUN_ID}"
@@ -2218,13 +2232,25 @@ jobs:
           extract_review_field_line() {
             local field_name="$1"
             awk -v field_name="$field_name" '
-              BEGIN { IGNORECASE = 1 }
+              BEGIN { IGNORECASE = 1; in_zaver = 0 }
+              /^##[[:space:]]+(Zaver|Závěr)[[:space:]]*$/ {
+                in_zaver = 1
+                next
+              }
+              /^##[[:space:]]/ {
+                if (in_zaver) exit
+                next
+              }
               {
+                if (!in_zaver) next
                 line = $0
                 gsub(/^[[:space:]>-]*/, "", line)
-                gsub(/[*`]/, "", line)
-                if (tolower(line) ~ ("^" tolower(field_name) ":[[:space:]]*")) {
-                  print line
+                n = split(line, parts, ":")
+                key = parts[1]
+                gsub(/[*_`]/, "", key)
+                if (n >= 2 && tolower(key) == tolower(field_name)) {
+                  sub(/^[^:]*:[[:space:]]*/, "", line)
+                  print field_name ": " line
                   exit
                 }
               }
@@ -2390,7 +2416,7 @@ jobs:
       - name: Upload Metrics Artifact
         if: always() && steps.context.outputs.skip_review != 'true'
         continue-on-error: true
-        # Verify pin: gh api repos/actions/upload-artifact/git/ref/tags/v4.6.2 --jq .object.sha
+        # Verify pin: gh api repos/actions/upload-artifact/git/ref/tags/v7.0.0 --jq .object.sha
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: review-metrics-${{ env.PR_NUMBER }}-${{ github.run_id }}

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -43,7 +43,7 @@ def parse_markers(body: str) -> dict[str, str]:
 
 
 def normalize_machine_token(value: str) -> str:
-    normalized = value.strip().lower().replace(" ", "_")
+    normalized = value.strip().lower().replace(" ", "_").replace("-", "_")
     normalized = MACHINE_TOKEN_STRIP_RE.sub("", normalized)
     normalized = re.sub(r"_+", "_", normalized).strip("_")
     return normalized
@@ -67,9 +67,14 @@ def extract_zaver_field(body: str, field_name: str) -> str:
                 break
         if not in_zaver:
             continue
-        cleaned = re.sub(r"^[\s>\-]*", "", line).replace("*", "").replace("`", "")
+        cleaned = re.sub(r"^[\s>\-]*", "", line)
         parts = cleaned.split(":", 1)
-        if len(parts) == 2 and parts[0].strip().lower() == field_name.lower():
+        field_key = (
+            parts[0].replace("*", "").replace("_", "").replace("`", "").strip()
+            if parts
+            else ""
+        )
+        if len(parts) == 2 and field_key.lower() == field_name.lower():
             return normalize_machine_token(parts[1])
     return ""
 
@@ -217,6 +222,11 @@ def self_test() -> int:
     assert trusted_markers and trusted_markers["MERGLBOT_REVIEW_HEAD_SHA"] == "abc123"
     assert extract_zaver_field(trusted_body, "Verdict") == ""
     assert normalize_machine_token("Review V4 Failed!") == "review_v4_failed"
+    assert normalize_machine_token("approved-for-closeout") == "approved_for_closeout"
+    assert (
+        extract_zaver_field("## Zaver\n_Verdict_: approved-for-closeout", "Verdict")
+        == "approved_for_closeout"
+    )
     spoofed_markers, _, _ = latest_receipt(
         [{"body": body, "user": {"login": "octocat", "type": "User"}}]
     )


### PR DESCRIPTION
## Summary
- normalize hyphenated machine tokens consistently in workflow and verifier
- parse emphasized Zaver fields without mutating field values
- restore docs-obligation fail-closed closeout guard for missing/unknown authority
- scope review metrics verdict extraction to the Zaver section
- correct upload-artifact pin verification comment to v7.0.0

## Validation
- git diff --check
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- /tmp/pr-assistant-v4-rollout/venv-ruff/bin/ruff check scripts/pr-assistant/verify-review-receipt.py
- actionlint .github/workflows/merglbot-pr-assistant-v3-on-demand.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR-assistant workflow logic that determines `verdict`/closeout eligibility and metrics extraction; parsing changes could unintentionally misclassify review receipts or block/allow closeout incorrectly.
> 
> **Overview**
> Improves review-receipt field parsing in the v3 on-demand workflow to correctly read `Verdict`/docs metadata from the `## Zaver` section even when labels are emphasized (e.g., `*Verdict*`, `_Verdict_`) and without stripping characters from field values.
> 
> Normalizes machine tokens consistently by treating hyphens like whitespace (hyphen→underscore) in both the workflow and `verify-review-receipt.py`, and scopes metrics `Verdict` extraction to the `Zaver` section.
> 
> Restores a **fail-closed** guard: if `Documentation Obligation State` is `missing`/`unknown`, an `approved_for_closeout` verdict is downgraded to `blocked_missing_authority`. Also updates the `upload-artifact` pin verification comment to reference `v7.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cca5633f5675eedd46795698641bad4950e097c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->