### PR TITLE
fix(pr-assistant): fail closed on unresolved docs state

### DIFF
--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -55,6 +55,10 @@ def normalize_heading(value: str) -> str:
     return heading.lower()
 
 
+def docs_state_blocks_closeout(verdict: str, docs_state: str) -> bool:
+    return verdict == "approved_for_closeout" and docs_state in {"missing", "unknown"}
+
+
 def extract_zaver_field(body: str, field_name: str) -> str:
     in_zaver = False
     in_code = False
@@ -142,6 +146,7 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
     pr_check_surface = markers.get("MERGLBOT_PR_CHECK_SURFACE", "")
     run_id = markers.get("MERGLBOT_RUN_ID", "")
     run_url = markers.get("MERGLBOT_RUN_URL", "")
+    docs_state_marker_present = "MERGLBOT_DOCUMENTATION_OBLIGATION_STATE" in markers
     docs_state = markers.get("MERGLBOT_DOCUMENTATION_OBLIGATION_STATE", "")
 
     current_head_match = bool(
@@ -165,11 +170,13 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
     if visible_verdict in valid_verdicts and verdict and visible_verdict != verdict:
         blockers.append("review_visible_verdict_marker_mismatch")
     valid_docs_states = {"satisfied", "not_required", "missing", "unknown"}
-    if docs_state not in valid_docs_states:
+    if docs_state_marker_present and docs_state not in valid_docs_states:
         blockers.append("missing_or_invalid_documentation_obligation_state")
     visible_docs_state = extract_zaver_field(receipt_body, "Documentation Obligation State")
     if visible_docs_state in valid_docs_states and docs_state and visible_docs_state != docs_state:
         blockers.append("review_visible_docs_state_marker_mismatch")
+    if docs_state_blocks_closeout(verdict, docs_state):
+        blockers.append("review_docs_state_blocks_closeout")
     if status != "success" or verdict != "approved_for_closeout":
         blockers.append("review_not_approved_for_closeout")
     if status == "success" and verdict != "approved_for_closeout":
@@ -240,6 +247,11 @@ def self_test() -> int:
     assert normalize_machine_token("Review V4 Failed!") == "review_v4_failed"
     assert normalize_machine_token("approved-for-closeout") == "approved_for_closeout"
     assert normalize_machine_token("approved\tfor\ncloseout") == "approved_for_closeout"
+    assert docs_state_blocks_closeout("approved_for_closeout", "missing")
+    assert docs_state_blocks_closeout("approved_for_closeout", "unknown")
+    assert not docs_state_blocks_closeout("approved_for_closeout", "")
+    assert not docs_state_blocks_closeout("approved_for_closeout", "not_required")
+    assert not docs_state_blocks_closeout("changes_required", "unknown")
     assert (
         extract_zaver_field("## Zaver\n_Verdict_: approved-for-closeout", "Verdict")
         == "approved_for_closeout"


### PR DESCRIPTION
## Summary
- block `approved_for_closeout` receipts when documentation obligation state is `missing` or `unknown`
- keep legacy receipts without the newer docs-state marker compatible until a fresh receipt replaces them
- add verifier self-tests for docs-state closeout blocking

## Verification
- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`
- `python3 -m py_compile scripts/pr-assistant/verify-review-receipt.py scripts/pr-assistant/repo-policy-manifest.py`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`\n- `bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh scripts/pr-assistant/extract-zaver-field.sh`\n- `actionlint -no-color .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`\n- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens closeout eligibility checks in the PR assistant verifier, which can newly block merges/closeouts if documentation state is unresolved or malformed. Risk is moderate because it changes gating behavior but is limited to receipt validation logic with added self-tests.
> 
> **Overview**
> The receipt verifier now **fails closed** by blocking `approved_for_closeout` when `MERGLBOT_DOCUMENTATION_OBLIGATION_STATE` is `missing` or `unknown` (new `review_docs_state_blocks_closeout` blocker).
> 
> To preserve backward compatibility, docs-state validation only runs when the docs-state marker is present, and new self-tests cover the closeout-blocking rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e49e7d98df20abb880236cc9bda5d099b7c7986a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## SSOT Docs Evidence
- Docs obligation satisfied by merged `merglbot-public/docs#718`: https://github.com/merglbot-public/docs/pull/718
- Docs merge commit: `e72f1037ade51bcc7302ee758ee71ee2e36c6b36`
- Canonical targets updated: `PR_POLICY.md`, `SECURITY.md`, `docs-inventory.generated.json`
