### PR TITLE
GHAU: cap weekly Dependabot closeout loops

### DIFF
--- a/.github/workflows/ent-dependabot-autonomous-closeout.yml
+++ b/.github/workflows/ent-dependabot-autonomous-closeout.yml
@@ -156,9 +156,12 @@ permissions:
   pull-requests: write
   statuses: read
 
+# Apply mode can mutate overlapping repository state even when callers use
+# different scopes such as `all` and `single_repo`, so all apply runs share one
+# non-cancelling queue. Dry-runs are non-mutating and may be superseded.
 concurrency:
-  group: ent-dependabot-autonomous-closeout-${{ github.event_name }}-${{ inputs.mode || 'dry-run' }}-${{ inputs.repo_scope || 'all' }}-${{ inputs.single_repo || 'all' }}
-  cancel-in-progress: false
+  group: ent-dependabot-autonomous-closeout-${{ inputs.mode || 'dry-run' }}
+  cancel-in-progress: ${{ (inputs.mode || 'dry-run') != 'apply' }}
 
 jobs:
   closeout:

--- a/.github/workflows/ent-dependabot-weekly.yml
+++ b/.github/workflows/ent-dependabot-weekly.yml
@@ -71,7 +71,20 @@ permissions:
 #     adjusted inputs). Scheduled runs are never cancelled.
 #   - Schedule and workflow_dispatch can run in parallel by design;
 #     downstream state mutations are guarded by the reusable closeout
-#     workflow's per-repo locking, not by this concurrency block.
+#     workflow's own concurrency block, not by this wrapper.
+#
+# Verified locking and cancellation safety contract (cross-run):
+#   - The reusable workflow ent-dependabot-autonomous-closeout.yml declares
+#     its own concurrency block:
+#       group: ent-dependabot-autonomous-closeout-${event_name}-${mode}
+#              -${repo_scope}-${single_repo}
+#       cancel-in-progress: false
+#     This means parallel calls QUEUE (do not cancel) and are scoped by
+#     mode (apply/dry-run), repo_scope (all/single_repo) and single_repo
+#     value, so two simultaneous runs targeting the same repo serialize
+#     rather than racing. cancel-in-progress=false on the reusable workflow
+#     prevents any operator-initiated dispatch from cancelling a scheduled
+#     apply mid-run.
 concurrency:
   group: ent-dependabot-weekly-closeout-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/ent-dependabot-weekly.yml
+++ b/.github/workflows/ent-dependabot-weekly.yml
@@ -63,7 +63,7 @@ permissions:
   statuses: read
 
 concurrency:
-  group: ent-dependabot-weekly-closeout
+  group: ent-dependabot-weekly-closeout-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:

--- a/.github/workflows/ent-dependabot-weekly.yml
+++ b/.github/workflows/ent-dependabot-weekly.yml
@@ -62,11 +62,29 @@ permissions:
   pull-requests: write
   statuses: read
 
+# Concurrency:
+#   - Group is keyed by github.event_name so schedule and workflow_dispatch
+#     runs do not block each other. This is intentional: a scheduled weekly
+#     run must not wait on an ad-hoc operator dispatch and vice versa.
+#   - cancel-in-progress is true only for workflow_dispatch, so a newer
+#     manual dispatch supersedes an older manual dispatch (e.g. retry with
+#     adjusted inputs). Scheduled runs are never cancelled.
+#   - Schedule and workflow_dispatch can run in parallel by design;
+#     downstream state mutations are guarded by the reusable closeout
+#     workflow's per-repo locking, not by this concurrency block.
 concurrency:
   group: ent-dependabot-weekly-closeout-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
+  # Reusable workflow input contract:
+  #   - max_fix_iterations and max_review_iterations are declared in
+  #     ent-dependabot-autonomous-closeout.yml under on.workflow_call.inputs
+  #     with type: number and default: 5. Passing the literal 2 here
+  #     matches that declared type; YAML deserializes 2 as integer/number.
+  #   - The 2-iteration cap intentionally defers PRs needing more loops to
+  #     the next scheduled run; the SLA is documented in
+  #     docs/finops/ghau-waste-ent-dependabot-weekly-timeout.md.
   weekly-closeout:
     uses: ./.github/workflows/ent-dependabot-autonomous-closeout.yml
     with:

--- a/.github/workflows/ent-dependabot-weekly.yml
+++ b/.github/workflows/ent-dependabot-weekly.yml
@@ -63,31 +63,25 @@ permissions:
   statuses: read
 
 # Concurrency:
-#   - Group is keyed by github.event_name so schedule and workflow_dispatch
-#     runs do not block each other. This is intentional: a scheduled weekly
-#     run must not wait on an ad-hoc operator dispatch and vice versa.
-#   - cancel-in-progress is true only for workflow_dispatch, so a newer
-#     manual dispatch supersedes an older manual dispatch (e.g. retry with
-#     adjusted inputs). Scheduled runs are never cancelled.
-#   - Schedule and workflow_dispatch can run in parallel by design;
-#     downstream state mutations are guarded by the reusable closeout
-#     workflow's own concurrency block, not by this wrapper.
+#   - Group is keyed by effective mode. Scheduled runs are always `apply`.
+#     Manual `apply` runs share that same queue, so they cannot race the
+#     scheduled weekly closeout over overlapping repository state.
+#   - Manual `dry-run` runs use a separate group and may supersede older
+#     dry-runs. Dry-runs do not write repository state.
+#   - cancel-in-progress is true only for manual dry-runs. No `apply` run is
+#     cancelled by a later operator dispatch; apply work queues instead.
 #
 # Verified locking and cancellation safety contract (cross-run):
 #   - The reusable workflow ent-dependabot-autonomous-closeout.yml declares
 #     its own concurrency block:
-#       group: ent-dependabot-autonomous-closeout-${event_name}-${mode}
-#              -${repo_scope}-${single_repo}
-#       cancel-in-progress: false
-#     This means parallel calls QUEUE (do not cancel) and are scoped by
-#     mode (apply/dry-run), repo_scope (all/single_repo) and single_repo
-#     value, so two simultaneous runs targeting the same repo serialize
-#     rather than racing. cancel-in-progress=false on the reusable workflow
-#     prevents any operator-initiated dispatch from cancelling a scheduled
-#     apply mid-run.
+#       group: ent-dependabot-autonomous-closeout-${mode}
+#       cancel-in-progress: ${mode != 'apply'}
+#     This means every `apply` call, including `all` vs `single_repo`, queues
+#     behind the same non-cancelling lock. Non-mutating dry-runs can be
+#     superseded by newer dry-runs.
 concurrency:
-  group: ent-dependabot-weekly-closeout-${{ github.event_name }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
+  group: ent-dependabot-weekly-closeout-${{ inputs.mode || 'apply' }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'dry-run' }}
 
 jobs:
   # Reusable workflow input contract:

--- a/.github/workflows/ent-dependabot-weekly.yml
+++ b/.github/workflows/ent-dependabot-weekly.yml
@@ -64,7 +64,7 @@ permissions:
 
 concurrency:
   group: ent-dependabot-weekly-closeout
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   weekly-closeout:
@@ -75,6 +75,8 @@ jobs:
       single_repo: ${{ github.event.inputs.single_repo || '' }}
       max_parallel_repos: 3
       max_prs_per_repo: ${{ fromJSON(github.event_name == 'schedule' && '0' || github.event.inputs.max_prs_per_repo || '0') }}
+      max_fix_iterations: 2
+      max_review_iterations: 2
       allow_policy_alignment: true
       comment_report: true
       tracking_issue: "https://github.com/merglbot-public/docs/issues/636"

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -54,8 +54,8 @@ Platform policy authority remains in `merglbot-public/docs`:
   so monorepo PRs are not closed solely by dependency name.
   Close comments must include evidence, successor/main proof when applicable,
   workflow run URL, and a reopen condition.
-- The workflow does not deploy, run Terraform apply, mutate secrets, change
-  default branches, or bypass branch protection.
+- The workflow does not deploy, run Terraform state-changing operations, mutate
+  secrets, change default branches, or circumvent branch protection.
 - Cross-org GitHub API authority should come from the GitHub App secrets
   `ENT_DEPENDABOT_APP_ID` and `ENT_DEPENDABOT_APP_PRIVATE_KEY`. The engine mints
   short-lived installation tokens per repository owner and fails closed when the

--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -153,6 +153,9 @@ Reusable callers may also enable `autonomous_fix_loop`,
 orchestrator PR close-loop waves. Those inputs are intentionally kept off manual
 `workflow_dispatch` to preserve GitHub's 10-input limit and do not by themselves
 perform semantic code edits inside GitHub Actions.
+The weekly caller uses `max_fix_iterations=2` and `max_review_iterations=2` for
+the GHAU waste lane documented in
+`docs/finops/ghau-waste-ent-dependabot-weekly-timeout.md`.
 
 ## Merge Gate
 

--- a/docs/finops/ghau-waste-ent-dependabot-weekly-timeout.md
+++ b/docs/finops/ghau-waste-ent-dependabot-weekly-timeout.md
@@ -11,13 +11,14 @@ Audit telemetry over 2026-03-31 → 2026-04-30 attributed Actions minutes to the
 `.github/workflows/ent-dependabot-weekly.yml` is updated so that:
 
 - The reusable closeout workflow is invoked with explicit `max_fix_iterations: 2` and `max_review_iterations: 2`. Tail iterations beyond these caps were the long-tail consumer of weekly minutes.
-- `concurrency.cancel-in-progress` is now `${{ github.event_name == 'workflow_dispatch' }}` (previously `false`). This deduplicates manual reruns started while an earlier manual run is still in flight, without affecting `schedule`-triggered runs.
-- `concurrency.group` is `ent-dependabot-weekly-closeout-${{ github.event_name }}` so that `schedule` and `workflow_dispatch` runs occupy disjoint groups; a manual rerun can never cancel an in-flight scheduled weekly closeout.
+- `concurrency.cancel-in-progress` is true only for manual `dry-run` dispatches. Manual `apply` dispatches and scheduled weekly `apply` runs queue instead of being cancelled.
+- `concurrency.group` is keyed by effective mode, so scheduled `apply` and manual `apply` runs share a non-cancelling queue while manual dry-runs remain independently deduplicated.
+- The reusable closeout workflow also queues all `apply` calls behind one non-cancelling lock. This covers overlapping scopes such as `all` and `single_repo`.
 
 ## Operator notes
 
 - The change does not introduce a job-level `timeout-minutes` cap. The waste reduction here is iteration-count and dedup, not wall-clock timeout. The candidate slug retains `weekly-timeout` as a historical lane key but the implementation is iteration-cap + trigger-isolated dedup.
-- Manual `workflow_dispatch` reruns are now deduplicated within their own group; in-flight scheduled runs are unaffected.
+- Manual `workflow_dispatch` dry-run reruns are deduplicated within their own group. In-flight scheduled or manual `apply` runs are never cancelled by this workflow; overlapping apply work queues behind the workflow locks.
 
 ## Merge policy
 

--- a/docs/finops/ghau-waste-ent-dependabot-weekly-timeout.md
+++ b/docs/finops/ghau-waste-ent-dependabot-weekly-timeout.md
@@ -1,17 +1,23 @@
-# GHAU-WASTE: github ent-dependabot weekly timeout
+# GHAU-WASTE: github ent-dependabot weekly closeout iteration caps + workflow_dispatch dedup
 
 Project: GitHub Actions 30-Day Consumption Audit v1 (`4863ff67-0df7-4faf-b9de-5911b1458ab8`)
 
 ## Why
 
-Audit telemetry over 2026-03-31 → 2026-04-30 attributed Actions minutes to the weekly enterprise Dependabot closeout job in `merglbot-core/github` running without a job-level `timeout-minutes` cap. When a downstream operation hung, the job would consume the default 6-hour ceiling.
+Audit telemetry over 2026-03-31 → 2026-04-30 attributed Actions minutes to the weekly enterprise Dependabot closeout job in `merglbot-core/github` running through long fix-and-review tail iterations and to redundant manual `workflow_dispatch` reruns that piled up alongside in-flight runs.
 
 ## Change
 
 `.github/workflows/ent-dependabot-weekly.yml` is updated so that:
 
-- The closeout job declares an explicit `timeout-minutes` cap matching observed p95 runtime plus a small buffer.
-- Schedule and trigger wiring are unchanged.
+- The reusable closeout workflow is invoked with explicit `max_fix_iterations: 2` and `max_review_iterations: 2`. Tail iterations beyond these caps were the long-tail consumer of weekly minutes.
+- `concurrency.cancel-in-progress` is now `${{ github.event_name == 'workflow_dispatch' }}` (previously `false`). This deduplicates manual reruns started while an earlier manual run is still in flight, without affecting `schedule`-triggered runs.
+- `concurrency.group` is `ent-dependabot-weekly-closeout-${{ github.event_name }}` so that `schedule` and `workflow_dispatch` runs occupy disjoint groups; a manual rerun can never cancel an in-flight scheduled weekly closeout.
+
+## Operator notes
+
+- The change does not introduce a job-level `timeout-minutes` cap. The waste reduction here is iteration-count and dedup, not wall-clock timeout. The candidate slug retains `weekly-timeout` as a historical lane key but the implementation is iteration-cap + trigger-isolated dedup.
+- Manual `workflow_dispatch` reruns are now deduplicated within their own group; in-flight scheduled runs are unaffected.
 
 ## Merge policy
 

--- a/docs/finops/ghau-waste-ent-dependabot-weekly-timeout.md
+++ b/docs/finops/ghau-waste-ent-dependabot-weekly-timeout.md
@@ -1,0 +1,23 @@
+# GHAU-WASTE: github ent-dependabot weekly timeout
+
+Project: GitHub Actions 30-Day Consumption Audit v1 (`4863ff67-0df7-4faf-b9de-5911b1458ab8`)
+
+## Why
+
+Audit telemetry over 2026-03-31 → 2026-04-30 attributed Actions minutes to the weekly enterprise Dependabot closeout job in `merglbot-core/github` running without a job-level `timeout-minutes` cap. When a downstream operation hung, the job would consume the default 6-hour ceiling.
+
+## Change
+
+`.github/workflows/ent-dependabot-weekly.yml` is updated so that:
+
+- The closeout job declares an explicit `timeout-minutes` cap matching observed p95 runtime plus a small buffer.
+- Schedule and trigger wiring are unchanged.
+
+## Merge policy
+
+This change touches `.github/workflows/**` and is therefore `human_merge_only`.
+
+## Reference
+
+- Cost audit window: `2026-03-31T08:27:19Z` → `2026-04-30T08:27:19Z`
+- Candidate mutex: `ghau-opt:merglbot-core/github:ent-dependabot-weekly-timeout`


### PR DESCRIPTION
## Summary
- Cap the weekly `ENT Dependabot Weekly Closeout` caller at `max_fix_iterations: 2` and `max_review_iterations: 2`.
- Deduplicate superseded manual dry-run dispatches while preventing any operator dispatch from cancelling an in-flight apply.
- Serialize all reusable closeout `apply` runs behind one non-cancelling lock so `all` and `single_repo` scopes cannot race over overlapping repository state.

## Audit context
- Candidate: `ent-dependabot-weekly-timeout`
- Canonical source evidence: `/tmp/ghau/t30/coverage.json` and `/tmp/ghau/t30/cap_loss_report.json`.
- Estimated savings: 169 Actions minutes over 30 days, about $0.503 net.
- Scope: `.github/workflows/ent-dependabot-weekly.yml` plus the called reusable workflow lock needed to make the caller change safe.

## Notes
- `timeout-minutes` cannot be set on a job that calls a reusable workflow with `uses`; `actionlint` rejects that syntax. This PR applies the safe caller-side caps available from this workflow file.
- `workflow_call.inputs.max_fix_iterations` and `workflow_call.inputs.max_review_iterations` are declared as `type: number` in `.github/workflows/ent-dependabot-autonomous-closeout.yml`.
- The reusable workflow concurrency group is now keyed by effective mode. All `apply` runs queue with `cancel-in-progress: false`; non-mutating dry-runs may be superseded.
- This changes `.github/workflows/**`, so the lane remains `human_merge_only` even after Merglbot approval/authority-clear evidence.

## Validation
- `actionlint -shellcheck= .github/workflows/ent-dependabot-weekly.yml .github/workflows/ent-dependabot-autonomous-closeout.yml`
- `git diff --check -- .github/workflows/ent-dependabot-weekly.yml .github/workflows/ent-dependabot-autonomous-closeout.yml docs/finops/ghau-waste-ent-dependabot-weekly-timeout.md docs/ent-dependabot-autonomous-closeout.md`
- Current remediation head: `486a8f260260d9a11456e9385a0cf9beaff4baf4`
