### PR TITLE
fix(pr-assistant): retry check-run lookup before fail-closed

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1779,7 +1779,18 @@ jobs:
 
           EXISTING_CHECK_ID=""
           CHECK_PUBLISH_STATE="published"
-          if gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs?per_page=100&filter=all" > pr_check_runs_for_publish.json 2> pr_check_runs_for_publish.err; then
+          CHECK_LOOKUP_OK="false"
+          for check_lookup_attempt in 1 2 3; do
+            if gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs?per_page=100&filter=all" > pr_check_runs_for_publish.json 2> pr_check_runs_for_publish.err; then
+              CHECK_LOOKUP_OK="true"
+              break
+            fi
+            echo "WARN: Unable to list PR head check-runs before publish (attempt ${check_lookup_attempt}/3)" >&2
+            head -c 4000 pr_check_runs_for_publish.err >&2 || true
+            sleep "$((check_lookup_attempt * 2))"
+          done
+
+          if [ "$CHECK_LOOKUP_OK" = "true" ]; then
             if ! EXISTING_CHECK_ID="$(
               jq -sr --arg name "Merglbot PR Assistant v3" --arg external_id "$CHECK_EXTERNAL_ID" '
                   [ .[]?.check_runs[]?
@@ -1789,13 +1800,14 @@ jobs:
                   ][0] // empty
                 ' pr_check_runs_for_publish.json 2> pr_check_runs_for_publish_jq.err
             )"; then
-              echo "WARN: Unable to parse PR head check-runs before publish; creating a fallback check-run if possible" >&2
+              echo "WARN: Unable to parse PR head check-runs before publish; skipping publish to preserve run-scoped idempotency" >&2
               head -c 4000 pr_check_runs_for_publish_jq.err >&2 || true
+              CHECK_PUBLISH_STATE="publish_failed"
               EXISTING_CHECK_ID=""
             fi
           else
-            echo "WARN: Unable to list PR head check-runs before publish; creating a fallback check-run if possible" >&2
-            head -c 4000 pr_check_runs_for_publish.err >&2 || true
+            echo "WARN: Unable to list PR head check-runs before publish after retries; skipping publish to preserve run-scoped idempotency" >&2
+            CHECK_PUBLISH_STATE="publish_failed"
             EXISTING_CHECK_ID=""
           fi
 


### PR DESCRIPTION
## Summary
- retry PR-head Check Run lookup up to 3 times before publishing
- fail closed after lookup/parse exhaustion to preserve run-scoped idempotency
- keeps create/patch path only when the read-side lookup is trustworthy

## Verification
- `git diff --check`
- YAML parse via PyYAML
- bounded retry text assertions

## Rollout context
Follow-up to PR Assistant v3 guard propagation review feedback: this resolves the conflict between PR-visible Check Run reliability and duplicate Check Run idempotency. After merge, repropagate this canonical source to the 43 copy-target PR branches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the workflow’s PR check-run publishing behavior to add bounded retries and to skip publishing when check-run listing/parsing fails, which could reduce check-run visibility but avoids duplicate/incorrect check updates.
> 
> **Overview**
> Improves reliability and idempotency of the PR Assistant’s **PR-visible Check Run publishing** in `merglbot-pr-assistant-v3-on-demand.yml`.
> 
> The workflow now **retries PR-head check-run lookup up to 3 times with backoff**, and **fails closed**: if listing/parsing check-runs still fails, it marks the publish as `publish_failed` and skips create/patch rather than attempting a fallback check-run that could break run-scoped idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94bf29aeb22eb95631e4e7b6334d48013b258df1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->