### PR TITLE
fix(pr-assistant): keep receipt parsing fail-closed

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1702,7 +1702,7 @@ jobs:
 
           ANTHROPIC_CONFIG_DESC="temperature=0.2"
           case "$ANTHROPIC_MODEL_FINAL" in
-            claude-opus-4-7|claude-opus-4-6|claude-sonnet-4-6)
+            claude-opus-4-7)
               ANTHROPIC_CONFIG_DESC="adaptive thinking, effort=max"
               ;;
             skipped)
@@ -1745,26 +1745,7 @@ jobs:
 
           extract_final_review_field_line() {
             local field_name="$1"
-            local zaver_line
-            zaver_line="$(extract_zaver_review_field_line "$field_name" || true)"
-            if [ -n "$zaver_line" ]; then
-              printf '%s\n' "$zaver_line"
-              return 0
-            fi
-            awk -v field_name="$field_name" '
-              {
-                line = $0
-                gsub(/^[[:space:]>-]*/, "", line)
-                n = split(line, parts, ":")
-                field_label = parts[1]
-                gsub(/[*_`]/, "", field_label)
-                if (n >= 2 && tolower(field_label) == tolower(field_name)) {
-                  sub(/^[^:]*:[[:space:]]*/, "", line)
-                  print field_name ": " line
-                  exit
-                }
-              }
-            ' final_review.txt
+            extract_zaver_review_field_line "$field_name"
           }
 
           normalize_machine_token() {

--- a/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+++ b/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
@@ -905,7 +905,7 @@ echo "Prompt size: $PROMPT_SIZE chars"
       echo "  → Trying Anthropic model: $MODEL_TO_TRY"
 
       case "$MODEL_TO_TRY" in
-        claude-opus-4-7|claude-opus-4-6|claude-sonnet-4-6)
+        claude-opus-4-7)
           jq -n \
             --arg model "$MODEL_TO_TRY" \
             --rawfile prompt "$FULL_PROMPT_FILE" \

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -134,6 +134,7 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
     pr_check_surface = markers.get("MERGLBOT_PR_CHECK_SURFACE", "")
     run_id = markers.get("MERGLBOT_RUN_ID", "")
     run_url = markers.get("MERGLBOT_RUN_URL", "")
+    docs_state = markers.get("MERGLBOT_DOCUMENTATION_OBLIGATION_STATE", "")
 
     current_head_match = bool(
         head_sha and review_head_sha and head_sha == review_head_sha
@@ -153,7 +154,17 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
     if verdict not in valid_verdicts:
         blockers.append("missing_or_invalid_review_verdict")
     visible_verdict = extract_zaver_field(receipt_body, "Verdict")
-    if visible_verdict in valid_verdicts and verdict and visible_verdict != verdict:
+    policy_override_mismatch = (
+        visible_verdict == "approved_for_closeout"
+        and verdict == "blocked_missing_authority"
+        and docs_state in {"missing", "unknown"}
+    )
+    if (
+        visible_verdict in valid_verdicts
+        and verdict
+        and visible_verdict != verdict
+        and not policy_override_mismatch
+    ):
         blockers.append("review_visible_verdict_marker_mismatch")
     if status != "success" or verdict != "approved_for_closeout":
         blockers.append("review_not_approved_for_closeout")
@@ -238,14 +249,13 @@ def self_test() -> int:
             "",
             "<!-- MERGLBOT_PR_ASSISTANT_V3 -->",
             "<!-- MERGLBOT_REVIEW_VERDICT: blocked_missing_authority -->",
+            "<!-- MERGLBOT_DOCUMENTATION_OBLIGATION_STATE: unknown -->",
         ]
     )
     assert extract_zaver_field(mismatched_body, "Verdict") == "approved_for_closeout"
     mismatched_markers = parse_markers(mismatched_body)
-    assert mismatched_markers["MERGLBOT_REVIEW_VERDICT"] != extract_zaver_field(
-        mismatched_body,
-        "Verdict",
-    )
+    assert mismatched_markers["MERGLBOT_REVIEW_VERDICT"] == "blocked_missing_authority"
+    assert mismatched_markers["MERGLBOT_DOCUMENTATION_OBLIGATION_STATE"] == "unknown"
     failed = parse_markers(
         "\n".join(
             [


### PR DESCRIPTION
## Summary
- keep authoritative receipt fields scoped to the `## Zaver` section instead of falling back to whole-file matches
- only send adaptive thinking / effort=max payloads to `claude-opus-4-7`, keeping older Anthropic fallbacks on temperature-based payloads
- allow verifier-visible verdict mismatch only for the documented policy override `approved_for_closeout` -> `blocked_missing_authority` when docs state is missing/unknown

## Validation
- bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh scripts/pr-assistant/extract-zaver-field.sh scripts/pr-assistant/deploy-v3.sh
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- ruby -e "require \"yaml\"; YAML.load_file(ARGV[0])" .github/workflows/merglbot-pr-assistant-v3-on-demand.yml
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens review receipt parsing and verifier logic used to gate approvals; mistakes could incorrectly block or allow PR closeout, but changes are localized to CI tooling.
> 
> **Overview**
> Ensures review receipt fields are parsed *fail-closed* by only extracting authoritative values from the `## Zaver` section (removing whole-file fallback parsing) when building/verifying the PR assistant receipt.
> 
> Restricts Anthropic “adaptive thinking / effort=max” payloads to `claude-opus-4-7` only, leaving older Anthropic fallback models on the temperature-based request format.
> 
> Updates `verify-review-receipt.py` to tolerate the specific documented policy override where the visible verdict is `approved_for_closeout` but the receipt marker verdict is `blocked_missing_authority` when `MERGLBOT_DOCUMENTATION_OBLIGATION_STATE` is `missing`/`unknown`, and extends the self-test to cover this case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9acda61e5a3f54806f2da5d772f4dd9529645f28. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->