### PR TITLE
fix(pr-assistant): address final propagation review findings

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -375,13 +375,13 @@ jobs:
 
           PR_VIEW_FIELDS_WITH_CHECKS="title,body,author,baseRefName,headRefName,baseRefOid,headRefOid,labels,additions,deletions,changedFiles,statusCheckRollup"
           PR_VIEW_FIELDS_NO_CHECKS="title,body,author,baseRefName,headRefName,baseRefOid,headRefOid,labels,additions,deletions,changedFiles"
-          if gh pr view "$PR_NUM" --json "$PR_VIEW_FIELDS_WITH_CHECKS" > pr_metadata.json 2>pr_view_err.txt; then
+          if gh pr view "$PR_NUM" --repo "$REPOSITORY_SLUG" --json "$PR_VIEW_FIELDS_WITH_CHECKS" > pr_metadata.json 2>pr_view_err.txt; then
             rm -f pr_view_err.txt
           else
             echo "WARN: gh pr view with statusCheckRollup failed; retrying without checks (best-effort)." >&2
             if grep -Eqi 'statusCheckRollup|Cannot query field|Resource not accessible|forbidden' pr_view_err.txt 2>/dev/null; then
               head -n 30 pr_view_err.txt >&2 || true
-              gh pr view "$PR_NUM" --json "$PR_VIEW_FIELDS_NO_CHECKS" > pr_metadata.json
+              gh pr view "$PR_NUM" --repo "$REPOSITORY_SLUG" --json "$PR_VIEW_FIELDS_NO_CHECKS" > pr_metadata.json
             else
               echo "ERROR: gh pr view failed (unexpected). Aborting." >&2
               head -n 30 pr_view_err.txt >&2 || true
@@ -530,7 +530,9 @@ jobs:
           echo "PR_BASE_SHA=$PR_BASE_SHA" >> "$GITHUB_ENV"
           echo "PR_HEAD_SHA=$PR_HEAD_SHA" >> "$GITHUB_ENV"
 
-          gh pr view "$PR_NUM" --json files -q '.files[].path' > changed_files.txt 2>/dev/null || echo "" > changed_files.txt
+          gh api "repos/${REPOSITORY_SLUG}/pulls/${PR_NUM}/files" \
+            --paginate \
+            --jq '.[].filename' > changed_files.txt 2>/dev/null || echo "" > changed_files.txt
 
           gh api "repos/${REPOSITORY_SLUG}/issues/$PR_NUM/comments" --paginate > issue_comments.json 2>/dev/null || echo "[]" > issue_comments.json
 
@@ -1075,7 +1077,7 @@ jobs:
           OPENAI_SYNTHESIS_REASONING_EFFORT_USED="n/a"
 
           PR_TITLE=$(< pr_title.txt)
-          PR_BODY=$(python3 -c 'from pathlib import Path; import sys; s=Path("pr_body.txt").read_text(encoding="utf-8", errors="replace"); sys.stdout.write(s[:3000])')
+          PR_BODY=$(python3 -c 'from pathlib import Path; import sys; p=Path("pr_body.txt"); s=p.read_text(encoding="utf-8", errors="replace") if p.exists() else ""; sys.stdout.write(s[:3000])')
 
           ANTHROPIC_REVIEW=""
           ANTHROPIC_OK="false"
@@ -2422,7 +2424,7 @@ jobs:
         if: always() && steps.context.outputs.skip_review != 'true'
         continue-on-error: true
         # Verify pin: gh api repos/actions/upload-artifact/git/ref/tags/v7.0.0 --jq .object.sha
-        # Expected tag object SHA (verified 2026-04-24): bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        # Expected tag object SHA: bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         # Compatibility: this workflow only uses stable name/path/retention-days inputs.
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:

--- a/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+++ b/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
@@ -1541,7 +1541,7 @@ if [ -s anthropic_review.txt ] && ! grep -qx "API_ERROR" anthropic_review.txt 2>
 fi
 
 if [ "$OPENAI_OK" != "true" ] && [ "$ANTHROPIC_OK" != "true" ]; then
-  echo "WARN: Step 1 produced no usable output from OpenAI or Anthropic; proceeding with CI-only fallback in Step 3." >&2
+  echo "WARN: Step 1 produced no usable output from OpenAI or Anthropic; Step 3 will emit a fail-closed CI-only fallback review." >&2
 fi
 
 echo "========================================="


### PR DESCRIPTION
## Summary
- restore paginated changed-files collection for large PRs
- keep gh pr metadata reads explicitly bound to the repository slug
- make the dual-provider failure path clearly fail-closed via the Step 3 CI-only fallback
- keep PR body reads defensive and remove date-specific artifact pin wording

## Verification
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
- workflow YAML parse via Ruby
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the GitHub Actions workflow logic that gathers PR metadata/files and controls review fallback behavior, which could impact review runs on private repos or large PRs if the API calls/permissions behave differently.
> 
> **Overview**
> Improves the PR Assistant workflow’s reliability and repo-binding by explicitly scoping `gh pr view` calls to `REPOSITORY_SLUG` and switching changed-files collection to a paginated REST call (`GET /pulls/{pr}/files`) to better handle large PRs.
> 
> Hardens synthesis input handling by making PR body reads defensive when `pr_body.txt` is missing, and clarifies the dual-provider failure path so Step 3 emits a **fail-closed CI-only fallback** review when both Anthropic and OpenAI produce unusable output.
> 
> Minor cleanup: removes date-specific wording from the `actions/upload-artifact` pin comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7a33b5ea851de052f40ac5098e7b10e90697a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->