### PR TITLE
fix(pr-assistant): align CI fallback docs state

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1210,7 +1210,7 @@ jobs:
               echo ""
               echo "## Zaver"
               echo "Verdict: $VERDICT"
-              echo "Documentation Obligation State: unknown"
+              echo "Documentation Obligation State: not_required"
               echo "Docs Follow-Up Hint: none"
               echo "Suggested Docs Targets: []"
               echo "Docs Signal Basis: review_output_only"

--- a/scripts/pr-assistant/repo-policy-manifest.py
+++ b/scripts/pr-assistant/repo-policy-manifest.py
@@ -713,7 +713,7 @@ def audit_repo(
     )
     documentation_gate_present = bool(
         workflow_content
-        and "Documentation Obligation State: unknown" in workflow_content
+        and "DOCUMENTATION_OBLIGATION_STATE" in workflow_content
         and "blocked_missing_authority" in workflow_content
     )
 


### PR DESCRIPTION
## Summary
- set CI-only fallback Documentation Obligation State to `not_required` when SSOT Sync (Docs) is `None`
- keep the policy manifest audit tied to the actual docs-obligation marker/guard contract instead of the old fallback literal

## Verification
- `bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh scripts/pr-assistant/extract-zaver-field.sh`
- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`
- `python3 -m py_compile scripts/pr-assistant/repo-policy-manifest.py scripts/pr-assistant/verify-review-receipt.py`
- `git diff --check`

## Rollout
- required before repropagating canonical source to v3 guard copy-target repos

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small string/marker alignment changes to PR Assistant workflow output and rollout audit checks, affecting only docs-obligation metadata detection.
> 
> **Overview**
> Updates the PR Assistant v3 CI-only fallback review output to emit `Documentation Obligation State: not_required` instead of `unknown` when `SSOT Sync (Docs)` is `None`.
> 
> Adjusts `repo-policy-manifest.py`’s rollout/audit detection to look for the `DOCUMENTATION_OBLIGATION_STATE` contract marker (and related guard) rather than matching the previous literal fallback text, keeping compliance checks tied to the handoff contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7113476bc4baf7d910ae05693ee24413b6bc7f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->