### PR TITLE
feat(reusable-build-attest): add optional trivyignores input

### DIFF
--- a/.github/workflows/reusable-build-attest.yml
+++ b/.github/workflows/reusable-build-attest.yml
@@ -59,6 +59,16 @@ on:
         required: false
         type: boolean
         default: true
+      trivyignores:
+        description: |
+          Optional path (relative to the checkout) to a .trivyignore file
+          listing CVE IDs to be temporarily ignored by the Trivy scan step.
+          Each ignore entry should follow the existing AADC D05 pattern
+          (CVE-... exp:YYYY-MM-DD) and must be tracked by a security
+          follow-up issue. Leave empty to apply no ignore file.
+        required: false
+        type: string
+        default: ''
     secrets:
       wif_provider:
         description: 'GCP Workload Identity Federation Provider'
@@ -181,6 +191,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           limit-severities-for-sarif: true
           exit-code: '1'
+          trivyignores: ${{ inputs.trivyignores }}
 
       - name: Upload Trivy SARIF
         if: inputs.scan && always()


### PR DESCRIPTION
## Summary
- Adds an optional `trivyignores` input to `.github/workflows/reusable-build-attest.yml`. The value is forwarded to `aquasecurity/trivy-action` as its `trivyignores` parameter so callers can apply a narrow, time-boxed `.trivyignore` file to the Trivy CRITICAL/HIGH scan without re-implementing the build pipeline.
- Default is the empty string, so the existing scan behavior is unchanged for every current caller.

## Motivation
Services using this reusable workflow today cannot pass a `.trivyignore` to the Trivy step (the AADC D05 image workflow had to inline `trivy-action` directly to apply ignores). When an OS-level CVE is disclosed with no fixed package in the current base image, the service is forced to either accept the failing scan or duplicate the entire workflow. Allowing the existing trivy-action `trivyignores` semantics to flow through this reusable workflow lets services follow the established AADC D05 pattern (narrow CVE list, `exp:YYYY-MM-DD` expiry, tracking issue) without losing SLSA provenance or Binary Authorization.

Immediate caller: pr-assistant-v4 needs to apply a narrow 30-day exception for 4 newly disclosed Debian trixie OS CVEs in `python:3.11-slim`. Tracking issue: [merglbot-core/platform#237](https://github.com/merglbot-core/platform/issues/237).

## Test plan
- [ ] Existing callers (`ads-analytics-sync`, `ai-usage-ingestor`, `pr-assistant-v4`, `terraform-policy-app`, etc.) continue to scan without ignores because the input defaults to `''`.
- [ ] A caller passing `trivyignores: services/foo/.trivyignore` invokes Trivy with `--ignorefile services/foo/.trivyignore`.
- [ ] Reusable workflow lint passes (`actionlint`, `yamllint`).
- [ ] Merglbot current-head review approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)