### PR TITLE
fix(pr-assistant): fail closed on prescan grep errors

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -817,10 +817,23 @@ jobs:
                   # secret-regex source lines in the diff. Those are guardrail code, not
                   # credentials. Keep scanning the rest of the diff fail-closed.
                   awk '
-                    /^[+-][[:space:]]*(SECRET_PATTERN(_STRICT(_NO_KEY)?|_NO_GENERIC)?|SENSITIVE_PATTERN(_STRICT|_NO_GENERIC)?|JWT_PATTERN(_STRICT)?|_[A-Z0-9_]+_RX|_GH[A-Z_]+|_SK_PREFIX|_GENERIC_[A-Z_]+_PREFIX)=/ { next }
-                    /^[+-][[:space:]]*printf[[:space:]]+-v[[:space:]]+SECRET_PATTERN_STRICT_NO_KEY[[:space:]]+/ { next }
-                    /^[+-][[:space:]]*(GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY):[[:space:]]*\$\{\{[[:space:]]*secrets\.(GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY)[[:space:]]*\}\}[[:space:]]*$/ { next }
-                    /^[+-][[:space:]]*-H[[:space:]]+"(Authorization: Bearer \$OPENAI_API_KEY|x-api-key: \$ANTHROPIC_API_KEY)"[[:space:]]*\\?[[:space:]]*$/ { next }
+                    function has_runtime_secret(line) {
+                      return line ~ /xox[baprs]-[A-Za-z0-9-]{10,}/ ||
+                        line ~ /ghp_[A-Za-z0-9]{30,}/ ||
+                        line ~ /github_pat_[A-Za-z0-9_]{20,}/ ||
+                        line ~ /gh[oprsut]_[A-Za-z0-9]{30,}/ ||
+                        line ~ /AKIA[0-9A-Z]{16}/ ||
+                        line ~ /AIza[0-9A-Za-z_-]{30,}/ ||
+                        line ~ /ya29\\.[A-Za-z0-9_-]{20,}/ ||
+                        line ~ /sk-(proj|ant)-[A-Za-z0-9_-]{20,}/ ||
+                        line ~ /sk-[A-Za-z0-9_-]{30,}/ ||
+                        line ~ /eyJ[A-Za-z0-9_-]{20,}\\.[A-Za-z0-9_-]{20,}\\.[A-Za-z0-9_-]{20,}/ ||
+                        line ~ /(api_key_|secret_key_|private_key_|access_key_)[A-Za-z0-9_-]{20,}/
+                    }
+                    /^[+-][[:space:]]*(SECRET_PATTERN(_STRICT(_NO_KEY)?|_NO_GENERIC)?|SENSITIVE_PATTERN(_STRICT|_NO_GENERIC)?|JWT_PATTERN(_STRICT)?|_[A-Z0-9_]+_RX|_GH[A-Z_]+|_SK_PREFIX|_GENERIC_[A-Z_]+_PREFIX)=/ && !has_runtime_secret($0) { next }
+                    /^[+-][[:space:]]*printf[[:space:]]+-v[[:space:]]+SECRET_PATTERN_STRICT_NO_KEY[[:space:]]+/ && !has_runtime_secret($0) { next }
+                    /^[+-][[:space:]]*(GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY):[[:space:]]*\$\{\{[[:space:]]*secrets\.(GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY)[[:space:]]*\}\}[[:space:]]*$/ && !has_runtime_secret($0) { next }
+                    /^[+-][[:space:]]*-H[[:space:]]+"(Authorization: Bearer \$OPENAI_API_KEY|x-api-key: \$ANTHROPIC_API_KEY)"[[:space:]]*\\?[[:space:]]*$/ && !has_runtime_secret($0) { next }
                     { print }
                   ' "$source_file" > "$target_file"
                   ;;
@@ -851,14 +864,13 @@ jobs:
                   break
                 fi
                 GREP_STATUS=0
-                if grep -Eqi -- "$PATTERN" "$SECRET_SCAN_INPUT"; then
+                grep -Eqi -- "$PATTERN" "$SECRET_SCAN_INPUT" || GREP_STATUS=$?
+                if [ "$GREP_STATUS" -eq 0 ]; then
                   echo "⛔️ Potential secret-like material detected in PR context; skipping AI review."
                   SKIP_REVIEW="true"
                   SKIP_REASON="potential_secret"
                   rm -f "$SECRET_SCAN_INPUT"
                   break
-                else
-                  GREP_STATUS=$?
                 fi
                 rm -f "$SECRET_SCAN_INPUT"
                 if [ "$GREP_STATUS" -gt 1 ]; then

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -59,6 +59,7 @@ on:
           - claude-opus-4-5-20250929
           - claude-sonnet-4-5-20250929
           - claude-opus-4-1-20250805
+          - claude-3-5-sonnet-20241022
           - claude-3-5-haiku-20241022
       openai_model:
         description: "OpenAI model (canonical default is gpt-5.4; org_default is override-only)"

--- a/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+++ b/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
@@ -894,7 +894,7 @@ echo "Prompt size: $PROMPT_SIZE chars"
     echo "Calling Anthropic (requested: $ANTHROPIC_MODEL)..."
 
     ANTHROPIC_MODELS_TRIED="|"
-    for MODEL_TO_TRY in "$ANTHROPIC_MODEL" "claude-opus-4-7" "claude-opus-4-6" "claude-sonnet-4-6" "claude-opus-4-5-20251101" "claude-opus-4-5-20250929" "claude-sonnet-4-5-20250929" "claude-opus-4-1-20250805" "claude-opus-4-20250514" "claude-sonnet-4-20250514" "claude-3-5-haiku-20241022"; do
+    for MODEL_TO_TRY in "$ANTHROPIC_MODEL" "claude-opus-4-7" "claude-opus-4-6" "claude-sonnet-4-6" "claude-opus-4-5-20251101" "claude-opus-4-5-20250929" "claude-sonnet-4-5-20250929" "claude-opus-4-1-20250805" "claude-opus-4-20250514" "claude-sonnet-4-20250514" "claude-3-5-sonnet-20241022" "claude-3-5-haiku-20241022"; do
       if [ -z "$MODEL_TO_TRY" ] || [ "$MODEL_TO_TRY" = "null" ]; then
         continue
       fi


### PR DESCRIPTION
## Summary
- captures secret pre-scan grep exit codes explicitly so grep/internal errors fail closed
- keeps the bootstrap diff filter narrow, but refuses to filter candidate self-pattern lines if they contain runtime token-shaped material
- preserves the bootstrap fix for old workflow copies whose diffs contain PR Assistant regex source literals
- adds `claude-3-5-sonnet-20241022` as an explicit emergency Anthropic fallback without changing the canonical Opus 4.7 default

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`\n- `actionlint -no-color .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`\n- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`\n- `python3 -m py_compile scripts/pr-assistant/verify-review-receipt.py scripts/pr-assistant/repo-policy-manifest.py`\n- `bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh scripts/pr-assistant/extract-zaver-field.sh`\n- `git diff --check`\n- local bootstrap diff simulation: self-pattern literals no longer trip secret pre-scan\n- local smuggling simulation: token-shaped material on a self-pattern assignment line remains detectable\n\n## Provider Recovery Note\n- Prior Merglbot attempts on this PR hit OpenAI `insufficient_quota` and Anthropic `invalid_request_error`. The fallback addition is scoped to provider recovery and does not change default model policy.\n\n## Related\n- Follow-up from current-head Merglbot findings on v3 guard propagation PRs after github#491.\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI guardrails that decide whether PR context is safe to send to LLMs; incorrect regex/exit-code handling could either block valid reviews or, worse, allow sensitive material through.
> 
> **Overview**
> Improves the PR Assistant secret pre-scan in `merglbot-pr-assistant-v3-on-demand.yml` by **capturing `grep` exit codes explicitly** and treating non-match errors as *fail-closed* (skip AI review).
> 
> Narrows the bootstrap diff-line suppression so it only drops self-pattern/secret-regex source lines when they **don’t also contain runtime token-shaped material** (via a new `has_runtime_secret()` check), reducing the chance of hiding real secrets.
> 
> Adds `claude-3-5-sonnet-20241022` as an explicit Anthropic model choice in the workflow and as an additional fallback in `pr-assistant-step1-parallel-api-calls.sh` without changing the default model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec074c724791405b0c458db29b9a3eee590444f2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->