### PR TITLE
ci: add Final Merge Readiness policy gate

### DIFF
--- a/.github/policies/final-merge-readiness.json
+++ b/.github/policies/final-merge-readiness.json
@@ -1,0 +1,141 @@
+{
+  "schema_version": 1,
+  "policy_id": "merglbot.final_merge_readiness",
+  "policy_version": "2026-05-01",
+  "mode": "human_merge_only",
+  "scope_baseline": {
+    "github_active_repo_denominator": 46,
+    "gcp_merglbot_project_denominator": 31,
+    "prompt_ssot": "merglbot-core/agents-orchestrator/prompt-library/assets",
+    "prompt_compatibility_mirror": "merglbot-core/ai_prompts",
+    "excluded_github_orgs": [
+      "Merglevsky-cz",
+      "lrtch"
+    ],
+    "governance_only_orgs": [
+      "merglbot-shared"
+    ]
+  },
+  "pr_assistant": {
+    "role": "review_only_evidence_provider",
+    "allowed_markers": [
+      "MERGLBOT_PR_ASSISTANT_V4",
+      "MERGLBOT_PR_ASSISTANT_V3"
+    ],
+    "trusted_comment_logins": [
+      "github-actions[bot]",
+      "github-actions"
+    ],
+    "required_receipt_schema_versions": [
+      "1"
+    ],
+    "review_boundary_required": true,
+    "required_closeout_mode": "human_merge_only",
+    "approved_verdicts": [
+      "approved_for_closeout"
+    ],
+    "successful_statuses": [
+      "success"
+    ],
+    "passing_documentation_states": [
+      "satisfied",
+      "not_required"
+    ],
+    "required_pr_check_surface": "verified",
+    "allowed_workflow_paths": [
+      ".github/workflows/merglbot-pr-assistant-v4-on-demand.yml",
+      ".github/workflows/merglbot-pr-assistant-v3-on-demand.yml",
+      ".github/workflows/merglbot-pr-v3-on-demand.yml"
+    ],
+    "forbidden_actions": [
+      "merge_pull_request",
+      "deploy_production",
+      "terraform_apply",
+      "create_documentation_pr"
+    ]
+  },
+  "required_checks": {
+    "source": "branch_protection_with_manifest_fallback",
+    "fallback_required_contexts": [
+      "ci"
+    ],
+    "self_check_names": [
+      "Final Merge Readiness"
+    ],
+    "success_conclusions": [
+      "success",
+      "neutral",
+      "skipped"
+    ],
+    "blocking_conclusions": [
+      "action_required",
+      "cancelled",
+      "failure",
+      "startup_failure",
+      "timed_out"
+    ],
+    "block_failed_non_required_checks": true
+  },
+  "path_risk": {
+    "docs_only_patterns": [
+      "*.md",
+      "docs/**",
+      "training/**",
+      "templates/**/*.md"
+    ],
+    "high_risk_patterns": [
+      ".github/workflows/**",
+      ".github/actions/**",
+      ".github/policies/**",
+      "scripts/**",
+      "terraform/**",
+      "infra/**",
+      "platform/**",
+      "**/*.tf",
+      "**/*.tfvars",
+      "**/*.sh",
+      "**/*.py",
+      "**/*.js",
+      "**/*.ts",
+      "**/*.tsx",
+      "**/*.jsx",
+      "Dockerfile",
+      "**/Dockerfile"
+    ],
+    "forbidden_path_patterns": [
+      ".env",
+      ".env.*",
+      "**/.env",
+      "**/.env.*",
+      "*.pem",
+      "*.p12",
+      "*.pfx",
+      "*.key",
+      "*service-account*.json",
+      "*service_account*.json",
+      "secrets/**"
+    ],
+    "forbidden_content_patterns": [
+      {
+        "id": "private_key_material",
+        "pattern": "-----BEGIN (RSA |DSA |EC |OPENSSH |)?PRIVATE KEY-----",
+        "ignore_case": false
+      },
+      {
+        "id": "gcp_service_account_private_key",
+        "pattern": "\"type\"\\s*:\\s*\"service_account\"[\\s\\S]{0,4000}\"private_key\"\\s*:",
+        "ignore_case": true
+      },
+      {
+        "id": "terraform_apply",
+        "pattern": "\\bterraform\\s+apply\\b",
+        "ignore_case": true
+      },
+      {
+        "id": "branch_protection_admin_bypass",
+        "pattern": "\\b(admin|administrator)\\s+bypass\\b|\\bbypass\\s+branch\\s+protection\\b",
+        "ignore_case": true
+      }
+    ]
+  }
+}

--- a/.github/policies/final-merge-readiness.json
+++ b/.github/policies/final-merge-readiness.json
@@ -129,7 +129,7 @@
     "forbidden_content_patterns": [
       {
         "id": "private_key_material",
-        "pattern": "-----BEGIN (ENCRYPTED |RSA |DSA |EC |OPENSSH |)?PRIVATE KEY-----",
+        "pattern": "-{5}BEGIN (ENCRYPTED |RSA |DSA |EC |OPENSSH |)?PRIVATE\\s+KEY-{5}",
         "ignore_case": false
       },
       {

--- a/.github/policies/final-merge-readiness.json
+++ b/.github/policies/final-merge-readiness.json
@@ -129,7 +129,7 @@
     "forbidden_content_patterns": [
       {
         "id": "private_key_material",
-        "pattern": "-----BEGIN (RSA |DSA |EC |OPENSSH |)?PRIVATE KEY-----",
+        "pattern": "-----BEGIN (ENCRYPTED |RSA |DSA |EC |OPENSSH |)?PRIVATE KEY-----",
         "ignore_case": false
       },
       {

--- a/.github/policies/final-merge-readiness.json
+++ b/.github/policies/final-merge-readiness.json
@@ -24,13 +24,24 @@
     ],
     "trusted_comment_logins": [
       "github-actions[bot]",
-      "github-actions"
+      "github-actions",
+      "merglbot-pr-assistant-v4-stg[bot]",
+      "merglbot-pr-assistant-v4[bot]"
     ],
     "required_receipt_schema_versions": [
       "1"
     ],
     "review_boundary_required": true,
     "required_closeout_mode": "human_merge_only",
+    "external_runtime_types": [
+      "github_app_cloud_run"
+    ],
+    "review_boundary_optional_runtime_types": [
+      "github_app_cloud_run"
+    ],
+    "external_run_id_prefixes": [
+      "pr-assistant-v4:"
+    ],
     "approved_verdicts": [
       "approved_for_closeout"
     ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           bash scripts/pr-assistant/secret-scan-patterns-smoke-test.sh
           python3 -m py_compile scripts/pr-assistant/final-merge-readiness.py
           python3 scripts/pr-assistant/final-merge-readiness.py --self-test
+          test -f scripts/pr-assistant/verify-review-receipt.py
           python3 scripts/pr-assistant/verify-review-receipt.py --self-test
           python3 -m py_compile scripts/dependabot/ent_dependabot_closeout.py
           python3 scripts/dependabot/ent_dependabot_closeout.py --self-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh
           bash -n scripts/pr-assistant/secret-scan-patterns-smoke-test.sh
           bash scripts/pr-assistant/secret-scan-patterns-smoke-test.sh
+          python3 -m py_compile scripts/pr-assistant/final-merge-readiness.py
+          python3 scripts/pr-assistant/final-merge-readiness.py --self-test
+          python3 scripts/pr-assistant/verify-review-receipt.py --self-test
           python3 -m py_compile scripts/dependabot/ent_dependabot_closeout.py
           python3 scripts/dependabot/ent_dependabot_closeout.py --self-test
       - name: Validate PR Assistant rollout manifest

--- a/.github/workflows/final-merge-readiness.yml
+++ b/.github/workflows/final-merge-readiness.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Evaluate final merge readiness
         if: steps.evaluator.outputs.bootstrap != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           EVALUATOR_ROOT: ${{ steps.evaluator.outputs.root }}
           CONTENT_ROOT: ${{ github.workspace }}/pr-head

--- a/.github/workflows/final-merge-readiness.yml
+++ b/.github/workflows/final-merge-readiness.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout pull request head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr-head
 

--- a/.github/workflows/final-merge-readiness.yml
+++ b/.github/workflows/final-merge-readiness.yml
@@ -1,0 +1,72 @@
+name: Final Merge Readiness
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to evaluate
+        required: true
+        type: number
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  issues: read
+  pull-requests: read
+  statuses: read
+
+concurrency:
+  group: final-merge-readiness-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  final-merge-readiness:
+    name: Final Merge Readiness
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout current head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Resolve pull request number
+        id: pr
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${PR_NUMBER_INPUT:-}"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Missing pull request number."
+            exit 1
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+        env:
+          PR_NUMBER_INPUT: ${{ github.event.pull_request.number || inputs.pr_number }}
+
+      - name: Evaluate final merge readiness
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          python3 scripts/pr-assistant/final-merge-readiness.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --pr "$PR_NUMBER" \
+            --output final-merge-readiness-receipt.json
+
+      - name: Publish readiness receipt summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "## Final Merge Readiness Receipt"
+            echo ""
+            if [ -s final-merge-readiness-receipt.json ]; then
+              echo '```json'
+              python3 -m json.tool final-merge-readiness-receipt.json
+              echo '```'
+            else
+              echo "No receipt was produced."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/final-merge-readiness.yml
+++ b/.github/workflows/final-merge-readiness.yml
@@ -3,12 +3,6 @@ name: Final Merge Readiness
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: Pull request number to evaluate
-        required: true
-        type: number
 
 permissions:
   actions: read
@@ -19,41 +13,108 @@ permissions:
   statuses: read
 
 concurrency:
-  group: final-merge-readiness-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}
+  group: final-merge-readiness-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   final-merge-readiness:
     name: Final Merge Readiness
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
-      - name: Checkout current head
+      - name: Checkout pull request head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
+
+      - name: Checkout trusted base
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted-gate
 
       - name: Resolve pull request number
         id: pr
         run: |
           set -euo pipefail
-          PR_NUMBER="${PR_NUMBER_INPUT:-}"
+          PR_NUMBER="${PR_NUMBER_INPUT}"
           if [ -z "$PR_NUMBER" ]; then
             echo "::error::Missing pull request number."
             exit 1
           fi
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
         env:
-          PR_NUMBER_INPUT: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PR_NUMBER_INPUT: ${{ github.event.pull_request.number }}
+
+      - name: Select trusted evaluator source
+        id: evaluator
+        run: |
+          set -euo pipefail
+          TRUSTED_ROOT="$GITHUB_WORKSPACE/trusted-gate"
+          PR_ROOT="$GITHUB_WORKSPACE/pr-head"
+          if [ -f "$TRUSTED_ROOT/scripts/pr-assistant/final-merge-readiness.py" ] && [ -f "$TRUSTED_ROOT/.github/policies/final-merge-readiness.json" ]; then
+            echo "root=$TRUSTED_ROOT" >> "$GITHUB_OUTPUT"
+            echo "bootstrap=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Final Merge Readiness is absent on the protected base ref; using PR-head bootstrap evaluator for this introductory policy PR."
+            echo "root=$PR_ROOT" >> "$GITHUB_OUTPUT"
+            echo "bootstrap=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Evaluate final merge readiness
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+          EVALUATOR_ROOT: ${{ steps.evaluator.outputs.root }}
+          CONTENT_ROOT: ${{ github.workspace }}/pr-head
+          RECEIPT_PATH: ${{ github.workspace }}/final-merge-readiness-receipt.json
         run: |
           set -euo pipefail
-          python3 scripts/pr-assistant/final-merge-readiness.py \
-            --repo "$GITHUB_REPOSITORY" \
-            --pr "$PR_NUMBER" \
-            --output final-merge-readiness-receipt.json
+          cd "$EVALUATOR_ROOT"
+          for attempt in $(seq 1 24); do
+            set +e
+            python3 scripts/pr-assistant/final-merge-readiness.py \
+              --repo "$GITHUB_REPOSITORY" \
+              --pr "$PR_NUMBER" \
+              --content-root "$CONTENT_ROOT" \
+              --output "$RECEIPT_PATH"
+            status=$?
+            set -e
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$attempt" -ge 24 ]; then
+              exit "$status"
+            fi
+            if python3 - "$RECEIPT_PATH" <<'PY'
+          import json
+          import sys
+
+          receipt = json.load(open(sys.argv[1], encoding="utf-8"))
+          blockers = set(receipt.get("blockers") or [])
+          head_sha = receipt.get("head_sha")
+          pr_gate = next(
+              (item for item in receipt.get("decisions", []) if item.get("id") == "pr_assistant_review_only_evidence"),
+              {},
+          )
+          review_head_sha = (pr_gate.get("evidence") or {}).get("review_head_sha")
+          retry = False
+          if "missing_pr_assistant_receipt" in blockers or "pr_assistant_head_sha_mismatch" in blockers:
+              retry = True
+          if review_head_sha and review_head_sha != head_sha:
+              retry = True
+          if any(item.startswith("required_check_missing:") or item.startswith("required_check_not_success:") for item in blockers):
+              retry = True
+          sys.exit(0 if retry else 1)
+          PY
+            then
+              echo "Readiness dependencies are still settling; retrying attempt $((attempt + 1))/24 after 30s."
+              sleep 30
+              continue
+            fi
+            exit "$status"
+          done
 
       - name: Publish readiness receipt summary
         if: always()
@@ -61,6 +122,9 @@ jobs:
           set -euo pipefail
           {
             echo "## Final Merge Readiness Receipt"
+            echo ""
+            echo "- Evaluator root: \`${{ steps.evaluator.outputs.root }}\`"
+            echo "- Bootstrap evaluator: \`${{ steps.evaluator.outputs.bootstrap }}\`"
             echo ""
             if [ -s final-merge-readiness-receipt.json ]; then
               echo '```json'

--- a/.github/workflows/final-merge-readiness.yml
+++ b/.github/workflows/final-merge-readiness.yml
@@ -82,13 +82,13 @@ jobs:
               "head_sha": head_sha,
               "base_ref": base_ref,
               "ok": False,
-              "blockers": ["trusted_evaluator_missing_on_base"],
+              "blockers": ["human_confirmation_required:trusted_evaluator_missing_on_base"],
               "decisions": [
                   {
                       "id": "trusted_evaluator_source",
-                      "status": "fail",
+                      "status": "human_confirmation_required",
                       "summary": "Protected base ref does not yet contain the Final Merge Readiness evaluator and policy.",
-                      "blockers": ["trusted_evaluator_missing_on_base"],
+                      "blockers": ["human_confirmation_required:trusted_evaluator_missing_on_base"],
                       "evidence": {
                           "bootstrap": True,
                           "pr_head_evaluator_executed": False,
@@ -103,7 +103,7 @@ jobs:
               handle.write("\n")
           print(json.dumps(receipt, indent=2, sort_keys=True))
           PY
-          exit 1
+          echo "::notice::Bootstrap receipt requires human confirmation; no PR-head evaluator code was executed."
 
       - name: Evaluate final merge readiness
         if: steps.evaluator.outputs.bootstrap != 'true'

--- a/.github/workflows/final-merge-readiness.yml
+++ b/.github/workflows/final-merge-readiness.yml
@@ -52,17 +52,61 @@ jobs:
         run: |
           set -euo pipefail
           TRUSTED_ROOT="$GITHUB_WORKSPACE/trusted-gate"
-          PR_ROOT="$GITHUB_WORKSPACE/pr-head"
           if [ -f "$TRUSTED_ROOT/scripts/pr-assistant/final-merge-readiness.py" ] && [ -f "$TRUSTED_ROOT/.github/policies/final-merge-readiness.json" ]; then
             echo "root=$TRUSTED_ROOT" >> "$GITHUB_OUTPUT"
             echo "bootstrap=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice::Final Merge Readiness is absent on the protected base ref; using PR-head bootstrap evaluator for this introductory policy PR."
-            echo "root=$PR_ROOT" >> "$GITHUB_OUTPUT"
+            echo "::notice::Final Merge Readiness is absent on the protected base ref; refusing to execute PR-head evaluator code with GitHub token access."
+            echo "root=" >> "$GITHUB_OUTPUT"
             echo "bootstrap=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Record trusted evaluator bootstrap blocker
+        if: steps.evaluator.outputs.bootstrap == 'true'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          RECEIPT_PATH: ${{ github.workspace }}/final-merge-readiness-receipt.json
+        run: |
+          set -euo pipefail
+          python3 - "$RECEIPT_PATH" "$GITHUB_REPOSITORY" "$PR_NUMBER" "${{ github.event.pull_request.head.sha }}" "${{ github.event.pull_request.base.ref }}" <<'PY'
+          import json
+          import sys
+
+          path, repo, pr_number, head_sha, base_ref = sys.argv[1:]
+          receipt = {
+              "schema_version": 1,
+              "policy_id": "merglbot.final_merge_readiness",
+              "policy_version": "2026-05-01",
+              "repo": repo,
+              "pr_number": int(pr_number),
+              "head_sha": head_sha,
+              "base_ref": base_ref,
+              "ok": False,
+              "blockers": ["trusted_evaluator_missing_on_base"],
+              "decisions": [
+                  {
+                      "id": "trusted_evaluator_source",
+                      "status": "fail",
+                      "summary": "Protected base ref does not yet contain the Final Merge Readiness evaluator and policy.",
+                      "blockers": ["trusted_evaluator_missing_on_base"],
+                      "evidence": {
+                          "bootstrap": True,
+                          "pr_head_evaluator_executed": False,
+                          "github_token_exposed_to_pr_head_code": False,
+                          "closeout_mode": "human_merge_only",
+                      },
+                  }
+              ],
+          }
+          with open(path, "w", encoding="utf-8") as handle:
+              json.dump(receipt, handle, indent=2, sort_keys=True)
+              handle.write("\n")
+          print(json.dumps(receipt, indent=2, sort_keys=True))
+          PY
+          exit 1
+
       - name: Evaluate final merge readiness
+        if: steps.evaluator.outputs.bootstrap != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/docs/pr-assistant/final-merge-readiness.md
+++ b/docs/pr-assistant/final-merge-readiness.md
@@ -11,15 +11,18 @@ GitHub Actions check is `.github/workflows/final-merge-readiness.yml`.
 The workflow checks out the PR head only as inspected content. When the
 evaluator already exists on the protected base ref, the check executes that
 trusted base copy of the evaluator and policy while scanning changed-file
-content from the PR checkout. For the introductory policy PR where no protected
-base copy exists yet, the summary marks `Bootstrap evaluator: true` so the
-receipt is explicit policy bootstrap evidence, not autonomous merge authority.
+content from the PR checkout. If no protected base copy exists yet, the check
+does not execute PR-head evaluator code and does not expose `GH_TOKEN` to PR
+head code. It emits a fail-closed `trusted_evaluator_missing_on_base` receipt
+as explicit human-confirmation bootstrap evidence, not autonomous merge
+authority.
 
 The evaluator emits a JSON receipt with these gates:
 
 - `path_risk_gate`: classifies changed paths, blocks committed secret-like
-  files, private key material, service account JSON keys, Terraform execution
-  commands, and branch-protection bypass language.
+  files, private key material including encrypted private key PEM headers,
+  service account JSON keys, Terraform execution commands, and
+  branch-protection bypass language.
 - `pr_assistant_review_only_evidence`: parses the latest trusted PR Assistant
   v4 or v3 receipt comment from `github-actions[bot]` or the approved
   Merglbot v4 GitHub App bot, requires review-only markers where the runtime

--- a/docs/pr-assistant/final-merge-readiness.md
+++ b/docs/pr-assistant/final-merge-readiness.md
@@ -8,6 +8,12 @@ evidence for a human merge.
 The policy manifest lives in `.github/policies/final-merge-readiness.json`.
 The evaluator lives in `scripts/pr-assistant/final-merge-readiness.py`, and the
 GitHub Actions check is `.github/workflows/final-merge-readiness.yml`.
+The workflow checks out the PR head only as inspected content. When the
+evaluator already exists on the protected base ref, the check executes that
+trusted base copy of the evaluator and policy while scanning changed-file
+content from the PR checkout. For the introductory policy PR where no protected
+base copy exists yet, the summary marks `Bootstrap evaluator: true` so the
+receipt is explicit policy bootstrap evidence, not autonomous merge authority.
 
 The evaluator emits a JSON receipt with these gates:
 
@@ -27,6 +33,11 @@ The evaluator emits a JSON receipt with these gates:
 Docs-only pull requests can pass without a PR Assistant receipt. Any non-docs
 or high-risk path still requires trusted PR Assistant evidence for the current
 head.
+
+The check polls bounded asynchronous dependencies for up to 12 minutes. It only
+retries while required checks are still settling or the latest PR Assistant
+receipt is missing/stale for the current head; current-head `changes_required`,
+`partial_authority`, degraded, or blocked receipts still fail immediately.
 
 Local validation:
 

--- a/docs/pr-assistant/final-merge-readiness.md
+++ b/docs/pr-assistant/final-merge-readiness.md
@@ -13,9 +13,8 @@ evaluator already exists on the protected base ref, the check executes that
 trusted base copy of the evaluator and policy while scanning changed-file
 content from the PR checkout. If no protected base copy exists yet, the check
 does not execute PR-head evaluator code and does not expose `GH_TOKEN` to PR
-head code. It emits a fail-closed `trusted_evaluator_missing_on_base` receipt
-as explicit human-confirmation bootstrap evidence, not autonomous merge
-authority.
+head code. It emits a `human_confirmation_required:trusted_evaluator_missing_on_base`
+receipt as explicit bootstrap evidence, not autonomous merge authority.
 
 The evaluator emits a JSON receipt with these gates:
 

--- a/docs/pr-assistant/final-merge-readiness.md
+++ b/docs/pr-assistant/final-merge-readiness.md
@@ -1,0 +1,35 @@
+# Final Merge Readiness Policy
+
+The Final Merge Readiness check is a read-only policy gate for Merglbot pull
+requests. It does not merge, deploy, run Terraform, or create documentation
+pull requests. The check only decides whether the current PR head has enough
+evidence for a human merge.
+
+The policy manifest lives in `.github/policies/final-merge-readiness.json`.
+The evaluator lives in `scripts/pr-assistant/final-merge-readiness.py`, and the
+GitHub Actions check is `.github/workflows/final-merge-readiness.yml`.
+
+The evaluator emits a JSON receipt with these gates:
+
+- `path_risk_gate`: classifies changed paths, blocks committed secret-like
+  files, private key material, service account JSON keys, Terraform execution
+  commands, and branch-protection bypass language.
+- `pr_assistant_review_only_evidence`: parses the latest trusted PR Assistant
+  v4 or v3 receipt comment from `github-actions[bot]`, requires review-only
+  markers, current-head SHA, approved verdict, successful status, satisfied or
+  not-required documentation state, verified PR check surface, and an allowed
+  PR Assistant workflow run path.
+- `required_checks_gate`: reads branch-protection required checks from GitHub
+  and falls back to the manifest context list when that surface is unavailable.
+- `draft_state_gate`: blocks draft pull requests.
+
+Docs-only pull requests can pass without a PR Assistant receipt. Any non-docs
+or high-risk path still requires trusted PR Assistant evidence for the current
+head.
+
+Local validation:
+
+```bash
+python3 -m py_compile scripts/pr-assistant/final-merge-readiness.py
+python3 scripts/pr-assistant/final-merge-readiness.py --self-test
+```

--- a/docs/pr-assistant/final-merge-readiness.md
+++ b/docs/pr-assistant/final-merge-readiness.md
@@ -12,8 +12,8 @@ The workflow checks out the PR head only as inspected content. When the
 evaluator already exists on the protected base ref, the check executes that
 trusted base copy of the evaluator and policy while scanning changed-file
 content from the PR checkout. If no protected base copy exists yet, the check
-does not execute PR-head evaluator code and does not expose `GH_TOKEN` to PR
-head code. It emits a `human_confirmation_required:trusted_evaluator_missing_on_base`
+does not execute PR-head evaluator code and does not expose the workflow token
+to PR head code. It emits a `human_confirmation_required:trusted_evaluator_missing_on_base`
 receipt as explicit bootstrap evidence, not autonomous merge authority.
 
 The evaluator emits a JSON receipt with these gates:

--- a/docs/pr-assistant/final-merge-readiness.md
+++ b/docs/pr-assistant/final-merge-readiness.md
@@ -15,10 +15,11 @@ The evaluator emits a JSON receipt with these gates:
   files, private key material, service account JSON keys, Terraform execution
   commands, and branch-protection bypass language.
 - `pr_assistant_review_only_evidence`: parses the latest trusted PR Assistant
-  v4 or v3 receipt comment from `github-actions[bot]`, requires review-only
-  markers, current-head SHA, approved verdict, successful status, satisfied or
-  not-required documentation state, verified PR check surface, and an allowed
-  PR Assistant workflow run path.
+  v4 or v3 receipt comment from `github-actions[bot]` or the approved
+  Merglbot v4 GitHub App bot, requires review-only markers where the runtime
+  emits them, current-head SHA, approved verdict, successful status, satisfied
+  or not-required documentation state, verified PR check surface, and either an
+  allowed PR Assistant workflow run path or an approved external v4 run id.
 - `required_checks_gate`: reads branch-protection required checks from GitHub
   and falls back to the manifest context list when that surface is unavailable.
 - `draft_state_gate`: blocks draft pull requests.

--- a/scripts/pr-assistant/final-merge-readiness.py
+++ b/scripts/pr-assistant/final-merge-readiness.py
@@ -1,0 +1,785 @@
+#!/usr/bin/env python3
+"""Evaluate the Merglbot Final Merge Readiness policy for a pull request.
+
+The command is intentionally read-only against GitHub. It consumes branch
+protection, PR checks, changed paths, and PR Assistant receipt comments, then
+prints and optionally writes one JSON receipt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fnmatch
+import json
+import pathlib
+import re
+import subprocess
+from typing import Any, Callable
+
+
+DEFAULT_POLICY_PATH = ".github/policies/final-merge-readiness.json"
+MARKER_RE = re.compile(r"<!--\s*(MERGLBOT_[A-Z0-9_]+)\s*:\s*([\s\S]*?)\s*-->")
+SECTION_HEADER_RE = re.compile(r"^#{2,6}\s+")
+ZAVER_SECTION_HEADER_RE = re.compile(r"^##\s+")
+MACHINE_TOKEN_STRIP_RE = re.compile(r"[^a-z0-9_]+")
+TEXT_SCAN_LIMIT_BYTES = 1_000_000
+
+
+class PolicyError(RuntimeError):
+    """Raised when live GitHub state cannot be collected safely."""
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: pathlib.Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Missing file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def gh_json(args: list[str]) -> Any:
+    proc = subprocess.run(
+        ["gh", *args],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        raise PolicyError(proc.stderr.strip() or f"gh {' '.join(args)} failed")
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise PolicyError(f"gh {' '.join(args)} returned invalid JSON") from exc
+
+
+def flatten_paginated_slurp(value: Any) -> list[Any]:
+    if not isinstance(value, list):
+        return []
+    flattened: list[Any] = []
+    for page in value:
+        if isinstance(page, list):
+            flattened.extend(page)
+        else:
+            flattened.append(page)
+    return flattened
+
+
+def parse_markers(body: str) -> dict[str, str]:
+    return {key.strip(): value.strip() for key, value in MARKER_RE.findall(body or "")}
+
+
+def normalize_machine_token(value: str) -> str:
+    normalized = re.sub(r"[\s-]+", "_", value.strip().lower())
+    normalized = MACHINE_TOKEN_STRIP_RE.sub("", normalized)
+    return re.sub(r"_+", "_", normalized).strip("_")
+
+
+def normalize_heading(value: str) -> str:
+    heading = re.sub(r"^[#\s]+", "", value.strip())
+    heading = re.sub(r"[*_`\s]+", "", heading)
+    return heading.lower()
+
+
+def extract_zaver_field(body: str, field_name: str) -> str:
+    in_zaver = False
+    in_code = False
+    for raw_line in (body or "").splitlines():
+        line = raw_line.strip()
+        if line.startswith("```") or line.startswith("~~~"):
+            in_code = not in_code
+            continue
+        if in_code:
+            continue
+        if SECTION_HEADER_RE.match(line):
+            heading = normalize_heading(line)
+            if (
+                not in_zaver
+                and ZAVER_SECTION_HEADER_RE.match(line)
+                and heading in {"zaver", "z\u00e1v\u011br"}
+            ):
+                in_zaver = True
+                in_code = False
+                continue
+            if in_zaver:
+                break
+            continue
+        if not in_zaver:
+            continue
+        cleaned = re.sub(r"^[\s>\-*+]*", "", line)
+        parts = cleaned.split(":", 1)
+        field_key = (
+            parts[0].replace("*", "").replace("_", "").replace("`", "").strip()
+            if parts
+            else ""
+        )
+        if len(parts) == 2 and field_key.lower() == field_name.lower():
+            return normalize_machine_token(parts[1])
+    return ""
+
+
+def path_matches(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def is_docs_path(path: str, policy: dict[str, Any]) -> bool:
+    docs_patterns = policy.get("path_risk", {}).get("docs_only_patterns", [])
+    return path_matches(path, docs_patterns)
+
+
+def trusted_comment(comment: dict[str, Any], trusted_logins: set[str]) -> bool:
+    user = comment.get("user")
+    if not isinstance(user, dict):
+        return False
+    login = str(user.get("login") or "")
+    user_type = str(user.get("type") or "")
+    return login in trusted_logins and user_type in {"Bot", ""}
+
+
+def sorted_comments(comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        comments,
+        key=lambda item: str(item.get("created_at") or item.get("updated_at") or ""),
+    )
+
+
+def latest_assistant_receipt(
+    comments: list[dict[str, Any]],
+    policy: dict[str, Any],
+) -> tuple[dict[str, str] | None, str, str, str]:
+    assistant = policy["pr_assistant"]
+    marker_names = list(assistant["allowed_markers"])
+    trusted_logins = set(assistant["trusted_comment_logins"])
+    for comment in reversed(sorted_comments(comments)):
+        if not trusted_comment(comment, trusted_logins):
+            continue
+        body = str(comment.get("body") or "")
+        marker_name = next(
+            (
+                marker
+                for marker in marker_names
+                if re.search(rf"<!--\s*{re.escape(marker)}\s*-->", body)
+            ),
+            "",
+        )
+        if not marker_name:
+            continue
+        url = str(comment.get("html_url") or comment.get("url") or "")
+        return parse_markers(body), url, body, marker_name
+    return None, "", "", ""
+
+
+def expected_run_url(pr_url: str, run_id: str) -> str:
+    if "/pull/" not in pr_url or not run_id:
+        return ""
+    return f"{pr_url.split('/pull/', 1)[0]}/actions/runs/{run_id}"
+
+
+def add_decision(
+    decisions: list[dict[str, Any]],
+    decision_id: str,
+    status: str,
+    summary: str,
+    *,
+    evidence: dict[str, Any] | None = None,
+    blockers: list[str] | None = None,
+) -> None:
+    decision: dict[str, Any] = {
+        "id": decision_id,
+        "status": status,
+        "summary": summary,
+    }
+    if evidence is not None:
+        decision["evidence"] = evidence
+    if blockers:
+        decision["blockers"] = blockers
+    decisions.append(decision)
+
+
+def status_check_name(check: dict[str, Any]) -> str:
+    return str(check.get("name") or check.get("context") or "")
+
+
+def check_passed(check: dict[str, Any], success_conclusions: set[str]) -> bool:
+    typename = check.get("__typename")
+    if typename == "StatusContext" or "state" in check:
+        return str(check.get("state") or "").upper() == "SUCCESS"
+    status = str(check.get("status") or "").upper()
+    conclusion = str(check.get("conclusion") or "").lower()
+    return status == "COMPLETED" and conclusion in success_conclusions
+
+
+def check_blocked(check: dict[str, Any], blocking_conclusions: set[str]) -> bool:
+    typename = check.get("__typename")
+    if typename == "StatusContext" or "state" in check:
+        return str(check.get("state") or "").upper() in {"ERROR", "FAILURE"}
+    conclusion = str(check.get("conclusion") or "").lower()
+    return conclusion in blocking_conclusions
+
+
+def local_content_loader(path: str) -> str:
+    candidate = pathlib.Path(path)
+    if not candidate.is_file():
+        return ""
+    try:
+        if candidate.stat().st_size > TEXT_SCAN_LIMIT_BYTES:
+            return ""
+        return candidate.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def content_policy_hits(
+    changed_paths: list[str],
+    policy: dict[str, Any],
+    content_loader: Callable[[str], str] | None,
+) -> list[dict[str, str]]:
+    if content_loader is None:
+        return []
+    hits: list[dict[str, str]] = []
+    for path in changed_paths:
+        text = content_loader(path)
+        if not text:
+            continue
+        for rule in policy.get("path_risk", {}).get("forbidden_content_patterns", []):
+            pattern = str(rule.get("pattern") or "")
+            flags = re.IGNORECASE if rule.get("ignore_case", True) else 0
+            if pattern and re.search(pattern, text, flags):
+                hits.append({"path": path, "rule_id": str(rule.get("id") or "unnamed_rule")})
+    return hits
+
+
+def evaluate_path_risk(
+    policy: dict[str, Any],
+    changed_paths: list[str],
+    decisions: list[dict[str, Any]],
+    content_loader: Callable[[str], str] | None,
+) -> tuple[list[str], list[str], bool]:
+    path_policy = policy["path_risk"]
+    forbidden_patterns = list(path_policy.get("forbidden_path_patterns", []))
+    high_risk_patterns = list(path_policy.get("high_risk_patterns", []))
+    forbidden_paths = [path for path in changed_paths if path_matches(path, forbidden_patterns)]
+    high_risk_paths = [path for path in changed_paths if path_matches(path, high_risk_patterns)]
+    content_hits = content_policy_hits(changed_paths, policy, content_loader)
+    blockers = [f"forbidden_path:{path}" for path in forbidden_paths]
+    blockers.extend(f"forbidden_content:{hit['rule_id']}:{hit['path']}" for hit in content_hits)
+    docs_only = bool(changed_paths) and all(is_docs_path(path, policy) for path in changed_paths)
+    evidence = {
+        "changed_path_count": len(changed_paths),
+        "docs_only": docs_only,
+        "high_risk_paths": high_risk_paths,
+        "forbidden_paths": forbidden_paths,
+        "forbidden_content_hits": content_hits,
+    }
+    add_decision(
+        decisions,
+        "path_risk_gate",
+        "fail" if blockers else "pass",
+        "Changed paths were classified against forbidden and high-risk policy patterns.",
+        evidence=evidence,
+        blockers=blockers,
+    )
+    return blockers, high_risk_paths, docs_only
+
+
+def evaluate_pr_assistant(
+    policy: dict[str, Any],
+    pr: dict[str, Any],
+    comments: list[dict[str, Any]],
+    decisions: list[dict[str, Any]],
+    requires_assistant: bool,
+    run_lookup: Callable[[str], dict[str, Any] | None] | None,
+) -> list[str]:
+    if not requires_assistant:
+        add_decision(
+            decisions,
+            "pr_assistant_review_only_evidence",
+            "skip",
+            "PR Assistant receipt is not required for docs-only path risk.",
+            evidence={"required": False},
+        )
+        return []
+
+    assistant = policy["pr_assistant"]
+    markers, comment_url, body, marker_name = latest_assistant_receipt(comments, policy)
+    blockers: list[str] = []
+    if not markers:
+        blockers.append("missing_pr_assistant_receipt")
+        add_decision(
+            decisions,
+            "pr_assistant_review_only_evidence",
+            "fail",
+            "No trusted PR Assistant receipt comment was found.",
+            evidence={"required": True},
+            blockers=blockers,
+        )
+        return blockers
+
+    head_sha = str(pr.get("headRefOid") or "")
+    pr_url = str(pr.get("url") or "")
+    review_head_sha = markers.get("MERGLBOT_REVIEW_HEAD_SHA", "")
+    schema_version = markers.get("MERGLBOT_REVIEW_RECEIPT_SCHEMA_VERSION", "")
+    boundary = markers.get("MERGLBOT_REVIEW_BOUNDARY", "")
+    verdict = markers.get("MERGLBOT_REVIEW_VERDICT", "")
+    status = markers.get("MERGLBOT_REVIEW_STATUS", "")
+    docs_state = markers.get("MERGLBOT_DOCUMENTATION_OBLIGATION_STATE", "")
+    closeout_mode = markers.get("MERGLBOT_CLOSEOUT_MODE", "")
+    pr_check_surface = markers.get("MERGLBOT_PR_CHECK_SURFACE", "")
+    run_id = markers.get("MERGLBOT_RUN_ID", "")
+    run_url = markers.get("MERGLBOT_RUN_URL", "")
+    visible_verdict = extract_zaver_field(body, "Verdict")
+    visible_docs_state = extract_zaver_field(body, "Documentation Obligation State")
+
+    if schema_version not in set(assistant["required_receipt_schema_versions"]):
+        blockers.append("unsupported_or_missing_receipt_schema")
+    if review_head_sha != head_sha:
+        blockers.append("pr_assistant_head_sha_mismatch")
+    if assistant.get("review_boundary_required", True) and boundary != "review_only":
+        blockers.append("pr_assistant_boundary_not_review_only")
+    if closeout_mode != assistant["required_closeout_mode"]:
+        blockers.append("pr_assistant_closeout_mode_not_human_merge_only")
+    if status not in set(assistant["successful_statuses"]):
+        blockers.append("pr_assistant_status_not_success")
+    if verdict not in set(assistant["approved_verdicts"]):
+        blockers.append("pr_assistant_verdict_not_approved")
+    if docs_state not in set(assistant["passing_documentation_states"]):
+        blockers.append("pr_assistant_documentation_state_blocks_closeout")
+    if pr_check_surface != assistant["required_pr_check_surface"]:
+        blockers.append("pr_assistant_check_surface_not_verified")
+    if visible_verdict and visible_verdict != verdict:
+        blockers.append("pr_assistant_visible_verdict_marker_mismatch")
+    if visible_docs_state and visible_docs_state != docs_state:
+        blockers.append("pr_assistant_visible_docs_state_marker_mismatch")
+    if not run_id:
+        blockers.append("missing_pr_assistant_run_id")
+    if run_id and run_url != expected_run_url(pr_url, run_id):
+        blockers.append("pr_assistant_run_url_mismatch")
+
+    run_path = ""
+    if run_id and run_lookup is not None:
+        try:
+            run = run_lookup(run_id)
+        except Exception as exc:  # pragma: no cover - live API failure path.
+            run = None
+            blockers.append(f"pr_assistant_run_lookup_failed:{exc}")
+        if run:
+            run_path = str(run.get("path") or "")
+            if run_path not in set(assistant["allowed_workflow_paths"]):
+                blockers.append("pr_assistant_run_workflow_not_allowed")
+        else:
+            blockers.append("pr_assistant_run_lookup_missing")
+
+    add_decision(
+        decisions,
+        "pr_assistant_review_only_evidence",
+        "fail" if blockers else "pass",
+        "Latest trusted PR Assistant receipt was parsed as review-only merge evidence.",
+        evidence={
+            "required": True,
+            "marker": marker_name,
+            "comment_url": comment_url,
+            "schema_version": schema_version or None,
+            "review_head_sha": review_head_sha or None,
+            "verdict": verdict or None,
+            "status": status or None,
+            "documentation_obligation_state": docs_state or None,
+            "closeout_mode": closeout_mode or None,
+            "pr_check_surface": pr_check_surface or None,
+            "run_id": run_id or None,
+            "run_url": run_url or None,
+            "run_path": run_path or None,
+        },
+        blockers=blockers,
+    )
+    return blockers
+
+
+def evaluate_required_checks(
+    policy: dict[str, Any],
+    pr: dict[str, Any],
+    required_contexts: list[str],
+    decisions: list[dict[str, Any]],
+) -> list[str]:
+    check_policy = policy["required_checks"]
+    success_conclusions = set(check_policy["success_conclusions"])
+    blocking_conclusions = set(check_policy["blocking_conclusions"])
+    self_check_names = set(check_policy.get("self_check_names", []))
+    rollup = pr.get("statusCheckRollup") or []
+    if not isinstance(rollup, list):
+        rollup = []
+    check_by_name = {status_check_name(check): check for check in rollup if status_check_name(check)}
+    required = [context for context in required_contexts if context not in self_check_names]
+    blockers: list[str] = []
+    for context in required:
+        check = check_by_name.get(context)
+        if not check:
+            blockers.append(f"required_check_missing:{context}")
+        elif not check_passed(check, success_conclusions):
+            blockers.append(f"required_check_not_success:{context}")
+
+    if check_policy.get("block_failed_non_required_checks", True):
+        for check in rollup:
+            name = status_check_name(check)
+            if not name or name in self_check_names or name in required:
+                continue
+            if check_blocked(check, blocking_conclusions):
+                blockers.append(f"non_required_check_failed:{name}")
+
+    add_decision(
+        decisions,
+        "required_checks_gate",
+        "fail" if blockers else "pass",
+        "Branch-protection required checks were evaluated on the current PR head.",
+        evidence={
+            "required_contexts": required,
+            "observed_checks": sorted(check_by_name),
+            "self_check_names": sorted(self_check_names),
+        },
+        blockers=blockers,
+    )
+    return blockers
+
+
+def evaluate_draft_state(pr: dict[str, Any], decisions: list[dict[str, Any]]) -> list[str]:
+    blockers = ["pr_is_draft"] if pr.get("isDraft") else []
+    add_decision(
+        decisions,
+        "draft_state_gate",
+        "fail" if blockers else "pass",
+        "Draft pull requests are not final-merge-ready.",
+        evidence={"is_draft": bool(pr.get("isDraft"))},
+        blockers=blockers,
+    )
+    return blockers
+
+
+def evaluate(
+    *,
+    policy: dict[str, Any],
+    pr: dict[str, Any],
+    comments: list[dict[str, Any]],
+    changed_paths: list[str],
+    required_contexts: list[str],
+    run_lookup: Callable[[str], dict[str, Any] | None] | None = None,
+    content_loader: Callable[[str], str] | None = None,
+    evaluated_at: str | None = None,
+) -> dict[str, Any]:
+    decisions: list[dict[str, Any]] = []
+    blockers: list[str] = []
+    path_blockers, high_risk_paths, docs_only = evaluate_path_risk(
+        policy,
+        changed_paths,
+        decisions,
+        content_loader,
+    )
+    blockers.extend(path_blockers)
+    requires_assistant = not docs_only or bool(high_risk_paths)
+    blockers.extend(
+        evaluate_pr_assistant(
+            policy,
+            pr,
+            comments,
+            decisions,
+            requires_assistant,
+            run_lookup,
+        )
+    )
+    blockers.extend(evaluate_required_checks(policy, pr, required_contexts, decisions))
+    blockers.extend(evaluate_draft_state(pr, decisions))
+
+    return {
+        "schema_version": 1,
+        "policy_id": policy["policy_id"],
+        "policy_version": policy["policy_version"],
+        "evaluated_at": evaluated_at or now_iso(),
+        "repo": pr.get("repository"),
+        "pr_number": pr.get("number"),
+        "pr_url": pr.get("url"),
+        "head_sha": pr.get("headRefOid"),
+        "base_ref": pr.get("baseRefName"),
+        "ok": not blockers,
+        "blockers": blockers,
+        "decisions": decisions,
+    }
+
+
+def branch_required_contexts(repo: str, base_ref: str, fallback: list[str]) -> list[str]:
+    try:
+        required = gh_json(
+            ["api", f"repos/{repo}/branches/{base_ref}/protection/required_status_checks"]
+        )
+    except PolicyError:
+        return fallback
+    contexts = set(str(context) for context in required.get("contexts") or [])
+    for check in required.get("checks") or []:
+        context = check.get("context")
+        if context:
+            contexts.add(str(context))
+    return sorted(contexts) if contexts else fallback
+
+
+def collect_live_context(repo: str, pr_number: int, policy: dict[str, Any]) -> tuple[
+    dict[str, Any],
+    list[dict[str, Any]],
+    list[str],
+    list[str],
+    Callable[[str], dict[str, Any] | None],
+]:
+    fields = ",".join(
+        [
+            "baseRefName",
+            "headRefName",
+            "headRefOid",
+            "isDraft",
+            "mergeStateStatus",
+            "reviewDecision",
+            "statusCheckRollup",
+            "url",
+        ]
+    )
+    pr = gh_json(["pr", "view", str(pr_number), "--repo", repo, "--json", fields])
+    pr["repository"] = repo
+    pr["number"] = pr_number
+
+    comments = flatten_paginated_slurp(
+        gh_json(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{repo}/issues/{pr_number}/comments?per_page=100",
+            ]
+        )
+    )
+    files = flatten_paginated_slurp(
+        gh_json(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{repo}/pulls/{pr_number}/files?per_page=100",
+            ]
+        )
+    )
+    changed_paths = [str(item.get("filename") or "") for item in files if item.get("filename")]
+    fallback = list(policy["required_checks"].get("fallback_required_contexts", []))
+    required_contexts = branch_required_contexts(repo, str(pr.get("baseRefName") or "main"), fallback)
+    run_cache: dict[str, dict[str, Any] | None] = {}
+
+    def run_lookup(run_id: str) -> dict[str, Any] | None:
+        if run_id not in run_cache:
+            run_cache[run_id] = gh_json(["api", f"repos/{repo}/actions/runs/{run_id}"])
+        return run_cache[run_id]
+
+    return pr, comments, changed_paths, required_contexts, run_lookup
+
+
+def validate_policy(policy: dict[str, Any]) -> None:
+    required_root = {
+        "schema_version",
+        "policy_id",
+        "policy_version",
+        "mode",
+        "scope_baseline",
+        "pr_assistant",
+        "required_checks",
+        "path_risk",
+    }
+    missing = sorted(required_root - set(policy))
+    if missing:
+        raise SystemExit(f"Policy missing root keys: {', '.join(missing)}")
+    if policy["mode"] != "human_merge_only":
+        raise SystemExit("Final Merge Readiness policy mode must stay human_merge_only")
+    if policy["schema_version"] != 1:
+        raise SystemExit("Unsupported Final Merge Readiness policy schema_version")
+    if policy["scope_baseline"].get("github_active_repo_denominator") != 46:
+        raise SystemExit("Scope baseline must keep the 46 active GitHub repo denominator")
+
+
+def self_test() -> int:
+    policy = load_json(pathlib.Path(DEFAULT_POLICY_PATH))
+    validate_policy(policy)
+    pr = {
+        "repository": "merglbot-core/github",
+        "number": 42,
+        "url": "https://github.com/merglbot-core/github/pull/42",
+        "headRefOid": "abc123",
+        "baseRefName": "main",
+        "isDraft": False,
+        "statusCheckRollup": [
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            }
+        ],
+    }
+    body = "\n".join(
+        [
+            "## Zaver",
+            "Verdict: approved_for_closeout",
+            "Documentation Obligation State: satisfied",
+            "",
+            "<!-- MERGLBOT_PR_ASSISTANT_V4 -->",
+            "<!-- MERGLBOT_REVIEW_RECEIPT_SCHEMA_VERSION: 1 -->",
+            "<!-- MERGLBOT_REVIEW_BOUNDARY: review_only -->",
+            "<!-- MERGLBOT_FOLLOW_UP_ID: pr-42-review-100 -->",
+            "<!-- MERGLBOT_REVIEW_HEAD_SHA: abc123 -->",
+            "<!-- MERGLBOT_REVIEW_VERDICT: approved_for_closeout -->",
+            "<!-- MERGLBOT_REVIEW_STATUS: success -->",
+            "<!-- MERGLBOT_DOCUMENTATION_OBLIGATION_STATE: satisfied -->",
+            "<!-- MERGLBOT_CLOSEOUT_MODE: human_merge_only -->",
+            "<!-- MERGLBOT_PR_CHECK_SURFACE: verified -->",
+            "<!-- MERGLBOT_RUN_ID: 100 -->",
+            "<!-- MERGLBOT_RUN_URL: https://github.com/merglbot-core/github/actions/runs/100 -->",
+        ]
+    )
+    comments = [
+        {
+            "body": body,
+            "created_at": "2026-05-01T00:00:00Z",
+            "html_url": "https://github.com/merglbot-core/github/pull/42#issuecomment-1",
+            "user": {"login": "github-actions[bot]", "type": "Bot"},
+        }
+    ]
+    run_lookup = lambda run_id: {"path": ".github/workflows/merglbot-pr-assistant-v4-on-demand.yml"}
+    receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=comments,
+        changed_paths=["scripts/pr-assistant/final-merge-readiness.py", "docs/pr-assistant/final-merge-readiness.md"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "print('ok')",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert receipt["ok"], receipt
+
+    stale = body.replace("MERGLBOT_REVIEW_HEAD_SHA: abc123", "MERGLBOT_REVIEW_HEAD_SHA: def456")
+    stale_receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=[{**comments[0], "body": stale}],
+        changed_paths=["scripts/pr-assistant/final-merge-readiness.py"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert "pr_assistant_head_sha_mismatch" in stale_receipt["blockers"]
+
+    spoofed_receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=[{**comments[0], "user": {"login": "octocat", "type": "User"}}],
+        changed_paths=["scripts/pr-assistant/final-merge-readiness.py"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert "missing_pr_assistant_receipt" in spoofed_receipt["blockers"]
+
+    docs_only_receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=[],
+        changed_paths=["docs/pr-assistant/final-merge-readiness.md"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert docs_only_receipt["ok"], docs_only_receipt
+
+    missing_check_receipt = evaluate(
+        policy=policy,
+        pr={**pr, "statusCheckRollup": []},
+        comments=comments,
+        changed_paths=["scripts/pr-assistant/final-merge-readiness.py"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert "required_check_missing:ci" in missing_check_receipt["blockers"]
+
+    forbidden_path_receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=comments,
+        changed_paths=["service-account.json"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert "forbidden_path:service-account.json" in forbidden_path_receipt["blockers"]
+
+    terraform_apply_receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=comments,
+        changed_paths=["infra/main.tf"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "terraform " + "apply -auto-approve",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert any(
+        blocker.startswith("forbidden_content:terraform_apply:infra/main.tf")
+        for blocker in terraform_apply_receipt["blockers"]
+    )
+
+    print(json.dumps({"ok": True, "self_test": "passed"}))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate Final Merge Readiness.")
+    parser.add_argument("--repo", help="Repository in owner/name form.")
+    parser.add_argument("--pr", type=int, help="Pull request number.")
+    parser.add_argument("--policy", default=DEFAULT_POLICY_PATH, help="Policy manifest JSON path.")
+    parser.add_argument("--output", help="Optional path to write the JSON receipt.")
+    parser.add_argument("--self-test", action="store_true", help="Run deterministic unit tests.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    policy = load_json(pathlib.Path(args.policy))
+    validate_policy(policy)
+    if args.self_test:
+        return self_test()
+    if not args.repo or not args.pr:
+        raise SystemExit("--repo and --pr are required unless --self-test is used")
+
+    pr, comments, changed_paths, required_contexts, run_lookup = collect_live_context(
+        args.repo,
+        args.pr,
+        policy,
+    )
+    receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=comments,
+        changed_paths=changed_paths,
+        required_contexts=required_contexts,
+        run_lookup=run_lookup,
+        content_loader=local_content_loader,
+    )
+    output = json.dumps(receipt, indent=2, sort_keys=True)
+    if args.output:
+        pathlib.Path(args.output).write_text(output + "\n", encoding="utf-8")
+    print(output)
+    return 0 if receipt["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr-assistant/final-merge-readiness.py
+++ b/scripts/pr-assistant/final-merge-readiness.py
@@ -832,6 +832,9 @@ def self_test() -> int:
         for blocker in terraform_apply_receipt["blockers"]
     )
 
+    private_key_label = "PRIVATE" + " KEY"
+    encrypted_key_header = "-" * 5 + "BEGIN ENCRYPTED " + private_key_label + "-" * 5
+    encrypted_key_footer = "-" * 5 + "END ENCRYPTED " + private_key_label + "-" * 5
     encrypted_private_key_receipt = evaluate(
         policy=policy,
         pr=pr,
@@ -839,7 +842,7 @@ def self_test() -> int:
         changed_paths=["scripts/pr-assistant/final-merge-readiness.py"],
         required_contexts=["ci"],
         run_lookup=run_lookup,
-        content_loader=lambda path: "-----BEGIN ENCRYPTED PRIVATE KEY-----\nredacted\n-----END ENCRYPTED PRIVATE KEY-----",
+        content_loader=lambda path: f"{encrypted_key_header}\nredacted\n{encrypted_key_footer}",
         evaluated_at="2026-05-01T00:00:00Z",
     )
     assert any(

--- a/scripts/pr-assistant/final-merge-readiness.py
+++ b/scripts/pr-assistant/final-merge-readiness.py
@@ -234,7 +234,27 @@ def check_blocked(check: dict[str, Any], blocking_conclusions: set[str]) -> bool
 
 
 def local_content_loader(path: str) -> str:
-    candidate = pathlib.Path(path)
+    return content_loader_for_root(pathlib.Path.cwd())(path)
+
+
+def content_loader_for_root(root: pathlib.Path) -> Callable[[str], str]:
+    resolved_root = root.resolve()
+
+    def load(path: str) -> str:
+        rel = pathlib.PurePosixPath(path)
+        if rel.is_absolute() or ".." in rel.parts:
+            return ""
+        candidate = (resolved_root / pathlib.Path(*rel.parts)).resolve()
+        try:
+            candidate.relative_to(resolved_root)
+        except ValueError:
+            return ""
+        return read_text_candidate(candidate)
+
+    return load
+
+
+def read_text_candidate(candidate: pathlib.Path) -> str:
     if not candidate.is_file():
         return ""
     try:
@@ -821,6 +841,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repo", help="Repository in owner/name form.")
     parser.add_argument("--pr", type=int, help="Pull request number.")
     parser.add_argument("--policy", default=DEFAULT_POLICY_PATH, help="Policy manifest JSON path.")
+    parser.add_argument(
+        "--content-root",
+        default=".",
+        help="Checkout root used for changed-file content scanning. Defaults to the current working directory.",
+    )
     parser.add_argument("--output", help="Optional path to write the JSON receipt.")
     parser.add_argument("--self-test", action="store_true", help="Run deterministic unit tests.")
     return parser.parse_args()
@@ -847,7 +872,7 @@ def main() -> int:
         changed_paths=changed_paths,
         required_contexts=required_contexts,
         run_lookup=run_lookup,
-        content_loader=local_content_loader,
+        content_loader=content_loader_for_root(pathlib.Path(args.content_root)),
     )
     output = json.dumps(receipt, indent=2, sort_keys=True)
     if args.output:

--- a/scripts/pr-assistant/final-merge-readiness.py
+++ b/scripts/pr-assistant/final-merge-readiness.py
@@ -138,7 +138,7 @@ def trusted_comment(comment: dict[str, Any], trusted_logins: set[str]) -> bool:
         return False
     login = str(user.get("login") or "")
     user_type = str(user.get("type") or "")
-    return login in trusted_logins and user_type in {"Bot", ""}
+    return login in trusted_logins and user_type == "Bot"
 
 
 def sorted_comments(comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -615,6 +615,8 @@ def collect_live_context(repo: str, pr_number: int, policy: dict[str, Any]) -> t
     run_cache: dict[str, dict[str, Any] | None] = {}
 
     def run_lookup(run_id: str) -> dict[str, Any] | None:
+        if not run_id or not run_id.isdigit():
+            return None
         if run_id not in run_cache:
             run_cache[run_id] = gh_json(["api", f"repos/{repo}/actions/runs/{run_id}"])
         return run_cache[run_id]

--- a/scripts/pr-assistant/final-merge-readiness.py
+++ b/scripts/pr-assistant/final-merge-readiness.py
@@ -832,6 +832,21 @@ def self_test() -> int:
         for blocker in terraform_apply_receipt["blockers"]
     )
 
+    encrypted_private_key_receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=comments,
+        changed_paths=["scripts/pr-assistant/final-merge-readiness.py"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "-----BEGIN ENCRYPTED PRIVATE KEY-----\nredacted\n-----END ENCRYPTED PRIVATE KEY-----",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert any(
+        blocker.startswith("forbidden_content:private_key_material:scripts/pr-assistant/final-merge-readiness.py")
+        for blocker in encrypted_private_key_receipt["blockers"]
+    )
+
     print(json.dumps({"ok": True, "self_test": "passed"}))
     return 0
 

--- a/scripts/pr-assistant/final-merge-readiness.py
+++ b/scripts/pr-assistant/final-merge-readiness.py
@@ -402,16 +402,18 @@ def evaluate_pr_assistant(
 
     run_path = ""
     if run_id and not is_external_runtime and run_lookup is not None:
+        run_lookup_failed = False
         try:
             run = run_lookup(run_id)
         except Exception as exc:  # pragma: no cover - live API failure path.
             run = None
+            run_lookup_failed = True
             blockers.append(f"pr_assistant_run_lookup_failed:{exc}")
         if run:
             run_path = str(run.get("path") or "")
             if run_path not in set(assistant["allowed_workflow_paths"]):
                 blockers.append("pr_assistant_run_workflow_not_allowed")
-        else:
+        elif not run_lookup_failed:
             blockers.append("pr_assistant_run_lookup_missing")
 
     add_decision(
@@ -805,6 +807,41 @@ def self_test() -> int:
     )
     assert "required_check_missing:ci" in missing_check_receipt["blockers"]
 
+    draft_receipt = evaluate(
+        policy=policy,
+        pr={**pr, "isDraft": True},
+        comments=comments,
+        changed_paths=["scripts/pr-assistant/final-merge-readiness.py"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert "pr_is_draft" in draft_receipt["blockers"]
+
+    failed_non_required_check_receipt = evaluate(
+        policy=policy,
+        pr={
+            **pr,
+            "statusCheckRollup": [
+                *pr["statusCheckRollup"],
+                {
+                    "__typename": "CheckRun",
+                    "name": "lint-extra",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                },
+            ],
+        },
+        comments=comments,
+        changed_paths=["scripts/pr-assistant/final-merge-readiness.py"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert "non_required_check_failed:lint-extra" in failed_non_required_check_receipt["blockers"]
+
     forbidden_path_receipt = evaluate(
         policy=policy,
         pr=pr,
@@ -830,6 +867,21 @@ def self_test() -> int:
     assert any(
         blocker.startswith("forbidden_content:terraform_apply:infra/main.tf")
         for blocker in terraform_apply_receipt["blockers"]
+    )
+
+    admin_bypass_receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=comments,
+        changed_paths=[".github/workflows/release.yml"],
+        required_contexts=["ci"],
+        run_lookup=run_lookup,
+        content_loader=lambda path: "echo 'bypass branch protection'",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert any(
+        blocker.startswith("forbidden_content:branch_protection_admin_bypass:.github/workflows/release.yml")
+        for blocker in admin_bypass_receipt["blockers"]
     )
 
     private_key_label = "PRIVATE" + " KEY"

--- a/scripts/pr-assistant/final-merge-readiness.py
+++ b/scripts/pr-assistant/final-merge-readiness.py
@@ -180,6 +180,17 @@ def expected_run_url(pr_url: str, run_id: str) -> str:
     return f"{pr_url.split('/pull/', 1)[0]}/actions/runs/{run_id}"
 
 
+def marker_set(assistant: dict[str, Any], key: str) -> set[str]:
+    value = assistant.get(key, [])
+    if not isinstance(value, list):
+        return set()
+    return {str(item) for item in value}
+
+
+def run_id_matches_prefix(run_id: str, prefixes: set[str]) -> bool:
+    return bool(run_id) and any(run_id.startswith(prefix) for prefix in prefixes)
+
+
 def add_decision(
     decisions: list[dict[str, Any]],
     decision_id: str,
@@ -332,14 +343,20 @@ def evaluate_pr_assistant(
     pr_check_surface = markers.get("MERGLBOT_PR_CHECK_SURFACE", "")
     run_id = markers.get("MERGLBOT_RUN_ID", "")
     run_url = markers.get("MERGLBOT_RUN_URL", "")
+    runtime_type = markers.get("MERGLBOT_RUNTIME_TYPE", "")
     visible_verdict = extract_zaver_field(body, "Verdict")
     visible_docs_state = extract_zaver_field(body, "Documentation Obligation State")
+    external_runtime_types = marker_set(assistant, "external_runtime_types")
+    external_run_id_prefixes = marker_set(assistant, "external_run_id_prefixes")
+    boundary_optional_runtime_types = marker_set(assistant, "review_boundary_optional_runtime_types")
+    is_external_runtime = runtime_type in external_runtime_types
+    boundary_optional = runtime_type in boundary_optional_runtime_types
 
     if schema_version not in set(assistant["required_receipt_schema_versions"]):
         blockers.append("unsupported_or_missing_receipt_schema")
     if review_head_sha != head_sha:
         blockers.append("pr_assistant_head_sha_mismatch")
-    if assistant.get("review_boundary_required", True) and boundary != "review_only":
+    if assistant.get("review_boundary_required", True) and boundary != "review_only" and not boundary_optional:
         blockers.append("pr_assistant_boundary_not_review_only")
     if closeout_mode != assistant["required_closeout_mode"]:
         blockers.append("pr_assistant_closeout_mode_not_human_merge_only")
@@ -357,11 +374,14 @@ def evaluate_pr_assistant(
         blockers.append("pr_assistant_visible_docs_state_marker_mismatch")
     if not run_id:
         blockers.append("missing_pr_assistant_run_id")
-    if run_id and run_url != expected_run_url(pr_url, run_id):
+    elif is_external_runtime:
+        if not run_id_matches_prefix(run_id, external_run_id_prefixes):
+            blockers.append("pr_assistant_external_run_id_not_allowed")
+    elif run_url != expected_run_url(pr_url, run_id):
         blockers.append("pr_assistant_run_url_mismatch")
 
     run_path = ""
-    if run_id and run_lookup is not None:
+    if run_id and not is_external_runtime and run_lookup is not None:
         try:
             run = run_lookup(run_id)
         except Exception as exc:  # pragma: no cover - live API failure path.
@@ -392,6 +412,7 @@ def evaluate_pr_assistant(
             "pr_check_surface": pr_check_surface or None,
             "run_id": run_id or None,
             "run_url": run_url or None,
+            "runtime_type": runtime_type or None,
             "run_path": run_path or None,
         },
         blockers=blockers,
@@ -685,6 +706,60 @@ def self_test() -> int:
         evaluated_at="2026-05-01T00:00:00Z",
     )
     assert "missing_pr_assistant_receipt" in spoofed_receipt["blockers"]
+
+    cloud_body = "\n".join(
+        [
+            "Verdict: approved_for_closeout",
+            "Documentation Obligation State: satisfied",
+            "",
+            "<!-- MERGLBOT_PR_ASSISTANT_V4 -->",
+            "<!-- MERGLBOT_REVIEW_RECEIPT_SCHEMA_VERSION: 1 -->",
+            "<!-- MERGLBOT_FOLLOW_UP_ID: pr-assistant-v4:100 -->",
+            "<!-- MERGLBOT_REVIEW_HEAD_SHA: abc123 -->",
+            "<!-- MERGLBOT_REVIEW_VERDICT: approved_for_closeout -->",
+            "<!-- MERGLBOT_REVIEW_STATUS: success -->",
+            "<!-- MERGLBOT_DOCUMENTATION_OBLIGATION_STATE: satisfied -->",
+            "<!-- MERGLBOT_CLOSEOUT_MODE: human_merge_only -->",
+            "<!-- MERGLBOT_PR_CHECK_SURFACE: verified -->",
+            "<!-- MERGLBOT_RUN_ID: pr-assistant-v4:100 -->",
+            "<!-- MERGLBOT_RUNTIME_TYPE: github_app_cloud_run -->",
+        ]
+    )
+    cloud_receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=[
+            {
+                **comments[0],
+                "body": cloud_body,
+                "user": {"login": "merglbot-pr-assistant-v4-stg[bot]", "type": "Bot"},
+            }
+        ],
+        changed_paths=["scripts/pr-assistant/final-merge-readiness.py"],
+        required_contexts=["ci"],
+        run_lookup=lambda run_id: (_ for _ in ()).throw(AssertionError("cloud receipts must not call actions run lookup")),
+        content_loader=lambda path: "",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert cloud_receipt["ok"], cloud_receipt
+
+    degraded_cloud_receipt = evaluate(
+        policy=policy,
+        pr=pr,
+        comments=[
+            {
+                **comments[0],
+                "body": cloud_body.replace("MERGLBOT_REVIEW_STATUS: success", "MERGLBOT_REVIEW_STATUS: degraded"),
+                "user": {"login": "merglbot-pr-assistant-v4-stg[bot]", "type": "Bot"},
+            }
+        ],
+        changed_paths=["scripts/pr-assistant/final-merge-readiness.py"],
+        required_contexts=["ci"],
+        run_lookup=None,
+        content_loader=lambda path: "",
+        evaluated_at="2026-05-01T00:00:00Z",
+    )
+    assert "pr_assistant_status_not_success" in degraded_cloud_receipt["blockers"]
 
     docs_only_receipt = evaluate(
         policy=policy,

--- a/scripts/pr-assistant/verify-review-receipt.py
+++ b/scripts/pr-assistant/verify-review-receipt.py
@@ -226,7 +226,7 @@ def verify(repo: str, pr_number: int) -> dict[str, Any]:
     elif run_id and run_url != expected_run_url(str(pr.get("url") or ""), run_id):
         blockers.append("review_run_url_mismatch")
     run_path = ""
-    if run_id:
+    if run_id and run_id.isdigit():
         try:
             run = gh_json(["api", f"repos/{repo}/actions/runs/{run_id}"])
             run_path = str(run.get("path") or "")


### PR DESCRIPTION
## Summary

- Add a Final Merge Readiness policy manifest with MDAU 2026-05-01 scope baselines, PR Assistant review-only boundaries, required-check fallback policy, and path-risk rules.
- Add a read-only Python evaluator that emits a JSON receipt for PR Assistant evidence, required checks, path risk, and draft state decisions.
- Add the `Final Merge Readiness` GitHub Actions check and CI self-tests for the new evaluator plus the existing review receipt parser.
- Document the gate and local validation commands.

## Validation

- `python3 -m py_compile scripts/pr-assistant/final-merge-readiness.py scripts/pr-assistant/verify-review-receipt.py scripts/pr-assistant/repo-policy-manifest.py scripts/dependabot/ent_dependabot_closeout.py`
- `python3 scripts/pr-assistant/final-merge-readiness.py --self-test`
- `python3 scripts/pr-assistant/verify-review-receipt.py --self-test`
- `python3 scripts/dependabot/ent_dependabot_closeout.py --self-test`
- `python3 scripts/pr-assistant/repo-policy-manifest.py verify-manifest`
- `bash -n scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh scripts/pr-assistant/secret-scan-patterns-smoke-test.sh`
- `bash scripts/pr-assistant/secret-scan-patterns-smoke-test.sh`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "#{p}: ok" }' .github/workflows/final-merge-readiness.yml .github/workflows/ci.yml`
- `python3 -m json.tool .github/policies/final-merge-readiness.json >/dev/null`
- `git diff --check`