### PR TITLE
fix(pr-assistant): reduce rollout review false blockers

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -168,7 +168,7 @@ jobs:
             fi
             local comment_body
             comment_body="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
-            COMMENT_BODY="$comment_body" python3 -c 'import os, re, sys; body = re.sub(r"\s+", " ", os.environ.get("COMMENT_BODY", "")).rstrip().lower(); body = re.sub(r"[.!?]+$", "", body); parts = body.split(" "); allowed_flags = {"--full", "--light", "--retro", "--learn", "--full-diff"}; ok = len(parts) >= 2 and parts[0] == "@merglbot" and parts[1] == "review" and all(part in allowed_flags for part in parts[2:]); sys.exit(0 if ok else 1)'
+            COMMENT_BODY="$comment_body" python3 -c 'import os, re, sys; body = re.sub(r"\s+", " ", os.environ.get("COMMENT_BODY", "")).strip().lower(); body = re.sub(r"[.!?]+$", "", body); parts = body.split(); allowed_flags = {"--full", "--light", "--retro", "--learn", "--full-diff"}; ok = len(parts) >= 2 and parts[0] == "@merglbot" and parts[1] == "review" and all(part in allowed_flags for part in parts[2:]); sys.exit(0 if ok else 1)'
           }
 
           # Authorization gate: avoid running expensive workflows for untrusted commenters
@@ -764,8 +764,18 @@ jobs:
               .[]
               | select(.user.login | test($pat; "i"))
               | select(($cutoff == "") or (.created_at > $cutoff))
-              | select(((.body // "") | test("unable to generate a review|no actionable findings|no issues found|no bugs found"; "i")) | not)
-              | .body
+              | (.body // "") as $body
+              | ($body | gsub("\\s+"; " ") | ascii_downcase | gsub("^\\s+|\\s+$"; "")) as $normalized
+              | select(
+                  (
+                    ($normalized | test("^> \\[!note\\] > gemini is unable to generate a review for this pull request due to the file types involved not being currently supported\\.?$"))
+                    or ($normalized | test("^unable to generate a review[.! ]*$"))
+                    or ($normalized | test("^no actionable findings[.! ]*$"))
+                    or ($normalized | test("^no issues found[.! ]*$"))
+                    or ($normalized | test("^no bugs found[.! ]*$"))
+                  ) | not
+                )
+              | $body
             ' issue_comments.json 2>/dev/null || echo "")
             if [ -n "$FINDINGS" ] && [ "$FINDINGS" != "null" ]; then
               {
@@ -1740,6 +1750,8 @@ jobs:
           REVIEW_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           CHECK_SUMMARY="Merglbot PR Assistant v3 reviewed PR head ${PR_HEAD_SHA}. Verdict: ${REVIEW_VERDICT:-unknown}. Run: ${REVIEW_RUN_URL}"
 
+          # Run-scoped idempotency: retries of the same workflow run patch their
+          # original check run, while fresh review runs remain separate audit records.
           CHECK_EXTERNAL_ID="merglbot-pr-assistant-v3-${GITHUB_RUN_ID}"
 
           jq -n \
@@ -1764,30 +1776,45 @@ jobs:
               }
             }' > pr_check_run_payload.json
 
-          EXISTING_CHECK_ID="$(
-            gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs?per_page=100&filter=all" 2>/dev/null \
-              | jq -sr --arg name "Merglbot PR Assistant v3" --arg external_id "$CHECK_EXTERNAL_ID" '
+          EXISTING_CHECK_ID=""
+          if gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs?per_page=100&filter=all" > pr_check_runs_for_publish.json 2>/dev/null; then
+            EXISTING_CHECK_ID="$(
+              jq -sr --arg name "Merglbot PR Assistant v3" --arg external_id "$CHECK_EXTERNAL_ID" '
                   [ .[]?.check_runs[]?
                     | select((.name // "") == $name)
                     | select((.external_id // "") == $external_id)
                     | .id
                   ][0] // empty
-                ' || true
-          )"
-
-          if [ -n "${EXISTING_CHECK_ID:-}" ]; then
-            jq 'del(.head_sha)' pr_check_run_payload.json > pr_check_run_update_payload.json
-            gh api "repos/${GITHUB_REPOSITORY}/check-runs/${EXISTING_CHECK_ID}" \
-              --method PATCH \
-              --input pr_check_run_update_payload.json > pr_check_run_response.json
+                ' pr_check_runs_for_publish.json 2>/dev/null || true
+            )"
           else
-            gh api "repos/${GITHUB_REPOSITORY}/check-runs" \
-              --method POST \
-              --input pr_check_run_payload.json > pr_check_run_response.json
+            echo "WARN: Unable to list PR head check-runs before publish; creating a new check-run if possible" >&2
           fi
 
-          jq -e '.id and .head_sha' pr_check_run_response.json >/dev/null
-          printf '%s\n' "published" > pr_check_surface_state.txt
+          CHECK_PUBLISH_STATE="published"
+          if [ -n "${EXISTING_CHECK_ID:-}" ]; then
+            jq 'del(.head_sha)' pr_check_run_payload.json > pr_check_run_update_payload.json
+            if ! gh api "repos/${GITHUB_REPOSITORY}/check-runs/${EXISTING_CHECK_ID}" \
+              --method PATCH \
+              --input pr_check_run_update_payload.json > pr_check_run_response.json; then
+              echo "WARN: Failed to patch PR-visible check-run ${EXISTING_CHECK_ID}; continuing with review comment only" >&2
+              CHECK_PUBLISH_STATE="publish_failed"
+            fi
+          else
+            if ! gh api "repos/${GITHUB_REPOSITORY}/check-runs" \
+              --method POST \
+              --input pr_check_run_payload.json > pr_check_run_response.json; then
+              echo "WARN: Failed to create PR-visible check-run; continuing with review comment only" >&2
+              CHECK_PUBLISH_STATE="publish_failed"
+            fi
+          fi
+
+          if [ "$CHECK_PUBLISH_STATE" = "published" ] && jq -e '.id and .head_sha' pr_check_run_response.json >/dev/null 2>&1; then
+            printf '%s\n' "published" > pr_check_surface_state.txt
+          else
+            echo "WARN: PR-visible check-run response was unavailable or malformed; continuing with review comment only" >&2
+            printf '%s\n' "publish_failed" > pr_check_surface_state.txt
+          fi
 
       - name: Verify PR Check Surface
         if: success() && steps.context.outputs.skip_review != 'true'
@@ -1805,6 +1832,12 @@ jobs:
           if [ -z "${PR_HEAD_SHA:-}" ]; then
             echo "ERROR: Empty PR head SHA; cannot verify PR-visible check surface" >&2
             exit 1
+          fi
+
+          CHECK_SURFACE_STATE="$(tr -d '\r\n' < pr_check_surface_state.txt 2>/dev/null || true)"
+          if [ "$CHECK_SURFACE_STATE" != "published" ]; then
+            echo "WARN: Skipping PR check surface verification because publish state is ${CHECK_SURFACE_STATE:-unknown}" >&2
+            exit 0
           fi
 
           CHECK_EXTERNAL_ID="merglbot-pr-assistant-v3-${GITHUB_RUN_ID}"
@@ -1831,7 +1864,7 @@ jobs:
           done
 
           if ! [[ "${MATCH_COUNT:-0}" =~ ^[0-9]+$ ]] || [ "${MATCH_COUNT}" -eq 0 ]; then
-            echo "ERROR: Current workflow run check ${CHECK_EXTERNAL_ID} is not visible on PR head ${PR_HEAD_SHA:0:12}" >&2
+            echo "WARN: Current workflow run check ${CHECK_EXTERNAL_ID} is not visible on PR head ${PR_HEAD_SHA:0:12}; continuing with review comment only" >&2
             echo "Observed PR check runs on head:" >&2
             jq -r '
               (.check_runs // [])[]?
@@ -1840,7 +1873,7 @@ jobs:
                 + "external_id=" + ((.external_id // "none") | tostring) + " "
                 + (.details_url // "no-details-url")
             ' pr_head_check_runs.json >&2 || true
-            exit 1
+            printf '%s\n' "verify_failed" > pr_check_surface_state.txt
           fi
 
       - name: Post Review Comment


### PR DESCRIPTION
## Summary
- accept leading whitespace for `@merglbot review` while still rejecting trailing prose and unknown flags
- narrow bot issue-comment suppression to exact known no-op templates instead of broad substring matching
- make PR Check Run publish/verify non-fatal so transient Checks API issues do not suppress the review comment
- document that Check Run idempotency is run-scoped for retries while fresh reviews remain separate audit records

## Validation
- `actionlint .github/workflows/merglbot-pr-assistant-v3-on-demand.yml`
- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`
- `scripts/pr-assistant/extract-zaver-field.sh --self-test`
- `bash -n scripts/pr-assistant/extract-zaver-field.sh`
- `bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh`
- `git diff --check`

## Rollout context
This addresses the shared findings from the 43-repo PR Assistant v3 guard propagation review round. After merge, this canonical source should be repropagated to the existing consumer PR branches before fleet closeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts the PR Assistant workflow’s trigger parsing, bot-comment filtering, and Checks API publishing/verification behavior; mistakes could cause missed triggers or reduced observability, but changes are scoped to CI automation.
> 
> **Overview**
> Improves `@merglbot review` detection to accept leading whitespace and require an exact command with only known flags (no trailing prose).
> 
> Tightens “no-op” bot finding suppression by normalizing bodies and matching only specific known templates, reducing accidental hiding of real findings.
> 
> Makes PR check-run publish and visibility verification **non-fatal**: failures now warn, record `publish_failed`/`verify_failed` state, and continue posting the PR review comment; also documents run-scoped idempotency via `external_id` tied to `GITHUB_RUN_ID`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75835c0ee398bdfb33111f8dd55b0a299dc78961. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->