### PR TITLE
fix(pr-assistant): avoid verifier self-test redeclaration

### DIFF
--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -366,12 +366,12 @@ def self_test() -> int:
         "missing_or_invalid_documentation_obligation_state",
         "review_docs_state_blocks_closeout",
     ]
-    blockers: list[str] = []
+    review_blockers: list[str] = []
     status = "blocked"
     verdict = "changes_required"
     if status != "success" or verdict != "approved_for_closeout":
-        blockers.append("review_not_approved_for_closeout")
-    assert blockers == ["review_not_approved_for_closeout"]
+        review_blockers.append("review_not_approved_for_closeout")
+    assert review_blockers == ["review_not_approved_for_closeout"]
     assert expected_run_url("https://github.enterprise.example/o/r/pull/42", "123") == (
         "https://github.enterprise.example/o/r/actions/runs/123"
     )


### PR DESCRIPTION
## Summary
- rename the second verifier self-test blockers list to avoid mypy `no-redef`
- unblock repositories that run mypy across copied PR Assistant scripts

## Verification
- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`
- `git diff --check`

## Rollout context
Canonical source follow-up for PR Assistant v3 guard propagation. After merge, repropagate this source to the remaining open copy-target PR branches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a self-test-only variable rename to avoid a `mypy` `no-redef` error, with no change to runtime verification logic.
> 
> **Overview**
> Renames the second `blockers` list in `verify-review-receipt.py --self-test` to `review_blockers` to avoid mypy variable redeclaration (`no-redef`) when type-checking the script.
> 
> No behavioral change: assertions and blocker contents in the self-test remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc8c136a1dadcf69ba0adaa3dfe81b20a2aa458c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->