### PR TITLE
fix(pr-assistant): remove unused receipt state flags

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1826,14 +1826,12 @@ jobs:
           }
 
           DOCUMENTATION_OBLIGATION_STATE="unknown"
-          DOCUMENTATION_OBLIGATION_STATE_EXPLICIT="false"
           SSOT_SYNC_DOCS_NONE="false"
           if awk 'BEGIN{IGNORECASE=1; in_section=0} /^##[[:space:]]+SSOT Sync \(Docs\)/{in_section=1; next} /^##[[:space:]]/{in_section=0} in_section && $0 ~ /^[[:space:]]*None[[:space:]]*$/ {found=1} END{exit(found?0:1)}' final_review.txt 2>/dev/null; then
             SSOT_SYNC_DOCS_NONE="true"
           fi
           DOC_STATE_LINE="$(extract_final_review_field_line 'Documentation Obligation State' || true)"
           if [ -n "$DOC_STATE_LINE" ]; then
-            DOCUMENTATION_OBLIGATION_STATE_EXPLICIT="true"
             DOCUMENTATION_OBLIGATION_STATE="$(normalize_machine_token "$(printf '%s' "$DOC_STATE_LINE" | sed -E 's/^Documentation Obligation State:[[:space:]]*//I')")"
           elif [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
             DOCUMENTATION_OBLIGATION_STATE="not_required"
@@ -1891,7 +1889,6 @@ jobs:
           fi
 
           REVIEW_VERDICT="blocked_missing_authority"
-          REVIEW_VERDICT_POLICY_OVERRIDE="false"
           REVIEW_VERDICT_RAW=""
           VERDICT_LINE="$(extract_final_review_field_line 'Verdict' || true)"
           if [ -n "$VERDICT_LINE" ]; then
@@ -1907,7 +1904,6 @@ jobs:
             missing|unknown)
               if [ "$REVIEW_VERDICT" = "approved_for_closeout" ]; then
                 REVIEW_VERDICT="blocked_missing_authority"
-                REVIEW_VERDICT_POLICY_OVERRIDE="true"
               fi
               ;;
             *)
@@ -1915,13 +1911,9 @@ jobs:
               DOCUMENTATION_OBLIGATION_STATE="unknown"
               if [ "$REVIEW_VERDICT" = "approved_for_closeout" ]; then
                 REVIEW_VERDICT="blocked_missing_authority"
-                REVIEW_VERDICT_POLICY_OVERRIDE="true"
               fi
               ;;
           esac
-          if [ "$REVIEW_VERDICT" = "blocked_missing_authority" ] && [ "${REVIEW_VERDICT_RAW:-}" != "blocked_missing_authority" ]; then
-            REVIEW_VERDICT_POLICY_OVERRIDE="true"
-          fi
           if [ -s final_review.txt ]; then
             REVIEW_VERDICT="$REVIEW_VERDICT" DOCUMENTATION_OBLIGATION_STATE="$DOCUMENTATION_OBLIGATION_STATE" python3 - <<'PY'
           from pathlib import Path


### PR DESCRIPTION
## Summary
- remove unused receipt-state shell flags that trigger actionlint/shellcheck SC2034 in copied workflows
- keep the docs-state and verdict enforcement behavior unchanged

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`\n- `bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh scripts/pr-assistant/extract-zaver-field.sh`\n- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`\n- extracted inline Python heredoc `py_compile`\n- `actionlint -no-color .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`\n- `git diff --check`\n\n## Rollout\n- unblocks 43-repo v3 guard propagation CI where copied workflow lint fails on SC2034

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup limited to the GitHub Actions workflow; it removes unused shell variables without altering the docs-state/verdict enforcement logic.
> 
> **Overview**
> Removes unused shell flags from `merglbot-pr-assistant-v3-on-demand.yml` (`DOCUMENTATION_OBLIGATION_STATE_EXPLICIT` and `REVIEW_VERDICT_POLICY_OVERRIDE`) that were triggering lint warnings.
> 
> The workflow still derives `DOCUMENTATION_OBLIGATION_STATE` and normalizes the final `REVIEW_VERDICT` based on the docs state, but no longer tracks whether those values were set via explicit fields vs. policy enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f236695f98d2bbdf312d4809fcd99965da8d6cee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->