### PR TITLE
Harden PR assistant command and review parsing

### DIFF
--- a/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
+++ b/.github/workflows/merglbot-pr-assistant-v3-on-demand.yml
@@ -130,8 +130,7 @@ jobs:
       (
         (github.event_name == 'issue_comment' &&
          github.event.issue.pull_request &&
-         startsWith(github.event.comment.body, '@merglbot review') &&
-         !contains(github.event.comment.body, '@merglbot review-v4')) ||
+         startsWith(github.event.comment.body, '@merglbot review')) ||
         github.event_name == 'workflow_dispatch'
       )
     outputs:
@@ -173,6 +172,18 @@ jobs:
 
           # Authorization gate: avoid running expensive workflows for untrusted commenters
           if [ "$IS_WORKFLOW_DISPATCH" != "true" ]; then
+            if ! merglbot_v3_command_present; then
+              echo "⏭️ Skipping: no exact v3 @merglbot review command present"
+              {
+                echo "pr_number=$ISSUE_NUMBER"
+                echo "should_run=false"
+                echo "review_mode=light"
+                echo "diff_scope=auto"
+                echo "include_retro=false"
+                echo "trigger_comment_id=${COMMENT_ID:-}"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             case "${AUTHOR_ASSOCIATION:-}" in
               OWNER|MEMBER|COLLABORATOR)
                 ;;
@@ -189,18 +200,6 @@ jobs:
                 exit 0
                 ;;
             esac
-            if ! merglbot_v3_command_present; then
-              echo "⏭️ Skipping: no exact v3 @merglbot review command present"
-              {
-                echo "pr_number=$ISSUE_NUMBER"
-                echo "should_run=false"
-                echo "review_mode=light"
-                echo "diff_scope=auto"
-                echo "include_retro=false"
-                echo "trigger_comment_id=${COMMENT_ID:-}"
-              } >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
           fi
 
           flag_present() {
@@ -2224,7 +2223,7 @@ jobs:
                   field_name_normalized = field_label_clean.lower()
                   if len(parts) == 2 and field_name_normalized in replacements:
                       canonical_label, target = replacements[field_name_normalized]
-                      prefix = re.match(r"^([\s>\-*+]*)", line).group(1)
+                      prefix = re.match(r"^([\s>]*(?:[-*+]\s+)?)", line).group(1)
                       out.append(f"{prefix}{canonical_label}: {target}")
                       updated.add(field_name_normalized)
                       continue

--- a/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
+++ b/scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
@@ -965,6 +965,8 @@ echo "Prompt size: $PROMPT_SIZE chars"
         continue
       fi
 
+      # Adaptive-thinking responses can include non-text blocks before the
+      # final answer; review text is the concatenation of text blocks only.
       ANTHROPIC_CONTENT="$(echo "$ANTHROPIC_RESP" | jq -r '[.content[]? | select(.type=="text") | .text] | join("\n")')"
       if [ -z "$ANTHROPIC_CONTENT" ] || [ "$ANTHROPIC_CONTENT" = "null" ]; then
         echo "  ERROR: Anthropic response contained no content" >&2


### PR DESCRIPTION
## Summary
- let the exact v3 command parser, not a broad body contains check, distinguish review-v4 from review
- run exact command validation before authorization to make the gate structure unambiguous
- document Anthropic adaptive-thinking text-block parsing
- preserve only list/quote prefix when normalizing Zaver fields to avoid dangling Markdown formatting

## Verification
- python YAML parse of .github/workflows/merglbot-pr-assistant-v3-on-demand.yml
- bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions trigger/authorization gating and command parsing for the PR Assistant, which could affect when the workflow runs or skips on PR comments. Also tweaks model-response and markdown normalization logic that could subtly change generated review output formatting.
> 
> **Overview**
> **PR Assistant v3 trigger handling is hardened.** The workflow now relies on the exact v3 command parser (instead of excluding `@merglbot review-v4` via a broad contains check) and runs exact-command validation *before* the author-association authorization gate, making skip/run decisions unambiguous.
> 
> **Review output parsing/formatting is made more robust.** Anthropic response extraction is explicitly documented to concatenate only `.content` text blocks, and the Zaver field normalizer preserves only list/quote prefixes when rewriting fields to avoid dangling Markdown formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 902e9a9700a84265927fd2bd85d67c0712caef84. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->