### PR TITLE
fix(pr-assistant): keep check-run create fallback

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1789,15 +1789,14 @@ jobs:
                   ][0] // empty
                 ' pr_check_runs_for_publish.json 2> pr_check_runs_for_publish_jq.err
             )"; then
-              echo "WARN: Unable to parse PR head check-runs before publish; skipping publish to preserve run-scoped idempotency" >&2
+              echo "WARN: Unable to parse PR head check-runs before publish; creating a fallback check-run if possible" >&2
               head -c 4000 pr_check_runs_for_publish_jq.err >&2 || true
-              CHECK_PUBLISH_STATE="publish_failed"
               EXISTING_CHECK_ID=""
             fi
           else
-            echo "WARN: Unable to list PR head check-runs before publish; skipping publish to preserve run-scoped idempotency" >&2
+            echo "WARN: Unable to list PR head check-runs before publish; creating a fallback check-run if possible" >&2
             head -c 4000 pr_check_runs_for_publish.err >&2 || true
-            CHECK_PUBLISH_STATE="publish_failed"
+            EXISTING_CHECK_ID=""
           fi
 
           if [ "$CHECK_PUBLISH_STATE" = "published" ]; then


### PR DESCRIPTION
## Summary
- keep PR-visible Check Run create fallback when read-side lookup/listing fails
- preserve non-fatal publish failure behavior for actual create/patch errors
- address fleet rollout Merglbot finding on transient check-run lookup failures

## Verification
- `git diff --check`
- workflow text assertion for fallback wording
- YAML parse via PyYAML

## Rollout context
Follow-up to PR Assistant v3 guard propagation for PR Assistant v4 enterprise rollout. This PR is canonical source only; after merge it must be repropagated to the 43 copy-target PR branches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak confined to GitHub check-run publishing; the main behavior change is attempting to create a new check-run when check-run listing/parsing fails, which could slightly increase duplicate check-runs during transient API issues.
> 
> **Overview**
> Ensures the PR Assistant workflow still *publishes a PR-visible check-run* even when the pre-publish `gh api` check-run list or `jq` parse step fails.
> 
> Instead of marking publish as failed and skipping the check-run update/create path, the workflow now clears `EXISTING_CHECK_ID` and proceeds to the existing fallback logic to create a new check-run when an existing one can’t be identified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d267088b197286827ea74922ee57312c3a1a838. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->