### PR TITLE
fix(pr-assistant): avoid self secret-pattern prescan hits

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -817,8 +817,10 @@ jobs:
                   # secret-regex source lines in the diff. Those are guardrail code, not
                   # credentials. Keep scanning the rest of the diff fail-closed.
                   awk '
-                    /^[+-].*(SECRET_PATTERN|SENSITIVE_PATTERN|JWT_PATTERN|_[A-Z0-9_]+_RX=|_GH[A-Z_]*=|_SK_PREFIX=|_GENERIC_[A-Z_]+_PREFIX=)/ { next }
-                    /^[+-].*(secrets\.(GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY)|Authorization: Bearer \$OPENAI_API_KEY|x-api-key: \$ANTHROPIC_API_KEY)/ { next }
+                    /^[+-][[:space:]]*(SECRET_PATTERN(_STRICT(_NO_KEY)?|_NO_GENERIC)?|SENSITIVE_PATTERN(_STRICT|_NO_GENERIC)?|JWT_PATTERN(_STRICT)?|_[A-Z0-9_]+_RX|_GH[A-Z_]+|_SK_PREFIX|_GENERIC_[A-Z_]+_PREFIX)=/ { next }
+                    /^[+-][[:space:]]*printf[[:space:]]+-v[[:space:]]+SECRET_PATTERN_STRICT_NO_KEY[[:space:]]+/ { next }
+                    /^[+-][[:space:]]*(GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY):[[:space:]]*\$\{\{[[:space:]]*secrets\.(GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY)[[:space:]]*\}\}[[:space:]]*$/ { next }
+                    /^[+-][[:space:]]*-H[[:space:]]+"(Authorization: Bearer \$OPENAI_API_KEY|x-api-key: \$ANTHROPIC_API_KEY)"[[:space:]]*\\?[[:space:]]*$/ { next }
                     { print }
                   ' "$source_file" > "$target_file"
                   ;;
@@ -835,8 +837,19 @@ jobs:
                 PATTERN="${SENSITIVE_PATTERN_NO_GENERIC}|${JWT_PATTERN_STRICT}"
               fi
               if [ -s "$SECRET_SCAN_FILE" ]; then
-                SECRET_SCAN_INPUT="$(mktemp)"
-                prepare_secret_scan_input "$SECRET_SCAN_FILE" "$SECRET_SCAN_INPUT"
+                SECRET_SCAN_INPUT="$(mktemp)" || {
+                  echo "WARN: Secret pre-scan temp file creation failed for ${SECRET_SCAN_FILE}; skipping AI review fail-closed." >&2
+                  SKIP_REVIEW="true"
+                  SKIP_REASON="potential_secret"
+                  break
+                }
+                if ! prepare_secret_scan_input "$SECRET_SCAN_FILE" "$SECRET_SCAN_INPUT"; then
+                  echo "WARN: Secret pre-scan input preparation failed for ${SECRET_SCAN_FILE}; skipping AI review fail-closed." >&2
+                  rm -f "$SECRET_SCAN_INPUT"
+                  SKIP_REVIEW="true"
+                  SKIP_REASON="potential_secret"
+                  break
+                fi
                 GREP_STATUS=0
                 if grep -Eqi -- "$PATTERN" "$SECRET_SCAN_INPUT"; then
                   echo "⛔️ Potential secret-like material detected in PR context; skipping AI review."

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -808,6 +808,25 @@ jobs:
             #   (^|[^[:alnum:]_])eyJ[A-Za-z0-9_-]{5,}\.eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}($|[^[:alnum:]_])
             # NOTE: keep the gate on JWT_PATTERN_STRICT only; the loose heuristic is noisy (docs/test fixtures).
             JWT_PATTERN="${JWT_PATTERN_STRICT}"
+            prepare_secret_scan_input() {
+              local source_file="$1"
+              local target_file="$2"
+              case "$source_file" in
+                pr_diff_full.txt|pr_diff.txt)
+                  # Bootstrap PRs that upgrade old PR Assistant copies can contain removed
+                  # secret-regex source lines in the diff. Those are guardrail code, not
+                  # credentials. Keep scanning the rest of the diff fail-closed.
+                  awk '
+                    /^[+-].*(SECRET_PATTERN|SENSITIVE_PATTERN|JWT_PATTERN|_[A-Z0-9_]+_RX=|_GH[A-Z_]*=|_SK_PREFIX=|_GENERIC_[A-Z_]+_PREFIX=)/ { next }
+                    /^[+-].*(secrets\.(GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY)|Authorization: Bearer \$OPENAI_API_KEY|x-api-key: \$ANTHROPIC_API_KEY)/ { next }
+                    { print }
+                  ' "$source_file" > "$target_file"
+                  ;;
+                *)
+                  cp "$source_file" "$target_file"
+                  ;;
+              esac
+            }
             for SECRET_SCAN_FILE in pr_diff_full.txt pr_diff.txt pr_title.txt pr_body.txt bugbot_findings.txt changed_files.txt new_commits.txt pr_checks_summary.txt; do
               # pr_diff_full.txt intentionally excludes only the broad generic key_ heuristic:
               # full lockfile/package diffs can contain long integrity strings that otherwise cause false positives.
@@ -816,15 +835,19 @@ jobs:
                 PATTERN="${SENSITIVE_PATTERN_NO_GENERIC}|${JWT_PATTERN_STRICT}"
               fi
               if [ -s "$SECRET_SCAN_FILE" ]; then
+                SECRET_SCAN_INPUT="$(mktemp)"
+                prepare_secret_scan_input "$SECRET_SCAN_FILE" "$SECRET_SCAN_INPUT"
                 GREP_STATUS=0
-                if grep -Eqi -- "$PATTERN" "$SECRET_SCAN_FILE"; then
+                if grep -Eqi -- "$PATTERN" "$SECRET_SCAN_INPUT"; then
                   echo "⛔️ Potential secret-like material detected in PR context; skipping AI review."
                   SKIP_REVIEW="true"
                   SKIP_REASON="potential_secret"
+                  rm -f "$SECRET_SCAN_INPUT"
                   break
                 else
                   GREP_STATUS=$?
                 fi
+                rm -f "$SECRET_SCAN_INPUT"
                 if [ "$GREP_STATUS" -gt 1 ]; then
                   echo "WARN: Secret pre-scan failed for ${SECRET_SCAN_FILE}; skipping AI review fail-closed." >&2
                   SKIP_REVIEW="true"


### PR DESCRIPTION
## Summary
- filters only PR Assistant secret-pattern source lines from diff inputs before the fail-closed secret pre-scan
- tightens the bootstrap filter so it only skips anchored self-pattern definitions and exact provider wiring lines
- preserves scanning of arbitrary diff content, titles, body, comments, commits, files, and check summaries
- fixes bootstrap reviews for repos upgrading from older PR Assistant copies whose diffs contain removed regex literals

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`\n- `actionlint -no-color .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`\n- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`\n- `python3 -m py_compile scripts/pr-assistant/verify-review-receipt.py scripts/pr-assistant/repo-policy-manifest.py`\n- `bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh scripts/pr-assistant/extract-zaver-field.sh`\n- `git diff --check`\n- local simulation against `merglbot-extractors/abra-flexi-extractor#12` diff: filtered self-pattern source literals no longer trip secret pre-scan\n- local smuggling regression simulation: `+ // SECRET_PATTERN sk-...` remains detectable after filtering\n\n## SSOT Docs Evidence\n- `merglbot-public/docs#720` merged as `d8335b75630af66efad8f33736d23c4f39fb3afb`\n- Updated `MERGLBOT_SECRETS_NAMING_AND_LOGGING.md` with the narrow PR Assistant bootstrap pre-scan exception and fail-closed boundaries.\n\n## Rollout Context\nNeeded to unblock the PR Assistant v3 guard propagation bootstrap for repos still running an older default-branch PR Assistant workflow.\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the workflow’s secret-detection gate that decides whether to send PR context to LLMs; mistakes could either skip reviews too often or, worse, miss sensitive material. Changes are narrow and remain fail-closed on errors.
> 
> **Overview**
> Prevents the PR Assistant’s **fail-closed secret pre-scan** from tripping on *its own* secret-regex source lines when reviewing bootstrap PRs that modify the workflow.
> 
> Adds `prepare_secret_scan_input` to pre-filter `pr_diff.txt`/`pr_diff_full.txt` via `awk` (dropping anchored pattern-definition/wiring lines only), scans the sanitized temp file instead of the raw diff, and treats temp-file/prep failures as `potential_secret` (skip review) while cleaning up temp artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9dbc3d5dbf81543c1fdb7e7b1809f98b3a76cf4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->