### PR TITLE
fix(pr-assistant): guard fork dispatch and secret scan exemptions

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -294,10 +294,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json headRefName,headRefOid,headRepositoryOwner > pr_dispatch.json
+          gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json headRefName,headRefOid,headRepository > pr_dispatch.json
           PR_HEAD_REF="$(jq -r '.headRefName // empty' pr_dispatch.json)"
           PR_HEAD_SHA="$(jq -r '.headRefOid // empty' pr_dispatch.json)"
-          PR_HEAD_OWNER="$(jq -r '.headRepositoryOwner.login // empty' pr_dispatch.json)"
+          PR_HEAD_REPO="$(jq -r '.headRepository.nameWithOwner // empty' pr_dispatch.json)"
           SELF_WORKFLOW_REF="${GITHUB_WORKFLOW_REF%@*}"
           SELF_WORKFLOW_FILE="${SELF_WORKFLOW_REF##*/}"
 
@@ -305,8 +305,8 @@ jobs:
             echo "ERROR: Unable to resolve PR head ref/SHA for dispatch" >&2
             exit 1
           fi
-          if [ -z "${PR_HEAD_OWNER:-}" ] || [ "$PR_HEAD_OWNER" != "${GITHUB_REPOSITORY_OWNER:-}" ]; then
-            echo "ERROR: head-bound workflow_dispatch cannot target fork PR refs safely (head_owner=${PR_HEAD_OWNER:-unknown}, base_owner=${GITHUB_REPOSITORY_OWNER:-unknown})" >&2
+          if [ -z "${PR_HEAD_REPO:-}" ] || [ "$PR_HEAD_REPO" != "${GITHUB_REPOSITORY:-}" ]; then
+            echo "ERROR: head-bound workflow_dispatch may only target refs from the base repository (head_repo=${PR_HEAD_REPO:-unknown}, base_repo=${GITHUB_REPOSITORY:-unknown})" >&2
             exit 1
           fi
 

--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -294,14 +294,19 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json headRefName,headRefOid > pr_dispatch.json
+          gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json headRefName,headRefOid,headRepositoryOwner > pr_dispatch.json
           PR_HEAD_REF="$(jq -r '.headRefName // empty' pr_dispatch.json)"
           PR_HEAD_SHA="$(jq -r '.headRefOid // empty' pr_dispatch.json)"
+          PR_HEAD_OWNER="$(jq -r '.headRepositoryOwner.login // empty' pr_dispatch.json)"
           SELF_WORKFLOW_REF="${GITHUB_WORKFLOW_REF%@*}"
           SELF_WORKFLOW_FILE="${SELF_WORKFLOW_REF##*/}"
 
           if [ -z "${PR_HEAD_REF:-}" ] || [ -z "${PR_HEAD_SHA:-}" ] || [ -z "${SELF_WORKFLOW_FILE:-}" ]; then
             echo "ERROR: Unable to resolve PR head ref/SHA for dispatch" >&2
+            exit 1
+          fi
+          if [ -z "${PR_HEAD_OWNER:-}" ] || [ "$PR_HEAD_OWNER" != "${GITHUB_REPOSITORY_OWNER:-}" ]; then
+            echo "ERROR: head-bound workflow_dispatch cannot target fork PR refs safely (head_owner=${PR_HEAD_OWNER:-unknown}, base_owner=${GITHUB_REPOSITORY_OWNER:-unknown})" >&2
             exit 1
           fi
 
@@ -884,8 +889,8 @@ jobs:
                         line ~ /eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/ ||
                         line ~ /(api_key_|secret_key_|private_key_|access_key_)[A-Za-z0-9_-]{20,}/
                     }
-                    /^[+-][[:space:]]*(SECRET_PATTERN(_STRICT(_NO_KEY)?|_NO_GENERIC)?|SENSITIVE_PATTERN(_STRICT|_NO_GENERIC)?|JWT_PATTERN(_STRICT)?|_[A-Z0-9_]+_RX|_GH[A-Z_]+|_SK_PREFIX|_GENERIC_[A-Z_]+_PREFIX)=/ && !has_runtime_secret($0) { next }
-                    /^[+-][[:space:]]*printf[[:space:]]+-v[[:space:]]+SECRET_PATTERN_STRICT_NO_KEY[[:space:]]+/ && !has_runtime_secret($0) { next }
+                    /^-[[:space:]]*(SECRET_PATTERN(_STRICT(_NO_KEY)?|_NO_GENERIC)?|SENSITIVE_PATTERN(_STRICT|_NO_GENERIC)?|JWT_PATTERN(_STRICT)?|_[A-Z0-9_]+_RX|_GH[A-Z_]+|_SK_PREFIX|_GENERIC_[A-Z_]+_PREFIX)=/ && !has_runtime_secret($0) { next }
+                    /^-[[:space:]]*printf[[:space:]]+-v[[:space:]]+SECRET_PATTERN_STRICT_NO_KEY[[:space:]]+/ && !has_runtime_secret($0) { next }
                     /^[+-][[:space:]]*(GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY):[[:space:]]*\$\{\{[[:space:]]*secrets\.(GITHUB_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY)[[:space:]]*\}\}[[:space:]]*$/ && !has_runtime_secret($0) { next }
                     /^[+-][[:space:]]*-H[[:space:]]+"(Authorization: Bearer \$OPENAI_API_KEY|x-api-key: \$ANTHROPIC_API_KEY)"[[:space:]]*\\?[[:space:]]*$/ && !has_runtime_secret($0) { next }
                     { print }


### PR DESCRIPTION
## Summary
- fail closed before head-bound workflow dispatch for fork PR refs that cannot be targeted safely in the base repo
- limit secret pre-scan guardrail regex-definition exemptions to deleted legacy lines, never added lines

## Validation
- `actionlint .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/merglbot-pr-assistant-v3-on-demand.yml"); puts "yaml_ok"'`
- `bash scripts/pr-assistant/extract-zaver-field.sh --self-test`
- `scripts/pr-assistant/verify-review-receipt.py --self-test`
- `git diff --check`

## Related SSOT evidence
- `merglbot-public/docs#721`
- `merglbot-public/docs#722`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions dispatch logic to fail closed for fork PR heads and adjusts secret pre-scan filtering; mistakes here could prevent reviews from running or reduce secret-detection coverage.
> 
> **Overview**
> Prevents the on-demand PR Assistant workflow from dispatching a head-bound `workflow_dispatch` run to refs that come from a fork by fetching `headRepository` and failing closed unless the PR head repo matches `GITHUB_REPOSITORY`.
> 
> Tightens the secret pre-scan guardrail in `prepare_secret_scan_input` so regex-definition exemptions apply only to **deleted** legacy lines (prefix `-`), ensuring newly added pattern-definition lines remain subject to secret detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be8dd8358f5d1bcf96e35bec428baf749fc2d06e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->