### PR TITLE
Document PR Assistant upload-artifact pin evidence

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -2422,6 +2422,7 @@ jobs:
         if: always() && steps.context.outputs.skip_review != 'true'
         continue-on-error: true
         # Verify pin: gh api repos/actions/upload-artifact/git/ref/tags/v7.0.0 --jq .object.sha
+        # Expected tag object SHA (verified 2026-04-24): bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: review-metrics-${{ env.PR_NUMBER }}-${{ github.run_id }}


### PR DESCRIPTION
## Summary
- document the expected actions/upload-artifact v7.0.0 tag object SHA beside the pinned SHA
- provides review-visible evidence for the copied PR Assistant v3 workflow pin

## Validation
- gh api repos/actions/upload-artifact/git/ref/tags/v7.0.0 --jq .object.sha
- git diff --check
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- actionlint .github/workflows/merglbot-pr-assistant-v3-on-demand.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only documentation change to a GitHub Actions workflow with no behavior or permission changes.
> 
> **Overview**
> Adds an inline comment in `.github/workflows/merglbot-pr-assistant-v3-on-demand.yml` documenting the expected `actions/upload-artifact` `v7.0.0` tag object SHA next to the already-pinned commit SHA, making the pin verification evidence review-visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46cdcb45ca196df977d0a1c8b29d136d5b75d87e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->