### PR TITLE
Clarify PR Assistant receipt parser and artifact pin

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -2423,6 +2423,7 @@ jobs:
         continue-on-error: true
         # Verify pin: gh api repos/actions/upload-artifact/git/ref/tags/v7.0.0 --jq .object.sha
         # Expected tag object SHA (verified 2026-04-24): bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        # Compatibility: this workflow only uses stable name/path/retention-days inputs.
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: review-metrics-${{ env.PR_NUMBER }}-${{ github.run_id }}

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -17,7 +17,6 @@ import subprocess
 from typing import Any
 
 MARKER_RE = re.compile(r"<!--\s*(MERGLBOT_[A-Z0-9_]+)\s*:\s*([\s\S]*?)\s*-->")
-ZAVER_HEADER_RE = re.compile(r"^##\s+(?:Zaver|Závěr)\s*$", re.IGNORECASE)
 SECTION_HEADER_RE = re.compile(r"^##\s+")
 MACHINE_TOKEN_STRIP_RE = re.compile(r"[^a-z0-9_]+")
 PR_ASSISTANT_WORKFLOW_PATHS = {

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -60,7 +60,8 @@ def extract_zaver_field(body: str, field_name: str) -> str:
     for raw_line in (body or "").splitlines():
         line = raw_line.strip()
         if SECTION_HEADER_RE.match(line):
-            if ZAVER_HEADER_RE.match(f"## {normalize_heading(line)}"):
+            heading = normalize_heading(line)
+            if heading in ("zaver", "závěr"):
                 in_zaver = True
                 continue
             if in_zaver:


### PR DESCRIPTION
## Summary
- simplify verify-review-receipt Zaver heading detection to compare normalized headings directly
- document upload-artifact v7 compatibility for the stable inputs used by the review metrics upload step

## Validation
- git diff --check
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- actionlint .github/workflows/merglbot-pr-assistant-v3-on-demand.yml
- /tmp/pr-assistant-v4-rollout/venv-ruff/bin/ruff check scripts/pr-assistant/verify-review-receipt.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change in the workflow and a small parsing tweak in a verification script with narrow scope and test coverage.
> 
> **Overview**
> Clarifies the metrics upload step in `.github/workflows/merglbot-pr-assistant-v3-on-demand.yml` by documenting that the pinned `actions/upload-artifact@v7` usage relies only on stable inputs (`name`, `path`, `retention-days`).
> 
> Simplifies `scripts/pr-assistant/verify-review-receipt.py` receipt parsing by removing the dedicated `ZAVER_HEADER_RE` and directly matching the normalized section heading against `("zaver", "závěr")` when extracting fields from the `## Zaver` section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9c78c87c4a6b5bec71cd6f1bb789e43286d035. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->