### PR TITLE
fix(pr-assistant): restore deterministic docs gate

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -552,9 +552,12 @@ jobs:
           echo "PR_BASE_SHA=$PR_BASE_SHA" >> "$GITHUB_ENV"
           echo "PR_HEAD_SHA=$PR_HEAD_SHA" >> "$GITHUB_ENV"
 
-          gh api "repos/${REPOSITORY_SLUG}/pulls/${PR_NUM}/files" \
+          if ! gh api "repos/${REPOSITORY_SLUG}/pulls/${PR_NUM}/files" \
             --paginate \
-            --jq '.[].filename' > changed_files.txt 2>/dev/null || echo "" > changed_files.txt
+            --jq '.[].filename' > changed_files.txt; then
+            echo "::error::Failed to fetch PR changed files for ${REPOSITORY_SLUG}#${PR_NUM}; refusing to infer documentation state."
+            exit 1
+          fi
 
           classify_documentation_obligation() {
             local changed_files_path="${1:-changed_files.txt}"
@@ -562,7 +565,11 @@ jobs:
               echo "unknown"
               return 0
             fi
-            if grep -Eiq '^[^/]+\.md$|(^|/)(README|MERGLBOT)(\.md)?$|(^|/)docs/|^merglbot-public/docs/' "$changed_files_path"; then
+            if [ "${REPOSITORY_SLUG:-}" = "merglbot-public/docs" ] && grep -Eiq '^[^/]+\.md$|^docs/' "$changed_files_path"; then
+              echo "satisfied"
+              return 0
+            fi
+            if grep -Eiq '^(README|MERGLBOT)\.md$|^docs/' "$changed_files_path"; then
               echo "satisfied"
               return 0
             fi

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -556,6 +556,22 @@ jobs:
             --paginate \
             --jq '.[].filename' > changed_files.txt 2>/dev/null || echo "" > changed_files.txt
 
+          classify_documentation_obligation() {
+            local changed_files_path="${1:-changed_files.txt}"
+            if [ ! -s "$changed_files_path" ]; then
+              echo "unknown"
+              return 0
+            fi
+            if grep -Eiq '(^|/)(README|MERGLBOT|DOCUMENTATION_INDEX|RULEBOOK|SECURITY|PR_POLICY|BRANCH_PROTECTION)(\.md)?$|(^|/)docs/|^merglbot-public/docs/' "$changed_files_path"; then
+              echo "satisfied"
+              return 0
+            fi
+            echo "not_required"
+          }
+
+          DOCUMENTATION_OBLIGATION_STATE_AUTHORITATIVE="$(classify_documentation_obligation changed_files.txt)"
+          printf '%s\n' "$DOCUMENTATION_OBLIGATION_STATE_AUTHORITATIVE" > documentation_obligation_state.txt
+
           gh api "repos/${REPOSITORY_SLUG}/issues/$PR_NUM/comments" --paginate > issue_comments.json 2>/dev/null || echo "[]" > issue_comments.json
 
           echo "Detecting previous Merglbot review..."
@@ -1262,7 +1278,7 @@ jobs:
               echo "Documentation Obligation State: not_required"
               echo "Docs Follow-Up Hint: none"
               echo "Suggested Docs Targets: []"
-              echo "Docs Signal Basis: review_output_only"
+              echo "Docs Signal Basis: changed_files_classifier"
             } > final_review.txt
 
             SYNTHESIS_USAGE_API="ci_only_fallback"
@@ -1316,7 +1332,7 @@ jobs:
           printf '%s\n' "5. Always include SSOT Sync (Docs) section (or 'None')"
           printf '%s\n' "6. Stay strictly review-only and end with approved_for_closeout, changes_required, or blocked_missing_authority"
           printf '%s\n' "7. Evidence-first: every kept finding must include file:line + a quoted diff excerpt; drop unverified speculation."
-          printf '%s\n' "8. Keep docs_follow_up_hint, suggested_docs_targets, and docs_signal_basis as advisory-only review metadata; do not invent a required check, merge blocker, or authoritative docs-classifier verdict."
+          printf '%s\n' "8. Keep docs_follow_up_hint and suggested_docs_targets advisory-only; docs_signal_basis may be changed_files_classifier when the workflow supplies deterministic docs-state evidence."
           printf '%s\n' "9. If SSOT Sync (Docs) is exactly 'None', set Documentation Obligation State to not_required; reserve unknown for cases where a docs obligation cannot be determined."
           printf '%s\n' ""
           printf '%s\n' "## UNTRUSTED INPUT (PROMPT INJECTION WARNING)"
@@ -1355,7 +1371,7 @@ jobs:
           printf '%s\n' "Documentation Obligation State: [satisfied or not_required or missing or unknown; use not_required when SSOT Sync (Docs) is None]"
           printf '%s\n' "Docs Follow-Up Hint: [likely_required or not_observed or none]"
           printf '%s\n' "Suggested Docs Targets: [JSON array of advisory repo-relative merglbot-public/docs paths; use [] when none are confidently known; never emit suggested_docs_paths]"
-          printf '%s\n' "Docs Signal Basis: review_output_only"
+          printf '%s\n' "Docs Signal Basis: [changed_files_classifier or review_output_only]"
           printf '%s\n' ""
           printf '%s\n' "DO NOT add Review Models section."
           printf '%s\n' "Do NOT include merge instructions, closeout execution steps, or post-merge claims."
@@ -1826,20 +1842,23 @@ jobs:
               | sed -E 's/[^a-z0-9_]+//g; s/^_+//; s/_+$//; s/_{2,}/_/g'
           }
 
-          DOCUMENTATION_OBLIGATION_STATE="unknown"
+          DOCUMENTATION_OBLIGATION_STATE="$(tr -d '\r\n' < documentation_obligation_state.txt 2>/dev/null || true)"
+          case "$DOCUMENTATION_OBLIGATION_STATE" in
+            satisfied|not_required|missing|unknown) ;;
+            *) DOCUMENTATION_OBLIGATION_STATE="unknown" ;;
+          esac
           SSOT_SYNC_DOCS_NONE="false"
           if awk 'BEGIN{IGNORECASE=1; in_section=0} /^##[[:space:]]+SSOT Sync \(Docs\)/{in_section=1; next} /^##[[:space:]]/{in_section=0} in_section && $0 ~ /^[[:space:]]*None[[:space:]]*$/ {found=1} END{exit(found?0:1)}' final_review.txt 2>/dev/null; then
             SSOT_SYNC_DOCS_NONE="true"
           fi
-          DOC_STATE_LINE="$(extract_final_review_field_line 'Documentation Obligation State' || true)"
-          if [ -n "$DOC_STATE_LINE" ]; then
-            DOCUMENTATION_OBLIGATION_STATE="$(normalize_machine_token "$(printf '%s' "$DOC_STATE_LINE" | sed -E 's/^Documentation Obligation State:[[:space:]]*//I')")"
-          elif [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
-            DOCUMENTATION_OBLIGATION_STATE="not_required"
+          REVIEW_DOC_STATE_LINE="$(extract_final_review_field_line 'Documentation Obligation State' || true)"
+          REVIEW_DOCUMENTATION_OBLIGATION_STATE=""
+          if [ -n "$REVIEW_DOC_STATE_LINE" ]; then
+            REVIEW_DOCUMENTATION_OBLIGATION_STATE="$(normalize_machine_token "$(printf '%s' "$REVIEW_DOC_STATE_LINE" | sed -E 's/^Documentation Obligation State:[[:space:]]*//I')")"
           fi
-          case "$DOCUMENTATION_OBLIGATION_STATE" in
-            satisfied|not_required|missing|unknown) ;;
-            *) DOCUMENTATION_OBLIGATION_STATE="unknown" ;;
+          case "$REVIEW_DOCUMENTATION_OBLIGATION_STATE" in
+            satisfied|not_required|missing|unknown|"") ;;
+            *) REVIEW_DOCUMENTATION_OBLIGATION_STATE="unknown" ;;
           esac
           if [ "$DOCUMENTATION_OBLIGATION_STATE" = "unknown" ] && [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
             DOCUMENTATION_OBLIGATION_STATE="not_required"
@@ -1855,11 +1874,11 @@ jobs:
             *) DOCS_FOLLOW_UP_HINT="none" ;;
           esac
 
-          DOCS_SIGNAL_BASIS="review_output_only"
+          DOCS_SIGNAL_BASIS="changed_files_classifier"
           DOCS_SIGNAL_BASIS_LINE="$(extract_final_review_field_line 'Docs Signal Basis' || true)"
           if [ -n "$DOCS_SIGNAL_BASIS_LINE" ]; then
             DOCS_SIGNAL_BASIS_RAW="$(normalize_machine_token "$(printf '%s' "$DOCS_SIGNAL_BASIS_LINE" | sed -E 's/^Docs Signal Basis:[[:space:]]*//I')")"
-            if [ "$DOCS_SIGNAL_BASIS_RAW" = "review_output_only" ]; then
+            if [ "$DOCS_SIGNAL_BASIS_RAW" = "review_output_only" ] && [ "$DOCUMENTATION_OBLIGATION_STATE" = "unknown" ]; then
               DOCS_SIGNAL_BASIS="review_output_only"
             fi
           fi
@@ -1927,6 +1946,10 @@ jobs:
                   "Documentation Obligation State",
                   os.environ["DOCUMENTATION_OBLIGATION_STATE"],
               ),
+              "docs signal basis": (
+                  "Docs Signal Basis",
+                  os.environ.get("DOCS_SIGNAL_BASIS", "changed_files_classifier"),
+              ),
           }
           path = Path("final_review.txt")
           lines = path.read_text(encoding="utf-8").splitlines()
@@ -1943,13 +1966,15 @@ jobs:
               if in_code:
                   out.append(line)
                   continue
-              if re.match(r"^##+\s+", stripped):
+              if re.match(r"^##\s+", stripped):
                   heading = re.sub(r"^[#\s]+", "", stripped)
                   heading = re.sub(r"[*_`\s]+", "", heading).lower()
                   if heading in {"zaver", "závěr"}:
                       in_zaver = True
                       in_code = False
-                  elif in_zaver and re.match(r"^##\s+", stripped):
+                  elif in_zaver:
+                      in_zaver = False
+                  elif in_zaver and re.match(r"^###+\s+", stripped):
                       in_zaver = False
               if in_zaver:
                   cleaned = re.sub(r"^[\s>\-*+]*", "", line)
@@ -2029,6 +2054,7 @@ jobs:
               printf '%s\n' "| run_url | $REVIEW_RUN_URL |"
               printf '%s\n' "| verdict | \`$REVIEW_VERDICT\` |"
               printf '%s\n' "| status | \`$REVIEW_STATUS\` |"
+              printf '%s\n' "| documentation_obligation_state | \`$DOCUMENTATION_OBLIGATION_STATE\` |"
               printf '%s\n' "| diff_scope | \`$DIFF_SCOPE\` |"
               printf '%s\n' "| pr_check_surface | \`$PR_CHECK_SURFACE_STATE\` |"
               echo ""

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1860,6 +1860,9 @@ jobs:
             satisfied|not_required|missing|unknown|"") ;;
             *) REVIEW_DOCUMENTATION_OBLIGATION_STATE="unknown" ;;
           esac
+          if [ "$REVIEW_DOCUMENTATION_OBLIGATION_STATE" = "missing" ]; then
+            DOCUMENTATION_OBLIGATION_STATE="missing"
+          fi
           if [ "$DOCUMENTATION_OBLIGATION_STATE" = "unknown" ] && [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
             DOCUMENTATION_OBLIGATION_STATE="not_required"
           fi

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -562,7 +562,7 @@ jobs:
               echo "unknown"
               return 0
             fi
-            if grep -Eiq '(^|/)(README|MERGLBOT|DOCUMENTATION_INDEX|RULEBOOK|SECURITY|PR_POLICY|BRANCH_PROTECTION)(\.md)?$|(^|/)docs/|^merglbot-public/docs/' "$changed_files_path"; then
+            if grep -Eiq '^[^/]+\.md$|(^|/)(README|MERGLBOT)(\.md)?$|(^|/)docs/|^merglbot-public/docs/' "$changed_files_path"; then
               echo "satisfied"
               return 0
             fi
@@ -1860,8 +1860,10 @@ jobs:
             satisfied|not_required|missing|unknown|"") ;;
             *) REVIEW_DOCUMENTATION_OBLIGATION_STATE="unknown" ;;
           esac
+          DOCS_STATE_SOURCE="changed_files_classifier"
           if [ "$REVIEW_DOCUMENTATION_OBLIGATION_STATE" = "missing" ]; then
             DOCUMENTATION_OBLIGATION_STATE="missing"
+            DOCS_STATE_SOURCE="review_output_only"
           fi
           if [ "$DOCUMENTATION_OBLIGATION_STATE" = "unknown" ] && [ "$SSOT_SYNC_DOCS_NONE" = "true" ]; then
             DOCUMENTATION_OBLIGATION_STATE="not_required"
@@ -1877,7 +1879,7 @@ jobs:
             *) DOCS_FOLLOW_UP_HINT="none" ;;
           esac
 
-          DOCS_SIGNAL_BASIS="changed_files_classifier"
+          DOCS_SIGNAL_BASIS="$DOCS_STATE_SOURCE"
           DOCS_SIGNAL_BASIS_LINE="$(extract_final_review_field_line 'Docs Signal Basis' || true)"
           if [ -n "$DOCS_SIGNAL_BASIS_LINE" ]; then
             DOCS_SIGNAL_BASIS_RAW="$(normalize_machine_token "$(printf '%s' "$DOCS_SIGNAL_BASIS_LINE" | sed -E 's/^Docs Signal Basis:[[:space:]]*//I')")"


### PR DESCRIPTION
## Summary
- restores deterministic `documentation_obligation_state` classification from `changed_files.txt`
- keeps model docs fields advisory and rewrites the visible `## Zaver` fields to the authoritative receipt state
- aligns the workflow `## Zaver` rewrite boundary with the shared extractor/verifier and includes docs-state in the success receipt table

## Validation
- `actionlint .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/merglbot-pr-assistant-v3-on-demand.yml"); puts "yaml_ok"'`
- `bash scripts/pr-assistant/extract-zaver-field.sh --self-test`
- `scripts/pr-assistant/verify-review-receipt.py --self-test`
- `git diff --check`

## Rollout note
This is a canonical source fix for the v3 guard propagation lane. After merge, the source must be repropagated to the existing 43 copy-target PR branches before any Terraform staging plan gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the PR Assistant workflow’s authoritative docs-state and receipt generation, including fail-closed behavior when changed-files cannot be fetched; mistakes could incorrectly block/allow closeout decisions across repos.
> 
> **Overview**
> Restores an **authoritative, deterministic** `documentation_obligation_state` by classifying it from `changed_files.txt` (and now *fails closed* if changed files can’t be fetched), instead of inferring docs status solely from model output.
> 
> Updates synthesis/output rules and the `## Zaver` rewrite logic to treat model-provided docs fields as *advisory only*, while allowing a controlled override to `missing` when the review explicitly flags it; also normalizes the `Docs Signal Basis` field accordingly.
> 
> Extends the published receipt table to include `documentation_obligation_state` and tweaks the Zaver-section boundary detection in the rewrite script to align with the shared extractor/verifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04caa7afa31d8ad442132e59a51c4b6d8c936970. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## SSOT docs follow-up
- `merglbot-public/docs#721` documents `MERGLBOT_DOCS_SIGNAL_BASIS`, `changed_files_classifier`, `review_output_only`, and fail-closed changed-files authority in `PR_POLICY.md`.
- Docs PR merged exact-head squash as merge commit `03d2536df8bbd605497c7d721c82fae6e385fb30`.
