### PR TITLE
Treat PR assistant rollout CI mirror as no-docs

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -577,6 +577,7 @@ jobs:
             local changed_files_path="${1:-changed_files.txt}"
             local has_docs_evidence="false"
             local has_impactful="false"
+            local has_pr_assistant_copy_file="false"
             local has_non_pr_assistant_copy_file="false"
             if [ ! -s "$changed_files_path" ]; then
               echo "unknown"
@@ -592,6 +593,20 @@ jobs:
               case "$changed_path" in
                 .github/workflows/merglbot-pr-v3-on-demand.yml|.github/workflows/merglbot-pr-assistant-v3-on-demand.yml|scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh|scripts/pr-assistant/verify-review-receipt.py|scripts/pr-assistant/extract-zaver-field.sh)
                   has_impactful="true"
+                  has_pr_assistant_copy_file="true"
+                  ;;
+                .github/workflows/ci.yml)
+                  has_impactful="true"
+                  case "${PR_HEAD_REF:-}" in
+                    codex/pr-assistant-v3-*)
+                      # Managed rollout support: some copy-target repos need a
+                      # required-check mirror job in ci.yml, but only alongside
+                      # PR Assistant copy files.
+                      ;;
+                    *)
+                      has_non_pr_assistant_copy_file="true"
+                      ;;
+                  esac
                   ;;
                 .github/workflows/*|scripts/*|src/*|app/*|packages/*|terraform/*|infra/*|Dockerfile|**/Dockerfile|*.tf|*.py|*.js|*.ts|*.tsx|*.jsx|*.sh|*.yml|*.yaml)
                   has_impactful="true"
@@ -599,7 +614,7 @@ jobs:
                   ;;
               esac
             done < "$changed_files_path"
-            if [ "$has_impactful" = "true" ] && [ "$has_non_pr_assistant_copy_file" = "false" ]; then
+            if [ "$has_pr_assistant_copy_file" = "true" ] && [ "$has_non_pr_assistant_copy_file" = "false" ]; then
               echo "not_required"
               return 0
             fi

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -24,6 +24,12 @@ PR_ASSISTANT_WORKFLOW_PATHS = {
     ".github/workflows/merglbot-pr-assistant-v3-on-demand.yml",
     ".github/workflows/merglbot-pr-v3-on-demand.yml",
 }
+PR_ASSISTANT_COPY_PATHS = PR_ASSISTANT_WORKFLOW_PATHS | {
+    "scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh",
+    "scripts/pr-assistant/verify-review-receipt.py",
+    "scripts/pr-assistant/extract-zaver-field.sh",
+}
+PR_ASSISTANT_ROLLOUT_SUPPORT_PATHS = {".github/workflows/ci.yml"}
 
 
 def gh_json(args: list[str]) -> Any:
@@ -57,6 +63,23 @@ def normalize_heading(value: str) -> str:
 
 def docs_state_blocks_closeout(verdict: str, docs_state: str) -> bool:
     return verdict == "approved_for_closeout" and docs_state in {"missing", "unknown"}
+
+
+def classify_pr_assistant_copy_docs_state(
+    changed_paths: set[str],
+    pr_head_ref: str,
+) -> str:
+    has_pr_assistant_copy_file = bool(changed_paths & PR_ASSISTANT_COPY_PATHS)
+    non_copy_paths = set(changed_paths) - PR_ASSISTANT_COPY_PATHS
+    if pr_head_ref.startswith("codex/pr-assistant-v3-"):
+        non_copy_paths -= PR_ASSISTANT_ROLLOUT_SUPPORT_PATHS
+    if has_pr_assistant_copy_file and not non_copy_paths:
+        return "not_required"
+    if any(path.endswith(".md") or path.startswith("docs/") for path in changed_paths):
+        return "satisfied"
+    if changed_paths:
+        return "missing"
+    return "not_required"
 
 
 def extract_zaver_field(body: str, field_name: str) -> str:
@@ -381,6 +404,36 @@ def self_test() -> int:
     )
     assert (
         ".github/workflows/merglbot-pr-v3-on-demand.yml" in PR_ASSISTANT_WORKFLOW_PATHS
+    )
+    copy_paths = {
+        ".github/workflows/merglbot-pr-v3-on-demand.yml",
+        "scripts/pr-assistant/verify-review-receipt.py",
+    }
+    copy_with_ci = copy_paths | {".github/workflows/ci.yml"}
+    assert (
+        classify_pr_assistant_copy_docs_state(copy_paths, "codex/pr-assistant-v3-guard")
+        == "not_required"
+    )
+    assert (
+        classify_pr_assistant_copy_docs_state(
+            copy_with_ci,
+            "codex/pr-assistant-v3-guard",
+        )
+        == "not_required"
+    )
+    assert (
+        classify_pr_assistant_copy_docs_state(
+            {".github/workflows/ci.yml"},
+            "codex/pr-assistant-v3-guard",
+        )
+        == "missing"
+    )
+    assert (
+        classify_pr_assistant_copy_docs_state(
+            copy_with_ci,
+            "feature/unrelated-ci",
+        )
+        == "missing"
     )
     print(json.dumps({"ok": True, "self_test": "passed"}))
     return 0


### PR DESCRIPTION
## Summary
- keep PR Assistant managed copy updates docs-not-required even when a propagation PR also carries the required-check mirror job in .github/workflows/ci.yml
- limit the exception to codex/pr-assistant-v3-* rollout branches that also contain PR Assistant copy files

## Verification
- python YAML parse of .github/workflows/merglbot-pr-assistant-v3-on-demand.yml
- static assertions for the rollout-support classifier branch
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts the PR Assistant workflow’s docs-obligation classifier logic, which can change whether PRs are flagged as missing documentation; mistakes here could silently relax or over-enforce docs requirements on some branches.
> 
> **Overview**
> Updates `classify_documentation_obligation` in `.github/workflows/merglbot-pr-assistant-v3-on-demand.yml` to more narrowly treat PR Assistant “managed copy” propagation PRs as **docs not required**.
> 
> The classifier now tracks PR-Assistant-copy changes separately from other impactful changes, and adds a special case for `.github/workflows/ci.yml`: it’s ignored for `codex/pr-assistant-v3-*` rollout branches but still counts as non-PR-assistant impact elsewhere, preventing CI-mirror-only rollout PRs from triggering a docs-missing state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 878bf2a10b1c93084f578759208bb3ebe1da1545. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->