### PR TITLE
chore: PR Assistant v4 staging canary

### DIFF
--- a/.merglbot-canary/pr-assistant-v4-stg-canary-20260427.md
+++ b/.merglbot-canary/pr-assistant-v4-stg-canary-20260427.md
@@ -1,0 +1,6 @@
+# PR Assistant v4 staging canary
+
+This temporary file exists only to create a harmless staging canary PR for the
+PR Assistant v4 GitHub App.
+
+The PR must be closed without merge after canary evidence is collected.


### PR DESCRIPTION
Temporary staging canary PR for PR Assistant v4 GitHub App.

Validation target:
- trigger `@merglbot review-v4`
- verify one v4 check run on this PR head
- verify markers/logs/no v3 duplicate

This PR must be closed without merge after canary evidence is collected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a temporary markdown file for staging verification with no code-path or runtime behavior changes. Low risk aside from minor repository noise if not removed/closed as intended.
> 
> **Overview**
> Adds `.merglbot-canary/pr-assistant-v4-stg-canary-20260427.md`, a temporary markdown marker file intended to create a harmless staging canary PR for validating the PR Assistant v4 GitHub App, with instructions to close the PR without merging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a63a32fc21433ac83d082036a5db1d551609f5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->