### PR TITLE
fix(pr-assistant): wrap review verifier docs blocker check

### DIFF
--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -62,7 +62,10 @@ def normalize_heading(value: str) -> str:
 
 
 def docs_state_blocks_closeout(verdict: str, docs_state: str) -> bool:
-    return verdict in {"approved_for_closeout", "blocked_missing_authority"} and docs_state in {"missing", "unknown"}
+    return verdict in {
+        "approved_for_closeout",
+        "blocked_missing_authority",
+    } and docs_state in {"missing", "unknown"}
 
 
 def classify_pr_assistant_copy_docs_state(


### PR DESCRIPTION
## Summary
- wraps the docs-state blocker predicate in the v3 review receipt verifier so copied repos with E501 lint gates can pass
- keeps the verifier behavior unchanged while preserving the canonical v3 guard source

## Validation
- bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
- bash -n scripts/pr-assistant/extract-zaver-field.sh
- python3 -m py_compile scripts/pr-assistant/verify-review-receipt.py
- python3 scripts/pr-assistant/verify-review-receipt.py --self-test

Docs obligation: not required; formatting-only helper script change.