### PR TITLE
fix(pr-assistant): harden cursor closeout blockers

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -129,8 +129,7 @@ jobs:
       (
         (github.event_name == 'issue_comment' &&
          github.event.issue.pull_request &&
-         contains(github.event.comment.body, '@merglbot review') &&
-         !contains(github.event.comment.body, '@merglbot review-v4')) ||
+         contains(github.event.comment.body, '@merglbot review')) ||
         github.event_name == 'workflow_dispatch'
       )
     outputs:
@@ -161,6 +160,15 @@ jobs:
             esac
           }
 
+          merglbot_v3_command_present() {
+            if [ "$IS_WORKFLOW_DISPATCH" == "true" ]; then
+              return 0
+            fi
+            local comment_body
+            comment_body="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
+            COMMENT_BODY="$comment_body" python3 -c 'import os, re, sys; body = os.environ.get("COMMENT_BODY", "").lower(); pattern = re.compile(r"(?<![a-z0-9_-])@merglbot\s+review(?![a-z0-9_-])"); sys.exit(0 if pattern.search(body) else 1)'
+          }
+
           # Authorization gate: avoid running expensive workflows for untrusted commenters
           if [ "$IS_WORKFLOW_DISPATCH" != "true" ]; then
             case "${AUTHOR_ASSOCIATION:-}" in
@@ -179,6 +187,18 @@ jobs:
                 exit 0
                 ;;
             esac
+            if ! merglbot_v3_command_present; then
+              echo "⏭️ Skipping: no exact v3 @merglbot review command present"
+              {
+                echo "pr_number=$ISSUE_NUMBER"
+                echo "should_run=false"
+                echo "review_mode=light"
+                echo "diff_scope=auto"
+                echo "include_retro=false"
+                echo "trigger_comment_id=${COMMENT_ID:-}"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           flag_present() {
@@ -1188,11 +1208,12 @@ jobs:
               echo "## SSOT Sync (Docs)"
               echo "None"
               echo ""
+              echo "## Zaver"
+              echo "Verdict: $VERDICT"
               echo "Documentation Obligation State: unknown"
               echo "Docs Follow-Up Hint: none"
               echo "Suggested Docs Targets: []"
               echo "Docs Signal Basis: review_output_only"
-              echo "Verdict: $VERDICT"
             } > final_review.txt
 
             SYNTHESIS_USAGE_API="ci_only_fallback"
@@ -1740,7 +1761,7 @@ jobs:
 
           extract_zaver_review_field_line() {
             local field_name="$1"
-            scripts/pr-assistant/extract-zaver-field.sh "$field_name" final_review.txt
+            bash scripts/pr-assistant/extract-zaver-field.sh "$field_name" final_review.txt
           }
 
           extract_final_review_field_line() {
@@ -1823,6 +1844,7 @@ jobs:
 
           REVIEW_VERDICT="blocked_missing_authority"
           REVIEW_VERDICT_POLICY_OVERRIDE="false"
+          REVIEW_VERDICT_RAW=""
           VERDICT_LINE="$(extract_final_review_field_line 'Verdict' || true)"
           if [ -n "$VERDICT_LINE" ]; then
             REVIEW_VERDICT_RAW="$(normalize_machine_token "$(printf '%s' "$VERDICT_LINE" | sed -E 's/^Verdict:[[:space:]]*//I')")"
@@ -1849,6 +1871,9 @@ jobs:
               fi
               ;;
           esac
+          if [ "$REVIEW_VERDICT" = "blocked_missing_authority" ] && [ "${REVIEW_VERDICT_RAW:-}" != "blocked_missing_authority" ]; then
+            REVIEW_VERDICT_POLICY_OVERRIDE="true"
+          fi
           if [ "$REVIEW_VERDICT_POLICY_OVERRIDE" = "true" ] && [ -s final_review.txt ]; then
             REVIEW_VERDICT="$REVIEW_VERDICT" python3 - <<'PY'
           from pathlib import Path
@@ -2237,7 +2262,7 @@ jobs:
           VERDICT="UNKNOWN"
           extract_review_field_line() {
             local field_name="$1"
-            scripts/pr-assistant/extract-zaver-field.sh "$field_name" final_review.txt
+            bash scripts/pr-assistant/extract-zaver-field.sh "$field_name" final_review.txt
           }
           VERDICT_LINE=$(extract_review_field_line 'Verdict' || true)
           if [ -n "$VERDICT_LINE" ]; then

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -156,6 +156,12 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
     visible_verdict = extract_zaver_field(receipt_body, "Verdict")
     if visible_verdict in valid_verdicts and verdict and visible_verdict != verdict:
         blockers.append("review_visible_verdict_marker_mismatch")
+    valid_docs_states = {"satisfied", "not_required", "missing", "unknown"}
+    if docs_state not in valid_docs_states:
+        blockers.append("missing_or_invalid_documentation_obligation_state")
+    visible_docs_state = extract_zaver_field(receipt_body, "Documentation Obligation State")
+    if visible_docs_state in valid_docs_states and docs_state and visible_docs_state != docs_state:
+        blockers.append("review_visible_docs_state_marker_mismatch")
     if status != "success" or verdict != "approved_for_closeout":
         blockers.append("review_not_approved_for_closeout")
     if status == "success" and verdict != "approved_for_closeout":
@@ -191,6 +197,7 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
         "schema_version": schema_version or None,
         "verdict": verdict or None,
         "status": status or None,
+        "documentation_obligation_state": docs_state or None,
         "pr_check_surface": pr_check_surface or None,
         "comment_url": comment_url,
         "run_id": run_id or None,


### PR DESCRIPTION
> **Risk**
> Medium risk because this touches PR Assistant v3 workflow parsing and receipt verification. Scope is limited to the canonical review workflow copy and verifier.

> **Overview**
> Tightens the v3/v4 command guard so `@merglbot review-v4` no longer suppresses an explicit `@merglbot review` when both are present, while still skipping v3 for review-v4-only comments.
>
> Adds a proper `## Zaver` block to CI-only fallback reviews so metrics and receipt parsing use the same section-scoped contract.
>
> Invokes the Zaver extractor through `bash` for mode-independent robustness and extends the receipt verifier to validate and return `MERGLBOT_DOCUMENTATION_OBLIGATION_STATE`.

> **Validation**
> - Ruby YAML load for `.github/workflows/merglbot-pr-assistant-v3-on-demand.yml`
> - `bash -n` for PR Assistant helper scripts
> - `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`
> - exact command regex smoke for `review` vs `review-v4`
> - `git diff --check`

> **SSOT / docs**
> Existing PR Assistant v3/v4 SSOT already documents the v3 disabled switch and review-v4 canary boundary. No additional docs change is required for this narrow parser/verifier hardening.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the PR Assistant v3 GitHub Actions workflow’s trigger gating and receipt parsing/validation, which can affect when reviews run and whether closeout is blocked; logic is still localized to the workflow + verifier.
> 
> **Overview**
> **Tightens v3 trigger handling** so `check-trigger` only runs on an *exact* `@merglbot review` command (regex-boundary match), while no longer special-casing `review-v4` suppression in the workflow `if` guard.
> 
> **Makes review metadata parsing more robust** by ensuring CI-only fallback reviews include a proper `## Zaver` section with `Verdict`, invoking `extract-zaver-field.sh` via `bash` for consistent execution, and treating any policy-normalized verdict (e.g., docs-state blockers forcing `blocked_missing_authority`) as an explicit override.
> 
> **Extends receipt verification** (`verify-review-receipt.py`) to validate `MERGLBOT_DOCUMENTATION_OBLIGATION_STATE` against allowed values, cross-check it against the visible `## Zaver` field, and include it in the verifier’s JSON output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e92011b5e075b36741fb3d57dc835911ade1d8d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->