### PR TITLE
Fix PR assistant publish verdict parsing

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -1703,7 +1703,7 @@ jobs:
           }
 
           REVIEW_VERDICT="blocked_missing_authority"
-          VERDICT_LINE="$(scripts/pr-assistant/extract-zaver-field.sh "Verdict" final_review.txt 2>/dev/null || true)"
+          VERDICT_LINE="$(bash scripts/pr-assistant/extract-zaver-field.sh "Verdict" final_review.txt 2>/dev/null || true)"
           if [ -n "$VERDICT_LINE" ]; then
             REVIEW_VERDICT_RAW="$(normalize_machine_token "$(printf '%s' "$VERDICT_LINE" | sed -E 's/^Verdict:[[:space:]]*//I')")"
             case "$REVIEW_VERDICT_RAW" in
@@ -1725,6 +1725,13 @@ jobs:
           case "$DOCUMENTATION_OBLIGATION_STATE" in
             satisfied|not_required) ;;
             missing|unknown)
+              if [ "$REVIEW_VERDICT" = "approved_for_closeout" ]; then
+                REVIEW_VERDICT="blocked_missing_authority"
+              fi
+              ;;
+            *)
+              echo "::warning::Unexpected DOCUMENTATION_OBLIGATION_STATE='${DOCUMENTATION_OBLIGATION_STATE}', normalizing to unknown advisory metadata."
+              DOCUMENTATION_OBLIGATION_STATE="unknown"
               if [ "$REVIEW_VERDICT" = "approved_for_closeout" ]; then
                 REVIEW_VERDICT="blocked_missing_authority"
               fi


### PR DESCRIPTION
## Summary
- invoke extract-zaver-field through bash in the Publish PR Check Surface step
- add the same fail-closed default handling for unexpected documentation states used by the comment publishing path

## Verification
- python YAML parse of .github/workflows/merglbot-pr-assistant-v3-on-demand.yml
- static assertions for bash invocation and docs-state default branch
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that makes verdict parsing more robust and fail-closed when documentation state metadata is unexpected; main risk is altered check-run status on edge-case metadata values.
> 
> **Overview**
> Fixes the PR check-surface publish step to invoke `extract-zaver-field.sh` via `bash`, avoiding reliance on executable/shebang behavior when parsing the final review `Verdict`.
> 
> Hardens documentation obligation handling during check publishing by adding a *fail-closed* default for unexpected `DOCUMENTATION_OBLIGATION_STATE` values (warn, normalize to `unknown`, and prevent `approved_for_closeout` from being emitted when docs state isn’t trusted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2544a09e27545fd8d1f1d5c44f4e177f2f2f126. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->