### PR TITLE
fix(pr-assistant): harden docs state receipt handling

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -129,7 +129,8 @@ jobs:
       (
         (github.event_name == 'issue_comment' &&
          github.event.issue.pull_request &&
-         contains(github.event.comment.body, '@merglbot review')) ||
+         contains(github.event.comment.body, '@merglbot review') &&
+         !contains(github.event.comment.body, '@merglbot review-v4')) ||
         github.event_name == 'workflow_dispatch'
       )
     outputs:
@@ -1766,7 +1767,54 @@ jobs:
 
           extract_final_review_field_line() {
             local field_name="$1"
-            extract_zaver_review_field_line "$field_name"
+            local zaver_value
+            zaver_value="$(extract_zaver_review_field_line "$field_name" || true)"
+            if [ -n "$zaver_value" ]; then
+              printf '%s\n' "$zaver_value"
+              return 0
+            fi
+            awk -v field_name="$field_name" '
+              /^```/ {
+                if (in_zaver) {
+                  in_code = !in_code
+                }
+                next
+              }
+              in_zaver && in_code {
+                next
+              }
+              /^##+[[:space:]]+/ {
+                header = $0
+                gsub(/^[#[:space:]]+/, "", header)
+                gsub(/[*_`[:space:]]/, "", header)
+                if (tolower(header) == "zaver" || tolower(header) == "závěr") {
+                  in_zaver = 1
+                  in_code = 0
+                  next
+                }
+                if (in_zaver && $0 ~ /^##[[:space:]]+/) {
+                  exit
+                }
+                next
+              }
+              !in_zaver || in_code {
+                next
+              }
+              {
+                line = $0
+                gsub(/^[[:space:]>*+-]*/, "", line)
+                n = split(line, parts, ":")
+                field_label = parts[1]
+                gsub(/[*_`]/, "", field_label)
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", field_label)
+                if (n >= 2 && tolower(field_label) == tolower(field_name)) {
+                  sub(/^[^:]*:[[:space:]]*/, "", line)
+                  gsub(/[*`]/, "", line)
+                  print field_name ": " line
+                  exit
+                }
+              }
+            ' final_review.txt
           }
 
           normalize_machine_token() {
@@ -1794,7 +1842,7 @@ jobs:
             satisfied|not_required|missing|unknown) ;;
             *) DOCUMENTATION_OBLIGATION_STATE="unknown" ;;
           esac
-          if [ "$DOCUMENTATION_OBLIGATION_STATE_EXPLICIT" != "true" ] && [ "$DOCUMENTATION_OBLIGATION_STATE" = "unknown" ] && [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
+          if [ "$DOCUMENTATION_OBLIGATION_STATE" = "unknown" ] && [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
             DOCUMENTATION_OBLIGATION_STATE="not_required"
           fi
 
@@ -1874,35 +1922,52 @@ jobs:
           if [ "$REVIEW_VERDICT" = "blocked_missing_authority" ] && [ "${REVIEW_VERDICT_RAW:-}" != "blocked_missing_authority" ]; then
             REVIEW_VERDICT_POLICY_OVERRIDE="true"
           fi
-          if [ "$REVIEW_VERDICT_POLICY_OVERRIDE" = "true" ] && [ -s final_review.txt ]; then
-            REVIEW_VERDICT="$REVIEW_VERDICT" python3 - <<'PY'
+          if [ -s final_review.txt ]; then
+            REVIEW_VERDICT="$REVIEW_VERDICT" DOCUMENTATION_OBLIGATION_STATE="$DOCUMENTATION_OBLIGATION_STATE" python3 - <<'PY'
           from pathlib import Path
           import os
           import re
 
-          target = os.environ["REVIEW_VERDICT"]
+          replacements = {
+              "verdict": ("Verdict", os.environ["REVIEW_VERDICT"]),
+              "documentation obligation state": (
+                  "Documentation Obligation State",
+                  os.environ["DOCUMENTATION_OBLIGATION_STATE"],
+              ),
+          }
           path = Path("final_review.txt")
           lines = path.read_text(encoding="utf-8").splitlines()
           out = []
           in_zaver = False
-          updated = False
+          in_code = False
+          updated = set()
           for line in lines:
               stripped = line.strip()
+              if in_zaver and stripped.startswith("```"):
+                  in_code = not in_code
+                  out.append(line)
+                  continue
+              if in_zaver and in_code:
+                  out.append(line)
+                  continue
               if re.match(r"^##+\s+", stripped):
                   heading = re.sub(r"^[#\s]+", "", stripped)
                   heading = re.sub(r"[*_`\s]+", "", heading).lower()
                   if heading in {"zaver", "závěr"}:
                       in_zaver = True
-                  elif in_zaver:
+                      in_code = False
+                  elif in_zaver and re.match(r"^##\s+", stripped):
                       in_zaver = False
-              if in_zaver and not updated:
+              if in_zaver:
                   cleaned = re.sub(r"^[\s>\-*+]*", "", line)
                   parts = cleaned.split(":", 1)
                   field_label_clean = parts[0].replace("*", "").replace("_", "").replace("`", "").strip()
-                  if len(parts) == 2 and field_label_clean.lower() == "verdict":
+                  field_name_normalized = field_label_clean.lower()
+                  if len(parts) == 2 and field_name_normalized in replacements:
+                      canonical_label, target = replacements[field_name_normalized]
                       prefix = re.match(r"^([\s>\-*+]*)", line).group(1)
-                      out.append(f"{prefix}Verdict: {target}")
-                      updated = True
+                      out.append(f"{prefix}{canonical_label}: {target}")
+                      updated.add(field_name_normalized)
                       continue
               out.append(line)
           if updated:
@@ -1939,6 +2004,7 @@ jobs:
               printf '%s\n' "| run_url | $REVIEW_RUN_URL |"
               printf '%s\n' "| verdict | \`review_generation_failed\` |"
               printf '%s\n' "| status | \`failed\` |"
+              printf '%s\n' "| documentation_obligation_state | \`$DOCUMENTATION_OBLIGATION_STATE\` |"
               printf '%s\n' "| diff_scope | \`$DIFF_SCOPE\` |"
               printf '%s\n' "| pr_check_surface | \`$PR_CHECK_SURFACE_STATE\` |"
               echo ""
@@ -1947,6 +2013,7 @@ jobs:
               echo "<!-- MERGLBOT_REVIEW_HEAD_SHA: $PR_HEAD_SHA -->"
               echo "<!-- MERGLBOT_REVIEW_VERDICT: review_generation_failed -->"
               echo "<!-- MERGLBOT_REVIEW_STATUS: failed -->"
+              echo "<!-- MERGLBOT_DOCUMENTATION_OBLIGATION_STATE: $DOCUMENTATION_OBLIGATION_STATE -->"
               echo "<!-- MERGLBOT_PR_CHECK_SURFACE: $PR_CHECK_SURFACE_STATE -->"
               echo "<!-- MERGLBOT_RUN_ID: ${{ github.run_id }} -->"
               echo "<!-- MERGLBOT_RUN_URL: $REVIEW_RUN_URL -->"

--- a/scripts/pr-assistant/extract-zaver-field.sh
+++ b/scripts/pr-assistant/extract-zaver-field.sh
@@ -11,16 +11,26 @@ FIELD_NAME="$1"
 REVIEW_FILE="$2"
 
 awk -v field_name="$FIELD_NAME" '
-  BEGIN { in_zaver = 0 }
+  BEGIN { in_zaver = 0; in_code = 0 }
+  /^```/ {
+    if (in_zaver) {
+      in_code = !in_code
+    }
+    next
+  }
+  in_zaver && in_code {
+    next
+  }
   /^##+[[:space:]]+/ {
     header = $0
     gsub(/^[#[:space:]]+/, "", header)
     gsub(/[*_`[:space:]]/, "", header)
     if (tolower(header) == "zaver" || tolower(header) == "závěr") {
       in_zaver = 1
+      in_code = 0
       next
     }
-    if (in_zaver) {
+    if (in_zaver && $0 ~ /^##[[:space:]]+/) {
       exit
     }
     next
@@ -35,6 +45,7 @@ awk -v field_name="$FIELD_NAME" '
     if (n >= 2 && tolower(field_label) == tolower(field_name)) {
       # Preserve any additional colons in the value; only remove the field label.
       sub(/^[^:]*:[[:space:]]*/, "", line)
+      gsub(/[*`]/, "", line)
       print field_name ": " line
       exit
     }

--- a/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+++ b/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
@@ -894,7 +894,7 @@ echo "Prompt size: $PROMPT_SIZE chars"
     echo "Calling Anthropic (requested: $ANTHROPIC_MODEL)..."
 
     ANTHROPIC_MODELS_TRIED="|"
-    for MODEL_TO_TRY in "$ANTHROPIC_MODEL" "claude-opus-4-7" "claude-opus-4-6" "claude-sonnet-4-6" "claude-opus-4-1-20250805" "claude-opus-4-20250514" "claude-sonnet-4-20250514" "claude-3-5-haiku-20241022"; do
+    for MODEL_TO_TRY in "$ANTHROPIC_MODEL" "claude-opus-4-7" "claude-opus-4-6" "claude-sonnet-4-6" "claude-opus-4-5-20251101" "claude-opus-4-5-20250929" "claude-sonnet-4-5-20250929" "claude-opus-4-1-20250805" "claude-opus-4-20250514" "claude-sonnet-4-20250514" "claude-3-5-haiku-20241022"; do
       if [ -z "$MODEL_TO_TRY" ] || [ "$MODEL_TO_TRY" = "null" ]; then
         continue
       fi

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -18,6 +18,7 @@ from typing import Any
 
 MARKER_RE = re.compile(r"<!--\s*(MERGLBOT_[A-Z0-9_]+)\s*:\s*([\s\S]*?)\s*-->")
 SECTION_HEADER_RE = re.compile(r"^##+\s+")
+TOP_LEVEL_SECTION_HEADER_RE = re.compile(r"^##\s+")
 MACHINE_TOKEN_STRIP_RE = re.compile(r"[^a-z0-9_]+")
 PR_ASSISTANT_WORKFLOW_PATHS = {
     ".github/workflows/merglbot-pr-assistant-v3-on-demand.yml",
@@ -56,14 +57,21 @@ def normalize_heading(value: str) -> str:
 
 def extract_zaver_field(body: str, field_name: str) -> str:
     in_zaver = False
+    in_code = False
     for raw_line in (body or "").splitlines():
         line = raw_line.strip()
+        if in_zaver and line.startswith("```"):
+            in_code = not in_code
+            continue
+        if in_zaver and in_code:
+            continue
         if SECTION_HEADER_RE.match(line):
             heading = normalize_heading(line)
             if heading in ("zaver", "závěr"):
                 in_zaver = True
+                in_code = False
                 continue
-            if in_zaver:
+            if in_zaver and TOP_LEVEL_SECTION_HEADER_RE.match(line):
                 break
         if not in_zaver:
             continue
@@ -238,6 +246,29 @@ def self_test() -> int:
     )
     assert (
         extract_zaver_field("### Zaver\n* _Verdict_ : approved-for-closeout", "Verdict")
+        == "approved_for_closeout"
+    )
+    assert (
+        extract_zaver_field(
+            "## Zaver\n### Details\nVerdict: approved_for_closeout",
+            "Verdict",
+        )
+        == "approved_for_closeout"
+    )
+    assert (
+        extract_zaver_field(
+            "\n".join(
+                [
+                    "## Zaver",
+                    "```",
+                    "## Spoofed",
+                    "Verdict: changes_required",
+                    "```",
+                    "Verdict: approved_for_closeout",
+                ]
+            ),
+            "Verdict",
+        )
         == "approved_for_closeout"
     )
     spoofed_markers, _, _ = latest_receipt(


### PR DESCRIPTION
## Summary
- keep v3 from starting on `@merglbot review-v4` at the YAML gate
- rewrite visible Zaver verdict/docs-state lines to match final receipt markers
- keep docs-state `not_required` when SSOT Sync (Docs) is `None`, including explicit `unknown` model output
- include documentation obligation state in failed review receipts
- make Zaver field extraction tolerate sub-headings and strip value-side markdown
- restore fallback field extraction and align Anthropic selectable fallback list

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`\n- `bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh scripts/pr-assistant/extract-zaver-field.sh`\n- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`\n- `python3 -m py_compile scripts/pr-assistant/repo-policy-manifest.py scripts/pr-assistant/verify-review-receipt.py`\n- shell extractor smoke for sub-heading + markdown wrapped fields\n- `git diff --check`\n\n## Rollout\n- required before final v3 guard propagation merge lane\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the PR Assistant v3 GitHub Actions workflow and receipt parsing logic, which can affect when reviews run and how merge-blocking metadata is derived. Risk is mitigated by being largely parsing/guardrail hardening, but mistakes could cause skipped/incorrect receipts or misclassified docs state/verdict.
> 
> **Overview**
> Prevents v3 from running on `@merglbot review-v4` by tightening the workflow trigger condition.
> 
> Makes Závěr/Závěr field extraction more robust (ignores code blocks, tolerates sub-headings, strips value-side markdown) and restores a fallback extractor in the workflow when the dedicated script finds nothing.
> 
> Aligns receipt generation with extracted metadata by rewriting visible `Zaver` lines to match the computed `Verdict` and `Documentation Obligation State`, ensures `SSOT Sync (Docs): None` forces `not_required` even if the model outputs `unknown`, and includes `documentation_obligation_state` in failed review receipts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f245aef9e084683a47e5b231a5ac3326dc2615b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->