### PR TITLE
fix(pr-assistant): fail closed receipt metadata parsing

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -129,9 +129,7 @@ jobs:
       vars.MERGLBOT_PR_ASSISTANT_V3_DISABLED != 'true' &&
       (
         (github.event_name == 'issue_comment' &&
-         github.event.issue.pull_request &&
-         contains(github.event.comment.body, '@merglbot review') &&
-         !contains(github.event.comment.body, '@merglbot review-v4')) ||
+         github.event.issue.pull_request) ||
         github.event_name == 'workflow_dispatch'
       )
     outputs:

--- a/scripts/pr-assistant/extract-zaver-field.sh
+++ b/scripts/pr-assistant/extract-zaver-field.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 if [ "$#" -eq 1 ] && [ "$1" = "--self-test" ]; then
   tmp_review="$(mktemp)"
-  trap 'rm -f "$tmp_review"' EXIT
+  tmp_nested="$(mktemp)"
+  trap 'rm -f "$tmp_review" "$tmp_nested"' EXIT
   cat >"$tmp_review" <<'EOF'
 ## Zaver
   ```text
@@ -17,6 +18,24 @@ EOF
   extracted="$("$0" "Verdict" "$tmp_review")"
   if [ "$extracted" != "Verdict: changes_required" ]; then
     echo "self-test failed: expected real Zaver field outside indented fence, got: $extracted" >&2
+    exit 1
+  fi
+  cat >"$tmp_nested" <<'EOF'
+### Zaver
+Verdict: approved_for_closeout
+## Zaver
+Verdict: changes_required
+### Details
+Documentation Obligation State: missing
+EOF
+  nested_extracted="$("$0" "Verdict" "$tmp_nested")"
+  if [ "$nested_extracted" != "Verdict: changes_required" ]; then
+    echo "self-test failed: expected top-level Zaver field, got: $nested_extracted" >&2
+    exit 1
+  fi
+  nested_docs="$("$0" "Documentation Obligation State" "$tmp_nested" || true)"
+  if [ -n "$nested_docs" ]; then
+    echo "self-test failed: nested subsection field was parsed: $nested_docs" >&2
     exit 1
   fi
   echo '{"ok":true,"self_test":"passed"}'
@@ -42,16 +61,22 @@ awk -v field_name="$FIELD_NAME" '
   in_zaver && in_code {
     next
   }
-  /^##+[[:space:]]+/ {
+  /^##[[:space:]]+/ {
     header = $0
     gsub(/^[#[:space:]]+/, "", header)
     gsub(/[*_`[:space:]]/, "", header)
-    if (tolower(header) == "zaver" || tolower(header) == "závěr") {
+    if (!in_zaver && (tolower(header) == "zaver" || tolower(header) == "závěr")) {
       in_zaver = 1
       in_code = 0
       next
     }
-    if (in_zaver && $0 ~ /^##[[:space:]]+/) {
+    if (in_zaver) {
+      exit
+    }
+    next
+  }
+  /^###+[[:space:]]+/ {
+    if (in_zaver) {
       exit
     }
     next

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -17,8 +17,8 @@ import subprocess
 from typing import Any
 
 MARKER_RE = re.compile(r"<!--\s*(MERGLBOT_[A-Z0-9_]+)\s*:\s*([\s\S]*?)\s*-->")
-SECTION_HEADER_RE = re.compile(r"^##+\s+")
-TOP_LEVEL_SECTION_HEADER_RE = re.compile(r"^##\s+")
+SECTION_HEADER_RE = re.compile(r"^#{2,6}\s+")
+ZAVER_SECTION_HEADER_RE = re.compile(r"^##\s+")
 MACHINE_TOKEN_STRIP_RE = re.compile(r"[^a-z0-9_]+")
 PR_ASSISTANT_WORKFLOW_PATHS = {
     ".github/workflows/merglbot-pr-assistant-v3-on-demand.yml",
@@ -71,12 +71,17 @@ def extract_zaver_field(body: str, field_name: str) -> str:
             continue
         if SECTION_HEADER_RE.match(line):
             heading = normalize_heading(line)
-            if heading in ("zaver", "závěr"):
+            if (
+                not in_zaver
+                and ZAVER_SECTION_HEADER_RE.match(line)
+                and heading in ("zaver", "závěr")
+            ):
                 in_zaver = True
                 in_code = False
                 continue
-            if in_zaver and TOP_LEVEL_SECTION_HEADER_RE.match(line):
+            if in_zaver:
                 break
+            continue
         if not in_zaver:
             continue
         cleaned = re.sub(r"^[\s>\-*+]*", "", line)
@@ -170,7 +175,10 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
     if visible_verdict in valid_verdicts and verdict and visible_verdict != verdict:
         blockers.append("review_visible_verdict_marker_mismatch")
     valid_docs_states = {"satisfied", "not_required", "missing", "unknown"}
-    if docs_state_marker_present and docs_state not in valid_docs_states:
+    if not docs_state_marker_present:
+        docs_state = "unknown"
+        blockers.append("missing_or_invalid_documentation_obligation_state")
+    elif docs_state not in valid_docs_states:
         blockers.append("missing_or_invalid_documentation_obligation_state")
     visible_docs_state = extract_zaver_field(receipt_body, "Documentation Obligation State")
     if visible_docs_state in valid_docs_states and docs_state and visible_docs_state != docs_state:
@@ -249,23 +257,20 @@ def self_test() -> int:
     assert normalize_machine_token("approved\tfor\ncloseout") == "approved_for_closeout"
     assert docs_state_blocks_closeout("approved_for_closeout", "missing")
     assert docs_state_blocks_closeout("approved_for_closeout", "unknown")
-    assert not docs_state_blocks_closeout("approved_for_closeout", "")
+    assert docs_state_blocks_closeout("approved_for_closeout", "unknown")
     assert not docs_state_blocks_closeout("approved_for_closeout", "not_required")
     assert not docs_state_blocks_closeout("changes_required", "unknown")
     assert (
         extract_zaver_field("## Zaver\n_Verdict_: approved-for-closeout", "Verdict")
         == "approved_for_closeout"
     )
-    assert (
-        extract_zaver_field("### Zaver\n* _Verdict_ : approved-for-closeout", "Verdict")
-        == "approved_for_closeout"
-    )
+    assert extract_zaver_field("### Zaver\n* _Verdict_ : approved-for-closeout", "Verdict") == ""
     assert (
         extract_zaver_field(
             "## Zaver\n### Details\nVerdict: approved_for_closeout",
             "Verdict",
         )
-        == "approved_for_closeout"
+        == ""
     )
     assert (
         extract_zaver_field(
@@ -313,6 +318,34 @@ def self_test() -> int:
     )
     assert failed["MERGLBOT_REVIEW_VERDICT"] == "review_generation_failed"
     assert failed["MERGLBOT_REVIEW_STATUS"] == "failed"
+    missing_docs_state_markers = parse_markers(
+        "\n".join(
+            [
+                "<!-- MERGLBOT_REVIEW_VERDICT: approved_for_closeout -->",
+                "<!-- MERGLBOT_REVIEW_STATUS: success -->",
+            ]
+        )
+    )
+    docs_state_marker_present = (
+        "MERGLBOT_DOCUMENTATION_OBLIGATION_STATE" in missing_docs_state_markers
+    )
+    docs_state = missing_docs_state_markers.get(
+        "MERGLBOT_DOCUMENTATION_OBLIGATION_STATE",
+        "",
+    )
+    blockers = []
+    if not docs_state_marker_present:
+        docs_state = "unknown"
+        blockers.append("missing_or_invalid_documentation_obligation_state")
+    if docs_state_blocks_closeout(
+        missing_docs_state_markers["MERGLBOT_REVIEW_VERDICT"],
+        docs_state,
+    ):
+        blockers.append("review_docs_state_blocks_closeout")
+    assert blockers == [
+        "missing_or_invalid_documentation_obligation_state",
+        "review_docs_state_blocks_closeout",
+    ]
     blockers: list[str] = []
     status = "blocked"
     verdict = "changes_required"


### PR DESCRIPTION
## Summary
- make the v3 issue-comment job-level guard broad enough for all PR comments and keep exact command matching in the runtime parser
- fail closed when the review receipt omits MERGLBOT_DOCUMENTATION_OBLIGATION_STATE
- restrict Zaver/Závěr parsing to the top-level ## section and stop before nested subsections
- expand shell and Python self-tests for indented fences, nested headings, and missing docs-state markers

## Validation
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/merglbot-pr-assistant-v3-on-demand.yml
- actionlint -no-color .github/workflows/merglbot-pr-assistant-v3-on-demand.yml
- bash -n scripts/pr-assistant/extract-zaver-field.sh
- scripts/pr-assistant/extract-zaver-field.sh --self-test
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test

## Rollout
- canonical source follow-up for PR Assistant v3 guard propagation
- after merge, repropagate into the 43 existing copy-target PR branches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gatekeeping for when the workflow runs and how receipt metadata is validated; mistakes could skip intended runs or incorrectly block/allow closeout. Parsing behavior changes are covered by new self-tests but still affect automation reliability.
> 
> **Overview**
> **PR Assistant v3 now triggers the `check-trigger` job for any PR `issue_comment` (not just comments containing `@merglbot review`), relying on the runtime parser to do exact command matching.** This is intended to avoid job-level filtering edge cases while keeping v3/v4 conflict guards.
> 
> **Receipt parsing is made stricter and more defensive.** `verify-review-receipt.py` now fails closed when `MERGLBOT_DOCUMENTATION_OBLIGATION_STATE` is missing (defaults to `unknown` and adds blockers), and both the shell (`extract-zaver-field.sh`) and Python Zaver extraction only consider a top-level `## Zaver/Závěr` section and stop before nested subsections, with expanded self-tests for indented code fences and nested headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34638765642c19e9e2125b0ad71c445f8bf24468. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->