### PR TITLE
fix(pr-assistant): ignore indented Zaver fences

### DIFF
--- a/scripts/pr-assistant/extract-zaver-field.sh
+++ b/scripts/pr-assistant/extract-zaver-field.sh
@@ -2,6 +2,27 @@
 # Extract a single machine-readable field from the final Zaver/Závěr section.
 set -euo pipefail
 
+if [ "$#" -eq 1 ] && [ "$1" = "--self-test" ]; then
+  tmp_review="$(mktemp)"
+  trap 'rm -f "$tmp_review"' EXIT
+  cat >"$tmp_review" <<'EOF'
+## Zaver
+  ```text
+  Verdict: approved_for_closeout
+  Documentation Obligation State: not_required
+  ```
+Verdict: changes_required
+Documentation Obligation State: not_required
+EOF
+  extracted="$("$0" "Verdict" "$tmp_review")"
+  if [ "$extracted" != "Verdict: changes_required" ]; then
+    echo "self-test failed: expected real Zaver field outside indented fence, got: $extracted" >&2
+    exit 1
+  fi
+  echo '{"ok":true,"self_test":"passed"}'
+  exit 0
+fi
+
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <field-name> <review-file>" >&2
   exit 2
@@ -12,7 +33,7 @@ REVIEW_FILE="$2"
 
 awk -v field_name="$FIELD_NAME" '
   BEGIN { in_zaver = 0; in_code = 0 }
-  /^```/ {
+  /^[[:space:]]*```/ {
     if (in_zaver) {
       in_code = !in_code
     }


### PR DESCRIPTION
## Summary
- make the shell Zaver field extractor ignore fenced code blocks with leading whitespace
- add a narrow self-test covering indented Markdown fences before the real receipt fields

## Validation
- bash -n scripts/pr-assistant/extract-zaver-field.sh
- scripts/pr-assistant/extract-zaver-field.sh --self-test
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test

## Rollout
- canonical source follow-up for PR Assistant v3 guard propagation
- after merge, repropagate into the 43 existing copy-target PR branches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small parsing tweak plus a self-test; main risk is minor behavior change in how fenced code blocks are detected while extracting receipt fields.
> 
> **Overview**
> Fixes `extract-zaver-field.sh` to treat Markdown fenced code blocks as fences even when the backticks are indented, so receipt field extraction ignores code-fenced content inside the `## Zaver/Závěr` section.
> 
> Adds a `--self-test` mode that builds a minimal sample review containing an indented fenced block and asserts the extractor returns the real `Verdict` line outside the fence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a03e750c946b0a86b3734846f4c59d90530b10ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->