### PR TITLE
fix(pr-assistant): keep zaver parser parity

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1822,6 +1822,7 @@ jobs:
           fi
 
           REVIEW_VERDICT="blocked_missing_authority"
+          REVIEW_VERDICT_POLICY_OVERRIDE="false"
           VERDICT_LINE="$(extract_final_review_field_line 'Verdict' || true)"
           if [ -n "$VERDICT_LINE" ]; then
             REVIEW_VERDICT_RAW="$(normalize_machine_token "$(printf '%s' "$VERDICT_LINE" | sed -E 's/^Verdict:[[:space:]]*//I')")"
@@ -1836,6 +1837,7 @@ jobs:
             missing|unknown)
               if [ "$REVIEW_VERDICT" = "approved_for_closeout" ]; then
                 REVIEW_VERDICT="blocked_missing_authority"
+                REVIEW_VERDICT_POLICY_OVERRIDE="true"
               fi
               ;;
             *)
@@ -1843,9 +1845,45 @@ jobs:
               DOCUMENTATION_OBLIGATION_STATE="unknown"
               if [ "$REVIEW_VERDICT" = "approved_for_closeout" ]; then
                 REVIEW_VERDICT="blocked_missing_authority"
+                REVIEW_VERDICT_POLICY_OVERRIDE="true"
               fi
               ;;
           esac
+          if [ "$REVIEW_VERDICT_POLICY_OVERRIDE" = "true" ] && [ -s final_review.txt ]; then
+            REVIEW_VERDICT="$REVIEW_VERDICT" python3 - <<'PY'
+          from pathlib import Path
+          import os
+          import re
+
+          target = os.environ["REVIEW_VERDICT"]
+          path = Path("final_review.txt")
+          lines = path.read_text(encoding="utf-8").splitlines()
+          out = []
+          in_zaver = False
+          updated = False
+          for line in lines:
+              stripped = line.strip()
+              if re.match(r"^##+\s+", stripped):
+                  heading = re.sub(r"^[#\s]+", "", stripped)
+                  heading = re.sub(r"[*_`\s]+", "", heading).lower()
+                  if heading in {"zaver", "závěr"}:
+                      in_zaver = True
+                  elif in_zaver:
+                      in_zaver = False
+              if in_zaver and not updated:
+                  cleaned = re.sub(r"^[\s>\-*+]*", "", line)
+                  parts = cleaned.split(":", 1)
+                  field_label_clean = parts[0].replace("*", "").replace("_", "").replace("`", "").strip()
+                  if len(parts) == 2 and field_label_clean.lower() == "verdict":
+                      prefix = re.match(r"^([\s>\-*+]*)", line).group(1)
+                      out.append(f"{prefix}Verdict: {target}")
+                      updated = True
+                      continue
+              out.append(line)
+          if updated:
+              path.write_text("\n".join(out) + "\n", encoding="utf-8")
+          PY
+          fi
           FOLLOW_UP_ID="pr-${PR_NUM}-review-${GITHUB_RUN_ID}"
           CLOSEOUT_MODE="human_merge_only"
           REVIEW_RECEIPT_SCHEMA_VERSION="1"

--- a/scripts/pr-assistant/extract-zaver-field.sh
+++ b/scripts/pr-assistant/extract-zaver-field.sh
@@ -12,7 +12,7 @@ REVIEW_FILE="$2"
 
 awk -v field_name="$FIELD_NAME" '
   BEGIN { in_zaver = 0 }
-  /^##[[:space:]]+/ {
+  /^##+[[:space:]]+/ {
     header = $0
     gsub(/^[#[:space:]]+/, "", header)
     gsub(/[*_`[:space:]]/, "", header)
@@ -27,10 +27,11 @@ awk -v field_name="$FIELD_NAME" '
   }
   in_zaver {
     line = $0
-    gsub(/^[[:space:]>-]*/, "", line)
+    gsub(/^[[:space:]>*+-]*/, "", line)
     n = split(line, parts, ":")
     field_label = parts[1]
     gsub(/[*_`]/, "", field_label)
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", field_label)
     if (n >= 2 && tolower(field_label) == tolower(field_name)) {
       # Preserve any additional colons in the value; only remove the field label.
       sub(/^[^:]*:[[:space:]]*/, "", line)

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -17,7 +17,7 @@ import subprocess
 from typing import Any
 
 MARKER_RE = re.compile(r"<!--\s*(MERGLBOT_[A-Z0-9_]+)\s*:\s*([\s\S]*?)\s*-->")
-SECTION_HEADER_RE = re.compile(r"^##\s+")
+SECTION_HEADER_RE = re.compile(r"^##+\s+")
 MACHINE_TOKEN_STRIP_RE = re.compile(r"[^a-z0-9_]+")
 PR_ASSISTANT_WORKFLOW_PATHS = {
     ".github/workflows/merglbot-pr-assistant-v3-on-demand.yml",
@@ -42,7 +42,7 @@ def parse_markers(body: str) -> dict[str, str]:
 
 
 def normalize_machine_token(value: str) -> str:
-    normalized = value.strip().lower().replace(" ", "_").replace("-", "_")
+    normalized = re.sub(r"[\s-]+", "_", value.strip().lower())
     normalized = MACHINE_TOKEN_STRIP_RE.sub("", normalized)
     normalized = re.sub(r"_+", "_", normalized).strip("_")
     return normalized
@@ -67,7 +67,7 @@ def extract_zaver_field(body: str, field_name: str) -> str:
                 break
         if not in_zaver:
             continue
-        cleaned = re.sub(r"^[\s>\-]*", "", line)
+        cleaned = re.sub(r"^[\s>\-*+]*", "", line)
         parts = cleaned.split(":", 1)
         field_key = (
             parts[0].replace("*", "").replace("_", "").replace("`", "").strip()
@@ -154,17 +154,7 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
     if verdict not in valid_verdicts:
         blockers.append("missing_or_invalid_review_verdict")
     visible_verdict = extract_zaver_field(receipt_body, "Verdict")
-    policy_override_mismatch = (
-        visible_verdict == "approved_for_closeout"
-        and verdict == "blocked_missing_authority"
-        and docs_state in {"missing", "unknown"}
-    )
-    if (
-        visible_verdict in valid_verdicts
-        and verdict
-        and visible_verdict != verdict
-        and not policy_override_mismatch
-    ):
+    if visible_verdict in valid_verdicts and verdict and visible_verdict != verdict:
         blockers.append("review_visible_verdict_marker_mismatch")
     if status != "success" or verdict != "approved_for_closeout":
         blockers.append("review_not_approved_for_closeout")
@@ -234,8 +224,13 @@ def self_test() -> int:
     assert extract_zaver_field(trusted_body, "Verdict") == ""
     assert normalize_machine_token("Review V4 Failed!") == "review_v4_failed"
     assert normalize_machine_token("approved-for-closeout") == "approved_for_closeout"
+    assert normalize_machine_token("approved\tfor\ncloseout") == "approved_for_closeout"
     assert (
         extract_zaver_field("## Zaver\n_Verdict_: approved-for-closeout", "Verdict")
+        == "approved_for_closeout"
+    )
+    assert (
+        extract_zaver_field("### Zaver\n* _Verdict_ : approved-for-closeout", "Verdict")
         == "approved_for_closeout"
     )
     spoofed_markers, _, _ = latest_receipt(
@@ -254,8 +249,10 @@ def self_test() -> int:
     )
     assert extract_zaver_field(mismatched_body, "Verdict") == "approved_for_closeout"
     mismatched_markers = parse_markers(mismatched_body)
-    assert mismatched_markers["MERGLBOT_REVIEW_VERDICT"] == "blocked_missing_authority"
-    assert mismatched_markers["MERGLBOT_DOCUMENTATION_OBLIGATION_STATE"] == "unknown"
+    assert mismatched_markers["MERGLBOT_REVIEW_VERDICT"] != extract_zaver_field(
+        mismatched_body,
+        "Verdict",
+    )
     failed = parse_markers(
         "\n".join(
             [


### PR DESCRIPTION
## Summary
- keep shell/Python Zaver parser behavior aligned for heading levels, markdown bullets, whitespace, and machine-token normalization
- make docs policy override update the visible Zaver verdict before publishing the PR review comment
- restore strict visible verdict vs marker mismatch validation in the receipt verifier

## Validation
- bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh scripts/pr-assistant/extract-zaver-field.sh scripts/pr-assistant/deploy-v3.sh
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- ruby -e "require \"yaml\"; YAML.load_file(ARGV[0])" .github/workflows/merglbot-pr-assistant-v3-on-demand.yml
- scripts/pr-assistant/extract-zaver-field.sh Verdict smoke with `### Zaver` + markdown bullet
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the PR Assistant derives and rewrites the published `Verdict` in the review comment and tightens receipt verification, which could block closeout if parsing/normalization differs from expectations.
> 
> **Overview**
> Aligns `Zaver/Závěr` parsing across the workflow, `extract-zaver-field.sh`, and `verify-review-receipt.py` (supporting `##+` heading levels, bullet/list prefixes, stricter label trimming, and whitespace/hyphen normalization for machine tokens).
> 
> When documentation policy forces an approval downgrade, the workflow now *rewrites the visible* `## Zaver` `Verdict:` line in `final_review.txt` before posting the PR comment so the human-readable verdict matches the marker verdict.
> 
> `verify-review-receipt.py` restores strict validation by flagging any mismatch between the visible `Verdict` in the comment body and the `MERGLBOT_REVIEW_VERDICT` marker, and extends self-tests to cover the new normalization and parsing cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bc39e83228d32097903ff2f3ad57871210a6506. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->