### PR TITLE
feat(policy-engine): add Merglbot autonomy policy implementation

### DIFF
--- a/.github/workflows/policy-engine-tests.yml
+++ b/.github/workflows/policy-engine-tests.yml
@@ -1,0 +1,25 @@
+name: Policy Engine Tests
+
+on:
+  pull_request:
+    paths:
+      - "scripts/policy-engine/**"
+      - "tests/test_final_merge_readiness.py"
+      - ".github/workflows/policy-engine-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unittest:
+    name: Policy Engine Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Run tests
+        run: python3 -m unittest discover -s tests -p 'test_*.py'

--- a/.github/workflows/policy-engine-tests.yml
+++ b/.github/workflows/policy-engine-tests.yml
@@ -18,6 +18,8 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      # Pinned action SHAs are reviewed through the normal dependency refresh
+      # lane; update both pins in one PR with policy-engine tests green.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 

--- a/.github/workflows/policy-engine-tests.yml
+++ b/.github/workflows/policy-engine-tests.yml
@@ -21,5 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+
       - name: Run tests
-        run: python3 -m unittest discover -s tests -p 'test_*.py'
+        run: python -m unittest discover -s tests -p 'test_*.py'

--- a/docs/pr-assistant/final-merge-readiness.md
+++ b/docs/pr-assistant/final-merge-readiness.md
@@ -64,7 +64,9 @@ The bootstrap evaluator has these safety contracts:
   Missing or malformed scope fails closed, the same as an out-of-scope
   repository owner.
 - Changed-file paths are normalized before glob matching and receipt hashing,
-  including Windows separators and leading slashes.
+  including Windows separators. Absolute paths, drive-prefixed paths, parent
+  traversal, and changed-file lists above the policy size limit are classified
+  as security-sensitive instead of being accepted.
 - The module remains import-safe for unit tests; command-line execution stays
   behind the `if __name__ == "__main__"` guard.
 - GitHub Actions are pinned to commit SHAs. Refresh both the checkout and

--- a/docs/pr-assistant/final-merge-readiness.md
+++ b/docs/pr-assistant/final-merge-readiness.md
@@ -47,3 +47,26 @@ Local validation:
 python3 -m py_compile scripts/pr-assistant/final-merge-readiness.py
 python3 scripts/pr-assistant/final-merge-readiness.py --self-test
 ```
+
+## Policy Engine Bootstrap
+
+`scripts/policy-engine/final_merge_readiness.py` is the stdlib-only bootstrap
+evaluator used before the protected-base final merge readiness evaluator is
+available in a repository. It is covered by
+`.github/workflows/policy-engine-tests.yml` and
+`tests/test_final_merge_readiness.py`.
+
+The bootstrap evaluator has these safety contracts:
+
+- Runtime is Python 3.11 or newer. The workflow installs Python 3.11 and the
+  script exits immediately on older interpreters.
+- `repo_scope` is required in `scripts/policy-engine/policy-manifest.json`.
+  Missing or malformed scope fails closed, the same as an out-of-scope
+  repository owner.
+- Changed-file paths are normalized before glob matching and receipt hashing,
+  including Windows separators and leading slashes.
+- The module remains import-safe for unit tests; command-line execution stays
+  behind the `if __name__ == "__main__"` guard.
+- GitHub Actions are pinned to commit SHAs. Refresh both the checkout and
+  setup-python pins in the dependency refresh lane, with policy-engine tests
+  green in the same PR.

--- a/scripts/policy-engine/final_merge_readiness.py
+++ b/scripts/policy-engine/final_merge_readiness.py
@@ -19,6 +19,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+if sys.version_info < (3, 11):
+    raise SystemExit("final_merge_readiness.py requires Python 3.11 or newer")
+
 
 DECISION_ALLOW = "allow"
 DECISION_BLOCK = "block"
@@ -124,7 +127,7 @@ def extract_repository_full_name(event: dict[str, Any]) -> str:
 def evaluate_repo_scope(event: dict[str, Any], manifest: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
     scope = manifest.get("repo_scope", {})
     if not isinstance(scope, dict) or not scope:
-        return {"configured": False, "accepted": True}, []
+        return {"configured": False, "accepted": False}, ["Repository scope is missing from policy manifest."]
 
     repository_full_name = extract_repository_full_name(event)
     owner = repository_full_name.split("/", 1)[0] if "/" in repository_full_name else ""

--- a/scripts/policy-engine/final_merge_readiness.py
+++ b/scripts/policy-engine/final_merge_readiness.py
@@ -16,7 +16,7 @@ import hashlib
 import json
 import sys
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -49,18 +49,27 @@ def stable_digest(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-def glob_match(path_value: str, patterns: list[str]) -> bool:
-    """Match repository-relative paths with fnmatch semantics.
+def normalize_repo_path(path_value: str) -> str:
+    return str(path_value or "").replace("\\", "/").lstrip("/")
 
-    Python's fnmatch treats `**` as ordinary glob characters, so this helper
-    keeps one documented compatibility rule: patterns that start with `**/`
-    also match the same suffix at repository root.
+
+def glob_match(path_value: str, patterns: list[str]) -> bool:
+    """Match normalized repository-relative paths.
+
+    `PurePosixPath.match` provides deterministic recursive `**` behavior for
+    manifest paths after separators and leading slashes are normalized.
+    Patterns that start with `**/` also match the same suffix at repository
+    root to keep historical manifest compatibility.
     """
-    normalized = path_value.replace("\\", "/").lstrip("/")
+    normalized = normalize_repo_path(path_value)
+    posix_path = PurePosixPath(normalized)
     for pattern in patterns:
-        if fnmatch.fnmatchcase(normalized, pattern):
+        normalized_pattern = normalize_repo_path(str(pattern))
+        if posix_path.match(normalized_pattern):
             return True
-        if pattern.startswith("**/") and fnmatch.fnmatchcase(normalized, pattern[3:]):
+        if normalized_pattern.startswith("**/") and posix_path.match(normalized_pattern[3:]):
+            return True
+        if fnmatch.fnmatchcase(normalized, normalized_pattern):
             return True
     return False
 
@@ -78,7 +87,7 @@ def stable_tree_marker(changed_files: list[str], head_sha: str, base_sha: str) -
     digest.update(head_sha.encode("utf-8"))
     digest.update(b"\0")
     digest.update(base_sha.encode("utf-8"))
-    for file_path in sorted(changed_files):
+    for file_path in sorted({normalize_repo_path(file_path) for file_path in changed_files}):
         digest.update(b"\0")
         digest.update(file_path.encode("utf-8"))
     return digest.hexdigest()

--- a/scripts/policy-engine/final_merge_readiness.py
+++ b/scripts/policy-engine/final_merge_readiness.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Merglbot autonomy policy evaluator.
+
+The script is intentionally stdlib-only so it can run from GitHub Actions
+without bootstrapping a repo-specific runtime. It emits bounded JSON receipts
+for final merge readiness and Terraform deployment protection approval.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+DECISION_ALLOW = "allow"
+DECISION_BLOCK = "block"
+DECISION_HUMAN_REQUIRED = "human_required"
+
+
+def load_json(path: str | Path) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return data
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_z(value: datetime) -> str:
+    return value.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def glob_match(path_value: str, patterns: list[str]) -> bool:
+    normalized = path_value.replace("\\", "/").lstrip("/")
+    for pattern in patterns:
+        if fnmatch.fnmatchcase(normalized, pattern):
+            return True
+        if pattern.startswith("**/") and fnmatch.fnmatchcase(normalized, pattern[3:]):
+            return True
+    return False
+
+
+def all_match(paths: list[str], patterns: list[str]) -> bool:
+    return bool(paths) and all(glob_match(path_value, patterns) for path_value in paths)
+
+
+def any_match(paths: list[str], patterns: list[str]) -> bool:
+    return any(glob_match(path_value, patterns) for path_value in paths)
+
+
+def stable_tree_marker(changed_files: list[str], head_sha: str, base_sha: str) -> str:
+    digest = hashlib.sha256()
+    digest.update(head_sha.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(base_sha.encode("utf-8"))
+    for file_path in sorted(changed_files):
+        digest.update(b"\0")
+        digest.update(file_path.encode("utf-8"))
+    return digest.hexdigest()
+
+
+def classify_path_risk(changed_files: list[str], manifest: dict[str, Any]) -> tuple[str, list[str]]:
+    path_policy = manifest.get("path_policy", {})
+    docs_globs = as_list(path_policy.get("docs_only_globs"))
+    prompt_globs = as_list(path_policy.get("prompt_library_globs"))
+    workflow_globs = as_list(path_policy.get("workflow_globs"))
+    terraform_globs = as_list(path_policy.get("terraform_globs"))
+    denied_globs = as_list(path_policy.get("denied_globs"))
+
+    notes: list[str] = []
+    if not changed_files:
+        return "unknown", ["No changed files were supplied."]
+    if any_match(changed_files, denied_globs):
+        return "security_sensitive", ["Denied or credential-shaped path changed."]
+    if any_match(changed_files, workflow_globs):
+        notes.append("Workflow, reusable action, or policy path changed.")
+        return "workflow", notes
+    if any_match(changed_files, terraform_globs):
+        notes.append("Terraform or Terraform deployment path changed.")
+        return "terraform", notes
+    if all_match(changed_files, docs_globs):
+        return "docs_only", notes
+    if any_match(changed_files, prompt_globs):
+        notes.append("Prompt library governance path changed.")
+        return "prompt_library", notes
+    return "code", ["General code path changed."]
+
+
+def normalize_status(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def evaluate_review_receipt(event: dict[str, Any], manifest: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    receipt = event.get("review_receipt")
+    if not isinstance(receipt, dict):
+        return {"status": "missing"}, ["Missing Merglbot review receipt."]
+
+    head_sha = str(event.get("head_sha") or "")
+    receipt_head_sha = str(receipt.get("head_sha") or receipt.get("review_head_sha") or "")
+    required = manifest.get("required_evidence", {}).get("review_receipt", {})
+    accepted = {normalize_status(value) for value in as_list(required.get("accepted_statuses"))}
+    status_candidates = [
+        receipt.get("status"),
+        receipt.get("decision"),
+        receipt.get("verdict"),
+        receipt.get("review_status"),
+    ]
+    statuses = {normalize_status(value) for value in status_candidates if value is not None}
+
+    problems: list[str] = []
+    if required.get("must_match_head_sha", True) and (not head_sha or receipt_head_sha != head_sha):
+        problems.append("Merglbot review receipt does not match current head SHA.")
+    if not statuses.intersection(accepted):
+        problems.append("Merglbot review receipt is not in an accepted status.")
+
+    normalized = {
+        "provider": receipt.get("provider") or required.get("provider") or "Merglbot PR Assistant",
+        "head_sha": receipt_head_sha,
+        "statuses": sorted(statuses),
+        "accepted": not problems,
+    }
+    return normalized, problems
+
+
+def evaluate_required_checks(event: dict[str, Any], manifest: dict[str, Any]) -> tuple[list[dict[str, Any]], list[str]]:
+    required = manifest.get("required_evidence", {}).get("required_checks", {})
+    accepted = {normalize_status(value) for value in as_list(required.get("accepted_conclusions"))}
+    checks = as_list(event.get("required_checks"))
+    normalized: list[dict[str, Any]] = []
+    problems: list[str] = []
+
+    if not checks:
+        return [], ["No required-check evidence was supplied."]
+
+    for raw in checks:
+        if not isinstance(raw, dict):
+            problems.append("Malformed required-check entry.")
+            continue
+        name = str(raw.get("name") or raw.get("context") or "unknown")
+        conclusion = normalize_status(raw.get("conclusion") or raw.get("status"))
+        ok = conclusion in accepted
+        normalized.append({"name": name, "conclusion": conclusion, "accepted": ok})
+        if not ok:
+            problems.append(f"Required check `{name}` is `{conclusion or 'unknown'}`.")
+    return normalized, problems
+
+
+def evaluate_docs_obligation(event: dict[str, Any], manifest: dict[str, Any], risk_class: str) -> tuple[str, list[str]]:
+    accepted = {
+        normalize_status(value)
+        for value in as_list(manifest.get("required_evidence", {}).get("docs_obligation", {}).get("accepted_states"))
+    }
+    raw_state = event.get("docs_obligation")
+    if raw_state is None and isinstance(event.get("review_receipt"), dict):
+        raw_state = (
+            event["review_receipt"].get("docs_obligation")
+            or event["review_receipt"].get("documentation_obligation_state")
+        )
+    state = normalize_status(raw_state)
+    if not state and risk_class == "docs_only":
+        return "not_required", []
+    if state in accepted:
+        return state, []
+    return state or "unknown", ["Documentation obligation is not satisfied."]
+
+
+def evaluate_ai_data_policy_check(event: dict[str, Any], manifest: dict[str, Any], changed_files: list[str]) -> tuple[dict[str, Any], list[str]]:
+    path_policy = manifest.get("path_policy", {})
+    policy_globs = as_list(path_policy.get("ai_data_policy_globs"))
+    required = bool(policy_globs) and any_match(changed_files, policy_globs)
+    if not required:
+        return {"required": False, "state": "not_applicable"}, []
+
+    accepted = {
+        normalize_status(value)
+        for value in as_list(manifest.get("required_evidence", {}).get("ai_data_policy_check", {}).get("accepted_states"))
+    }
+    raw_state = event.get("ai_data_policy_check")
+    if raw_state is None and isinstance(event.get("review_receipt"), dict):
+        raw_state = (
+            event["review_receipt"].get("ai_data_policy_check")
+            or event["review_receipt"].get("client_data_exposure_check")
+        )
+    state = normalize_status(raw_state)
+    if state in accepted:
+        return {"required": True, "state": state}, []
+    return {"required": True, "state": state or "missing"}, ["AI data policy check is required for this PR scope."]
+
+
+def evaluate_final_merge_readiness(event: dict[str, Any], manifest: dict[str, Any]) -> dict[str, Any]:
+    changed_files = [str(value) for value in as_list(event.get("changed_files"))]
+    head_sha = str(event.get("head_sha") or "")
+    base_sha = str(event.get("base_sha") or "")
+    now = utc_now()
+    ttl_minutes = int(manifest.get("receipt_ttl_minutes") or 30)
+    risk_class, risk_notes = classify_path_risk(changed_files, manifest)
+    review_receipt, review_problems = evaluate_review_receipt(event, manifest)
+    required_checks, check_problems = evaluate_required_checks(event, manifest)
+    docs_obligation, docs_problems = evaluate_docs_obligation(event, manifest, risk_class)
+    ai_data_policy_check, ai_data_policy_problems = evaluate_ai_data_policy_check(event, manifest, changed_files)
+
+    problems = [*risk_notes, *review_problems, *check_problems, *docs_problems, *ai_data_policy_problems]
+    allowed_actions = manifest.get("autonomous_actions", {}).get(risk_class, [])
+    if risk_class in {"workflow", "terraform", "security_sensitive", "code", "unknown"}:
+        decision = DECISION_HUMAN_REQUIRED
+        problems.append(f"Risk class `{risk_class}` is not eligible for autonomous final merge readiness.")
+    elif "final_merge_readiness" not in allowed_actions:
+        decision = DECISION_HUMAN_REQUIRED
+        problems.append(f"Risk class `{risk_class}` has no autonomous final merge policy.")
+    elif review_problems or check_problems or docs_problems or ai_data_policy_problems:
+        decision = DECISION_BLOCK
+    else:
+        decision = DECISION_ALLOW
+
+    candidate_tree_sha = str(event.get("candidate_tree_sha") or "") or stable_tree_marker(changed_files, head_sha, base_sha)
+
+    return {
+        "schema_version": manifest.get("schema_version"),
+        "policy_name": manifest.get("policy_name"),
+        "head_sha": head_sha,
+        "base_sha": base_sha,
+        "merge_strategy": str(event.get("merge_strategy") or manifest.get("default_merge_strategy") or "squash"),
+        "candidate_tree_sha": candidate_tree_sha,
+        "changed_files": changed_files,
+        "risk_class": risk_class,
+        "docs_obligation": docs_obligation,
+        "ai_data_policy_check": ai_data_policy_check,
+        "review_receipt": review_receipt,
+        "required_checks": required_checks,
+        "decision": decision,
+        "reasons": problems,
+        "issued_at": isoformat_z(now),
+        "expires_at": isoformat_z(now + timedelta(minutes=ttl_minutes)),
+    }
+
+
+def evaluate_terraform_approval(event: dict[str, Any], manifest: dict[str, Any]) -> dict[str, Any]:
+    tf_policy = manifest.get("terraform_approval", {})
+    required_fields = [str(value) for value in as_list(tf_policy.get("required_fields"))]
+    problems: list[str] = []
+    for field in required_fields:
+        if event.get(field) in (None, "", []):
+            problems.append(f"Missing Terraform approval field `{field}`.")
+
+    workspace_phase = str(event.get("workspace_phase") or "")
+    expected_action = str(event.get("expected_action") or "")
+    policy_decision = normalize_status(event.get("policy_decision"))
+    allowed_targets = [str(value) for value in as_list(event.get("allowed_targets"))]
+    plan_hash = str(event.get("plan_hash") or "")
+    head_sha = str(event.get("head_sha") or "")
+
+    if workspace_phase not in as_list(tf_policy.get("allowed_workspace_phases")):
+        problems.append(f"Workspace phase `{workspace_phase}` is not allowed.")
+    if expected_action not in as_list(tf_policy.get("allowed_expected_actions")):
+        problems.append(f"Expected action `{expected_action}` is not allowed.")
+    if policy_decision not in {normalize_status(value) for value in as_list(tf_policy.get("approved_policy_decisions"))}:
+        problems.append("Terraform approval policy decision is not approved.")
+    if not plan_hash.startswith("sha256:") or len(plan_hash) <= len("sha256:"):
+        problems.append("Terraform plan hash must use `sha256:<digest>` format.")
+    denied_target_globs = [str(value) for value in as_list(tf_policy.get("denied_target_globs"))]
+    if any_match(allowed_targets, denied_target_globs):
+        problems.append("Terraform approval includes a denied target.")
+    if not head_sha:
+        problems.append("Terraform approval is missing exact commit SHA.")
+
+    now = utc_now()
+    decision = DECISION_ALLOW if not problems else DECISION_BLOCK
+    return {
+        "schema_version": manifest.get("schema_version"),
+        "policy_name": manifest.get("policy_name"),
+        "workflow_run_id": event.get("workflow_run_id"),
+        "head_sha": head_sha,
+        "workspace_phase": workspace_phase,
+        "plan_hash": plan_hash,
+        "allowed_targets": allowed_targets,
+        "expected_action": expected_action,
+        "policy_decision": event.get("policy_decision"),
+        "rollback_note": event.get("rollback_note"),
+        "decision": decision,
+        "reasons": problems,
+        "issued_at": isoformat_z(now),
+        "custom_deployment_protection_rule": tf_policy.get("custom_deployment_protection_rule", {}),
+    }
+
+
+def write_receipt(receipt: dict[str, Any], output_path: str | None) -> None:
+    text = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    if output_path:
+        Path(output_path).write_text(text, encoding="utf-8")
+    print(text, end="")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", default="scripts/policy-engine/policy-manifest.json")
+    parser.add_argument("--event", required=True, help="JSON event payload to evaluate")
+    parser.add_argument("--output", help="Optional path for the emitted receipt")
+    parser.add_argument(
+        "--mode",
+        choices=["final-merge-readiness", "terraform-approval"],
+        default="final-merge-readiness",
+    )
+    args = parser.parse_args(argv)
+
+    manifest = load_json(args.manifest)
+    event = load_json(args.event)
+    if args.mode == "terraform-approval":
+        receipt = evaluate_terraform_approval(event, manifest)
+    else:
+        receipt = evaluate_final_merge_readiness(event, manifest)
+    write_receipt(receipt, args.output)
+    return 0 if receipt.get("decision") == DECISION_ALLOW else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/policy-engine/final_merge_readiness.py
+++ b/scripts/policy-engine/final_merge_readiness.py
@@ -4,6 +4,8 @@
 The script is intentionally stdlib-only so it can run from GitHub Actions
 without bootstrapping a repo-specific runtime. It emits bounded JSON receipts
 for final merge readiness and Terraform deployment protection approval.
+
+Runtime contract: Python 3.11 in CI. The script only uses the standard library.
 """
 
 from __future__ import annotations

--- a/scripts/policy-engine/final_merge_readiness.py
+++ b/scripts/policy-engine/final_merge_readiness.py
@@ -19,13 +19,12 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-if sys.version_info < (3, 11):
-    raise SystemExit("final_merge_readiness.py requires Python 3.11 or newer")
-
 
 DECISION_ALLOW = "allow"
 DECISION_BLOCK = "block"
 DECISION_HUMAN_REQUIRED = "human_required"
+INVALID_REPO_PATH_MARKER = "__invalid_repo_path__"
+MAX_CHANGED_FILES = 1_000
 
 
 def load_json(path: str | Path) -> dict[str, Any]:
@@ -53,7 +52,23 @@ def stable_digest(value: str) -> str:
 
 
 def normalize_repo_path(path_value: str) -> str:
-    return str(path_value or "").replace("\\", "/").lstrip("/")
+    raw = str(path_value or "").replace("\\", "/").strip()
+    if not raw:
+        return ""
+    if raw.startswith("/") or (len(raw) >= 2 and raw[1] == ":" and raw[0].isalpha()):
+        return INVALID_REPO_PATH_MARKER
+    parts: list[str] = []
+    for part in raw.split("/"):
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            return INVALID_REPO_PATH_MARKER
+        parts.append(part)
+    return "/".join(parts)
+
+
+def has_invalid_repo_path(paths: list[str]) -> bool:
+    return any(normalize_repo_path(path_value) == INVALID_REPO_PATH_MARKER for path_value in paths)
 
 
 def glob_match(path_value: str, patterns: list[str]) -> bool:
@@ -160,6 +175,10 @@ def classify_path_risk(changed_files: list[str], manifest: dict[str, Any]) -> tu
     notes: list[str] = []
     if not changed_files:
         return "unknown", ["No changed files were supplied."]
+    if len(changed_files) > MAX_CHANGED_FILES:
+        return "security_sensitive", ["Changed-file evidence exceeds policy size limit."]
+    if has_invalid_repo_path(changed_files):
+        return "security_sensitive", ["Invalid repository path changed."]
     if any_match(changed_files, denied_globs):
         return "security_sensitive", ["Denied or credential-shaped path changed."]
     if any_match(changed_files, workflow_globs):
@@ -383,6 +402,9 @@ def write_receipt(receipt: dict[str, Any], output_path: str | None) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    if sys.version_info < (3, 11):
+        raise SystemExit("final_merge_readiness.py requires Python 3.11 or newer")
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", default="scripts/policy-engine/policy-manifest.json")
     parser.add_argument("--event", required=True, help="JSON event payload to evaluate")

--- a/scripts/policy-engine/final_merge_readiness.py
+++ b/scripts/policy-engine/final_merge_readiness.py
@@ -43,7 +43,17 @@ def as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
 
 
+def stable_digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
 def glob_match(path_value: str, patterns: list[str]) -> bool:
+    """Match repository-relative paths with fnmatch semantics.
+
+    Python's fnmatch treats `**` as ordinary glob characters, so this helper
+    keeps one documented compatibility rule: patterns that start with `**/`
+    also match the same suffix at repository root.
+    """
     normalized = path_value.replace("\\", "/").lstrip("/")
     for pattern in patterns:
         if fnmatch.fnmatchcase(normalized, pattern):
@@ -70,6 +80,59 @@ def stable_tree_marker(changed_files: list[str], head_sha: str, base_sha: str) -
         digest.update(b"\0")
         digest.update(file_path.encode("utf-8"))
     return digest.hexdigest()
+
+
+def evidence_summary(values: list[str], *, head_sha: str = "", base_sha: str = "") -> dict[str, Any]:
+    return {
+        "count": len(values),
+        "marker": stable_tree_marker(values, head_sha, base_sha) if values else None,
+    }
+
+
+def extract_repository_full_name(event: dict[str, Any]) -> str:
+    raw_repository = event.get("repository") or event.get("repository_full_name") or event.get("repo")
+    if isinstance(raw_repository, dict):
+        full_name = raw_repository.get("full_name")
+        if isinstance(full_name, str) and "/" in full_name:
+            return full_name
+        owner = raw_repository.get("owner")
+        owner_name = owner.get("login") if isinstance(owner, dict) else owner
+        name = raw_repository.get("name")
+        if isinstance(owner_name, str) and isinstance(name, str):
+            return f"{owner_name}/{name}"
+        return ""
+    if isinstance(raw_repository, str):
+        return raw_repository.strip()
+    owner = event.get("owner") or event.get("organization")
+    repo_name = event.get("repo_name") or event.get("repository_name")
+    if isinstance(owner, str) and isinstance(repo_name, str):
+        return f"{owner}/{repo_name}"
+    return ""
+
+
+def evaluate_repo_scope(event: dict[str, Any], manifest: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    scope = manifest.get("repo_scope", {})
+    if not isinstance(scope, dict) or not scope:
+        return {"configured": False, "accepted": True}, []
+
+    repository_full_name = extract_repository_full_name(event)
+    owner = repository_full_name.split("/", 1)[0] if "/" in repository_full_name else ""
+    included_orgs = {str(value) for value in as_list(scope.get("included_orgs"))}
+    excluded_orgs = {str(value) for value in as_list(scope.get("excluded_orgs"))}
+    problems: list[str] = []
+
+    if not owner:
+        problems.append("Repository scope evidence is missing or malformed.")
+    elif owner in excluded_orgs:
+        problems.append("Repository owner is explicitly excluded by policy manifest.")
+    elif included_orgs and owner not in included_orgs:
+        problems.append("Repository owner is outside the policy manifest scope.")
+
+    return {
+        "configured": True,
+        "accepted": not problems,
+        "repository_marker": stable_digest(repository_full_name)[:16] if repository_full_name else None,
+    }, problems
 
 
 def classify_path_risk(changed_files: list[str], manifest: dict[str, Any]) -> tuple[str, list[str]]:
@@ -207,12 +270,13 @@ def evaluate_final_merge_readiness(event: dict[str, Any], manifest: dict[str, An
     now = utc_now()
     ttl_minutes = int(manifest.get("receipt_ttl_minutes") or 30)
     risk_class, risk_notes = classify_path_risk(changed_files, manifest)
+    repo_scope, repo_scope_problems = evaluate_repo_scope(event, manifest)
     review_receipt, review_problems = evaluate_review_receipt(event, manifest)
     required_checks, check_problems = evaluate_required_checks(event, manifest)
     docs_obligation, docs_problems = evaluate_docs_obligation(event, manifest, risk_class)
     ai_data_policy_check, ai_data_policy_problems = evaluate_ai_data_policy_check(event, manifest, changed_files)
 
-    problems = [*risk_notes, *review_problems, *check_problems, *docs_problems, *ai_data_policy_problems]
+    problems = [*repo_scope_problems, *risk_notes, *review_problems, *check_problems, *docs_problems, *ai_data_policy_problems]
     allowed_actions = manifest.get("autonomous_actions", {}).get(risk_class, [])
     if risk_class in {"workflow", "terraform", "security_sensitive", "code", "unknown"}:
         decision = DECISION_HUMAN_REQUIRED
@@ -220,7 +284,7 @@ def evaluate_final_merge_readiness(event: dict[str, Any], manifest: dict[str, An
     elif "final_merge_readiness" not in allowed_actions:
         decision = DECISION_HUMAN_REQUIRED
         problems.append(f"Risk class `{risk_class}` has no autonomous final merge policy.")
-    elif review_problems or check_problems or docs_problems or ai_data_policy_problems:
+    elif repo_scope_problems or review_problems or check_problems or docs_problems or ai_data_policy_problems:
         decision = DECISION_BLOCK
     else:
         decision = DECISION_ALLOW
@@ -234,7 +298,8 @@ def evaluate_final_merge_readiness(event: dict[str, Any], manifest: dict[str, An
         "base_sha": base_sha,
         "merge_strategy": str(event.get("merge_strategy") or manifest.get("default_merge_strategy") or "squash"),
         "candidate_tree_sha": candidate_tree_sha,
-        "changed_files": changed_files,
+        "changed_files_summary": evidence_summary(changed_files, head_sha=head_sha, base_sha=base_sha),
+        "repo_scope": repo_scope,
         "risk_class": risk_class,
         "docs_obligation": docs_obligation,
         "ai_data_policy_check": ai_data_policy_check,
@@ -285,7 +350,7 @@ def evaluate_terraform_approval(event: dict[str, Any], manifest: dict[str, Any])
         "head_sha": head_sha,
         "workspace_phase": workspace_phase,
         "plan_hash": plan_hash,
-        "allowed_targets": allowed_targets,
+        "allowed_targets_summary": evidence_summary(allowed_targets, head_sha=head_sha),
         "expected_action": expected_action,
         "policy_decision": event.get("policy_decision"),
         "rollback_note": event.get("rollback_note"),

--- a/scripts/policy-engine/policy-manifest.json
+++ b/scripts/policy-engine/policy-manifest.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": "2026-05-01",
+  "policy_name": "merglbot-autonomy-policy",
+  "default_merge_strategy": "squash",
+  "receipt_ttl_minutes": 30,
+  "repo_scope": {
+    "included_orgs": [
+      "merglbot-autodoplnky",
+      "merglbot-cerano",
+      "merglbot-core",
+      "merglbot-denatura",
+      "merglbot-extractors",
+      "merglbot-hodinarstvibechyne",
+      "merglbot-kiteboarding",
+      "merglbot-milan-private",
+      "merglbot-proteinaco",
+      "merglbot-public",
+      "merglbot-ruzovyslon",
+      "merglbot-shared"
+    ],
+    "excluded_orgs": ["Merglevsky-cz", "lrtch"],
+    "active_repo_count": 46,
+    "active_repo_count_source": "merglbot-public/docs/REPOSITORY_MAP.md"
+  },
+  "path_policy": {
+    "docs_only_globs": [
+      "*.md",
+      "docs/**",
+      "projects/**",
+      "ci-audit/**",
+      "DOCUMENTATION_INDEX.md",
+      "REPOSITORY_MAP.md"
+    ],
+    "prompt_library_globs": [
+      "prompt-library/assets/**",
+      "prompt-library/*.json",
+      "apps/server/src/promptCatalog.ts",
+      "apps/server/test/promptCatalog.test.ts"
+    ],
+    "ai_data_policy_globs": [
+      "MERGLBOT_AI_DATA_WORKFLOW_POLICY.md",
+      "MERGLBOT_AI_TOOLS.md",
+      "MERGLBOT_CURSOR_SETUP.md",
+      "MERGLBOT_DATA_VALIDATION.md",
+      "SECURITY.md",
+      "RULEBOOK_V2.md",
+      "DOCUMENTATION_INDEX.md",
+      "prompt-library/assets/**",
+      "prompt-library/*.json",
+      "agent-opening/**",
+      "agent-appendix/**",
+      "apps/server/src/contextPolicy.ts",
+      "apps/server/src/createServer.ts",
+      "apps/server/src/dataExposurePolicy.ts",
+      "apps/server/src/invocationAudit.ts",
+      "apps/server/test/*Policy*.test.ts",
+      "projects/**/*ANALYTICS*.md",
+      "projects/**/*BIGQUERY*.md"
+    ],
+    "workflow_globs": [
+      ".github/workflows/**",
+      ".github/actions/**",
+      ".github/policies/**"
+    ],
+    "terraform_globs": [
+      "terraform/**",
+      "**/*.tf",
+      "**/*.tfvars",
+      ".github/workflows/terraform-*.yml"
+    ],
+    "denied_globs": [
+      "**/*secret*",
+      "**/*.pem",
+      "**/*.key",
+      "**/*service-account*.json",
+      "**/*credentials*.json"
+    ]
+  },
+  "autonomous_actions": {
+    "docs_only": ["final_merge_readiness"],
+    "prompt_library": ["final_merge_readiness"],
+    "workflow": [],
+    "terraform": [],
+    "security_sensitive": []
+  },
+  "required_evidence": {
+    "review_receipt": {
+      "provider": "Merglbot PR Assistant",
+      "must_match_head_sha": true,
+      "accepted_statuses": ["success", "approved_for_closeout"],
+      "advisory_providers": ["Cursor", "Gemini", "Bugbot"]
+    },
+    "required_checks": {
+      "accepted_conclusions": ["success", "neutral", "skipped"]
+    },
+    "docs_obligation": {
+      "accepted_states": ["none", "not_required", "satisfied", "same_pr"]
+    },
+    "ai_data_policy_check": {
+      "accepted_states": ["not_applicable", "passed", "aggregate_only", "schema_only", "synthetic_only"]
+    }
+  },
+  "terraform_approval": {
+    "custom_deployment_protection_rule": {
+      "environment": "production",
+      "decision_provider": "merglbot-autonomy-policy-engine",
+      "docs_reference": "https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-deployments/configuring-custom-deployment-protection-rules"
+    },
+    "allowed_workspace_phases": ["bootstrap", "core", "public", "clients"],
+    "allowed_expected_actions": ["apply"],
+    "required_fields": [
+      "workflow_run_id",
+      "head_sha",
+      "workspace_phase",
+      "plan_hash",
+      "allowed_targets",
+      "expected_action",
+      "policy_decision",
+      "rollback_note"
+    ],
+    "approved_policy_decisions": ["approved"],
+    "denied_target_globs": [
+      "**/*service-account-key*",
+      "**/*iam_key*",
+      "google_service_account_key.*"
+    ]
+  }
+}

--- a/scripts/policy-engine/policy-manifest.json
+++ b/scripts/policy-engine/policy-manifest.json
@@ -18,9 +18,7 @@
       "merglbot-ruzovyslon",
       "merglbot-shared"
     ],
-    "excluded_orgs": ["Merglevsky-cz", "lrtch"],
-    "active_repo_count": 46,
-    "active_repo_count_source": "merglbot-public/docs/REPOSITORY_MAP.md"
+    "excluded_orgs": ["Merglevsky-cz", "lrtch"]
   },
   "path_policy": {
     "docs_only_globs": [
@@ -87,8 +85,7 @@
     "review_receipt": {
       "provider": "Merglbot PR Assistant",
       "must_match_head_sha": true,
-      "accepted_statuses": ["success", "approved_for_closeout"],
-      "advisory_providers": ["Cursor", "Gemini", "Bugbot"]
+      "accepted_statuses": ["success", "approved_for_closeout"]
     },
     "required_checks": {
       "accepted_conclusions": ["success", "neutral", "skipped"]

--- a/tests/test_final_merge_readiness.py
+++ b/tests/test_final_merge_readiness.py
@@ -20,6 +20,10 @@ MANIFEST = {
     "policy_name": "test-policy",
     "default_merge_strategy": "squash",
     "receipt_ttl_minutes": 30,
+    "repo_scope": {
+        "included_orgs": ["merglbot-core", "merglbot-public"],
+        "excluded_orgs": ["external-org"],
+    },
     "path_policy": {
         "docs_only_globs": ["*.md", "docs/**", "ci-audit/**", "REPOSITORY_MAP.md"],
         "prompt_library_globs": ["prompt-library/assets/**", "apps/server/src/promptCatalog.ts"],
@@ -71,6 +75,7 @@ def base_event():
     return {
         "head_sha": "abc123",
         "base_sha": "base123",
+        "repository": "merglbot-public/docs",
         "changed_files": ["REPOSITORY_MAP.md", "ci-audit/2026-05-01/inventory.md"],
         "review_receipt": {
             "provider": "Merglbot PR Assistant",
@@ -89,6 +94,8 @@ class FinalMergeReadinessTest(unittest.TestCase):
         self.assertEqual(receipt["decision"], DECISION_ALLOW)
         self.assertEqual(receipt["risk_class"], "docs_only")
         self.assertEqual(receipt["head_sha"], "abc123")
+        self.assertEqual(receipt["changed_files_summary"]["count"], 2)
+        self.assertNotIn("changed_files", receipt)
         self.assertIn("candidate_tree_sha", receipt)
 
     def test_stale_review_fails(self):
@@ -108,6 +115,27 @@ class FinalMergeReadinessTest(unittest.TestCase):
 
         self.assertEqual(receipt["decision"], DECISION_HUMAN_REQUIRED)
         self.assertEqual(receipt["risk_class"], "workflow")
+
+    def test_out_of_scope_repository_blocks_policy_evaluation(self):
+        event = base_event()
+        event["repository"] = "external-org/private-repo"
+
+        receipt = evaluate_final_merge_readiness(event, MANIFEST)
+
+        self.assertEqual(receipt["decision"], DECISION_BLOCK)
+        self.assertFalse(receipt["repo_scope"]["accepted"])
+        self.assertIn("Repository owner is explicitly excluded by policy manifest.", receipt["reasons"])
+
+    def test_receipt_does_not_echo_denied_changed_file_paths(self):
+        event = base_event()
+        event["changed_files"] = ["config/service-account-prod.json"]
+
+        receipt = evaluate_final_merge_readiness(event, MANIFEST)
+        serialized = str(receipt)
+
+        self.assertEqual(receipt["risk_class"], "security_sensitive")
+        self.assertEqual(receipt["changed_files_summary"]["count"], 1)
+        self.assertNotIn("service-account-prod.json", serialized)
 
     def test_ai_data_policy_scope_requires_policy_check(self):
         event = base_event()
@@ -140,6 +168,24 @@ class FinalMergeReadinessTest(unittest.TestCase):
         self.assertEqual(receipt["decision"], DECISION_BLOCK)
         self.assertTrue(any("plan_hash" in reason or "plan hash" in reason.lower() for reason in receipt["reasons"]))
 
+    def test_terraform_approval_does_not_echo_denied_targets(self):
+        event = {
+            "workflow_run_id": "12345",
+            "head_sha": "abc123",
+            "workspace_phase": "core",
+            "plan_hash": "sha256:" + ("b" * 64),
+            "allowed_targets": ["google_service_account_key.prod"],
+            "expected_action": "apply",
+            "policy_decision": "approved",
+            "rollback_note": "Rollback by reverting this commit and re-running apply.",
+        }
+
+        receipt = evaluate_terraform_approval(event, MANIFEST)
+
+        self.assertEqual(receipt["decision"], DECISION_BLOCK)
+        self.assertEqual(receipt["allowed_targets_summary"]["count"], 1)
+        self.assertNotIn("google_service_account_key.prod", str(receipt))
+
     def test_terraform_approval_passes_with_exact_policy_receipt(self):
         event = {
             "workflow_run_id": "12345",
@@ -156,6 +202,8 @@ class FinalMergeReadinessTest(unittest.TestCase):
 
         self.assertEqual(receipt["decision"], DECISION_ALLOW)
         self.assertEqual(receipt["workspace_phase"], "clients")
+        self.assertEqual(receipt["allowed_targets_summary"]["count"], 1)
+        self.assertNotIn("allowed_targets", receipt)
 
 
 if __name__ == "__main__":

--- a/tests/test_final_merge_readiness.py
+++ b/tests/test_final_merge_readiness.py
@@ -1,0 +1,162 @@
+import unittest
+import importlib.util
+from pathlib import Path
+
+POLICY_ENGINE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "policy-engine" / "final_merge_readiness.py"
+spec = importlib.util.spec_from_file_location("final_merge_readiness", POLICY_ENGINE_PATH)
+policy_engine = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(policy_engine)
+
+DECISION_ALLOW = policy_engine.DECISION_ALLOW
+DECISION_BLOCK = policy_engine.DECISION_BLOCK
+DECISION_HUMAN_REQUIRED = policy_engine.DECISION_HUMAN_REQUIRED
+evaluate_final_merge_readiness = policy_engine.evaluate_final_merge_readiness
+evaluate_terraform_approval = policy_engine.evaluate_terraform_approval
+
+
+MANIFEST = {
+    "schema_version": "test",
+    "policy_name": "test-policy",
+    "default_merge_strategy": "squash",
+    "receipt_ttl_minutes": 30,
+    "path_policy": {
+        "docs_only_globs": ["*.md", "docs/**", "ci-audit/**", "REPOSITORY_MAP.md"],
+        "prompt_library_globs": ["prompt-library/assets/**", "apps/server/src/promptCatalog.ts"],
+        "ai_data_policy_globs": [
+            "MERGLBOT_AI_DATA_WORKFLOW_POLICY.md",
+            "prompt-library/assets/**",
+            "apps/server/src/dataExposurePolicy.ts",
+        ],
+        "workflow_globs": [".github/workflows/**", ".github/actions/**"],
+        "terraform_globs": ["terraform/**", "**/*.tf", ".github/workflows/terraform-*.yml"],
+        "denied_globs": ["**/*service-account*.json", "**/*.pem"],
+    },
+    "autonomous_actions": {
+        "docs_only": ["final_merge_readiness"],
+        "prompt_library": ["final_merge_readiness"],
+        "workflow": [],
+        "terraform": [],
+    },
+    "required_evidence": {
+        "review_receipt": {
+            "provider": "Merglbot PR Assistant",
+            "must_match_head_sha": True,
+            "accepted_statuses": ["success", "approved_for_closeout"],
+        },
+        "required_checks": {"accepted_conclusions": ["success", "neutral", "skipped"]},
+        "docs_obligation": {"accepted_states": ["none", "not_required", "satisfied", "same_pr"]},
+        "ai_data_policy_check": {"accepted_states": ["not_applicable", "passed", "aggregate_only"]},
+    },
+    "terraform_approval": {
+        "allowed_workspace_phases": ["bootstrap", "core", "public", "clients"],
+        "allowed_expected_actions": ["apply"],
+        "required_fields": [
+            "workflow_run_id",
+            "head_sha",
+            "workspace_phase",
+            "plan_hash",
+            "allowed_targets",
+            "expected_action",
+            "policy_decision",
+            "rollback_note",
+        ],
+        "approved_policy_decisions": ["approved"],
+        "denied_target_globs": ["google_service_account_key.*", "**/*service-account-key*"],
+    },
+}
+
+
+def base_event():
+    return {
+        "head_sha": "abc123",
+        "base_sha": "base123",
+        "changed_files": ["REPOSITORY_MAP.md", "ci-audit/2026-05-01/inventory.md"],
+        "review_receipt": {
+            "provider": "Merglbot PR Assistant",
+            "head_sha": "abc123",
+            "status": "approved_for_closeout",
+        },
+        "required_checks": [{"name": "docs-smoke", "conclusion": "success"}],
+        "docs_obligation": "same_pr",
+    }
+
+
+class FinalMergeReadinessTest(unittest.TestCase):
+    def test_docs_only_passes_with_current_head_review(self):
+        receipt = evaluate_final_merge_readiness(base_event(), MANIFEST)
+
+        self.assertEqual(receipt["decision"], DECISION_ALLOW)
+        self.assertEqual(receipt["risk_class"], "docs_only")
+        self.assertEqual(receipt["head_sha"], "abc123")
+        self.assertIn("candidate_tree_sha", receipt)
+
+    def test_stale_review_fails(self):
+        event = base_event()
+        event["review_receipt"]["head_sha"] = "old123"
+
+        receipt = evaluate_final_merge_readiness(event, MANIFEST)
+
+        self.assertEqual(receipt["decision"], DECISION_BLOCK)
+        self.assertIn("Merglbot review receipt does not match current head SHA.", receipt["reasons"])
+
+    def test_workflow_change_requires_elevated_policy(self):
+        event = base_event()
+        event["changed_files"] = [".github/workflows/deploy.yml"]
+
+        receipt = evaluate_final_merge_readiness(event, MANIFEST)
+
+        self.assertEqual(receipt["decision"], DECISION_HUMAN_REQUIRED)
+        self.assertEqual(receipt["risk_class"], "workflow")
+
+    def test_ai_data_policy_scope_requires_policy_check(self):
+        event = base_event()
+        event["changed_files"] = ["MERGLBOT_AI_DATA_WORKFLOW_POLICY.md"]
+
+        receipt = evaluate_final_merge_readiness(event, MANIFEST)
+
+        self.assertEqual(receipt["decision"], DECISION_BLOCK)
+        self.assertTrue(receipt["ai_data_policy_check"]["required"])
+        self.assertIn("AI data policy check is required for this PR scope.", receipt["reasons"])
+
+        event["ai_data_policy_check"] = "passed"
+        receipt = evaluate_final_merge_readiness(event, MANIFEST)
+        self.assertEqual(receipt["decision"], DECISION_ALLOW)
+
+    def test_terraform_approval_requires_plan_hash(self):
+        event = {
+            "workflow_run_id": "12345",
+            "head_sha": "abc123",
+            "workspace_phase": "core",
+            "plan_hash": "",
+            "allowed_targets": [],
+            "expected_action": "apply",
+            "policy_decision": "approved",
+            "rollback_note": "Rollback by reverting this commit and re-running apply.",
+        }
+
+        receipt = evaluate_terraform_approval(event, MANIFEST)
+
+        self.assertEqual(receipt["decision"], DECISION_BLOCK)
+        self.assertTrue(any("plan_hash" in reason or "plan hash" in reason.lower() for reason in receipt["reasons"]))
+
+    def test_terraform_approval_passes_with_exact_policy_receipt(self):
+        event = {
+            "workflow_run_id": "12345",
+            "head_sha": "abc123",
+            "workspace_phase": "clients",
+            "plan_hash": "sha256:" + ("a" * 64),
+            "allowed_targets": ["google_cloud_run_v2_job.extractor"],
+            "expected_action": "apply",
+            "policy_decision": "approved",
+            "rollback_note": "Disable scheduler and revert the PR if apply has runtime impact.",
+        }
+
+        receipt = evaluate_terraform_approval(event, MANIFEST)
+
+        self.assertEqual(receipt["decision"], DECISION_ALLOW)
+        self.assertEqual(receipt["workspace_phase"], "clients")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_final_merge_readiness.py
+++ b/tests/test_final_merge_readiness.py
@@ -128,6 +128,16 @@ class FinalMergeReadinessTest(unittest.TestCase):
         self.assertFalse(receipt["repo_scope"]["accepted"])
         self.assertIn("Repository owner is explicitly excluded by policy manifest.", receipt["reasons"])
 
+    def test_missing_repo_scope_blocks_policy_evaluation(self):
+        manifest = dict(MANIFEST)
+        manifest.pop("repo_scope")
+
+        receipt = evaluate_final_merge_readiness(base_event(), manifest)
+
+        self.assertEqual(receipt["decision"], DECISION_BLOCK)
+        self.assertFalse(receipt["repo_scope"]["accepted"])
+        self.assertIn("Repository scope is missing from policy manifest.", receipt["reasons"])
+
     def test_receipt_does_not_echo_denied_changed_file_paths(self):
         event = base_event()
         event["changed_files"] = ["config/service-account-prod.json"]

--- a/tests/test_final_merge_readiness.py
+++ b/tests/test_final_merge_readiness.py
@@ -149,15 +149,35 @@ class FinalMergeReadinessTest(unittest.TestCase):
         self.assertEqual(receipt["changed_files_summary"]["count"], 1)
         self.assertNotIn("service-account-prod.json", serialized)
 
-    def test_path_markers_normalize_separators_and_leading_slashes(self):
-        left = stable_tree_marker(["/ci-audit\\2026-05-01\\inventory.md"], "head", "base")
+    def test_path_markers_normalize_separators(self):
+        left = stable_tree_marker(["ci-audit\\2026-05-01\\inventory.md"], "head", "base")
         right = stable_tree_marker(["ci-audit/2026-05-01/inventory.md"], "head", "base")
 
         self.assertEqual(left, right)
 
     def test_glob_match_supports_recursive_patterns_on_normalized_paths(self):
         self.assertTrue(glob_match("projects/client/deep/SALES_ANALYTICS_REPORT.md", ["projects/**/*ANALYTICS*.md"]))
-        self.assertTrue(glob_match("\\docs\\policy.md", ["**/*.md"]))
+        self.assertTrue(glob_match("docs\\policy.md", ["**/*.md"]))
+
+    def test_invalid_changed_file_path_is_security_sensitive(self):
+        event = base_event()
+        event["changed_files"] = ["../docs/policy.md"]
+
+        receipt = evaluate_final_merge_readiness(event, MANIFEST)
+
+        self.assertEqual(receipt["risk_class"], "security_sensitive")
+        self.assertEqual(receipt["decision"], DECISION_HUMAN_REQUIRED)
+        self.assertIn("Invalid repository path changed.", receipt["reasons"])
+
+    def test_changed_file_count_limit_is_security_sensitive(self):
+        event = base_event()
+        event["changed_files"] = [f"docs/generated-{index}.md" for index in range(policy_engine.MAX_CHANGED_FILES + 1)]
+
+        receipt = evaluate_final_merge_readiness(event, MANIFEST)
+
+        self.assertEqual(receipt["risk_class"], "security_sensitive")
+        self.assertEqual(receipt["decision"], DECISION_HUMAN_REQUIRED)
+        self.assertIn("Changed-file evidence exceeds policy size limit.", receipt["reasons"])
 
     def test_ai_data_policy_scope_requires_policy_check(self):
         event = base_event()

--- a/tests/test_final_merge_readiness.py
+++ b/tests/test_final_merge_readiness.py
@@ -13,6 +13,8 @@ DECISION_BLOCK = policy_engine.DECISION_BLOCK
 DECISION_HUMAN_REQUIRED = policy_engine.DECISION_HUMAN_REQUIRED
 evaluate_final_merge_readiness = policy_engine.evaluate_final_merge_readiness
 evaluate_terraform_approval = policy_engine.evaluate_terraform_approval
+glob_match = policy_engine.glob_match
+stable_tree_marker = policy_engine.stable_tree_marker
 
 
 MANIFEST = {
@@ -136,6 +138,16 @@ class FinalMergeReadinessTest(unittest.TestCase):
         self.assertEqual(receipt["risk_class"], "security_sensitive")
         self.assertEqual(receipt["changed_files_summary"]["count"], 1)
         self.assertNotIn("service-account-prod.json", serialized)
+
+    def test_path_markers_normalize_separators_and_leading_slashes(self):
+        left = stable_tree_marker(["/ci-audit\\2026-05-01\\inventory.md"], "head", "base")
+        right = stable_tree_marker(["ci-audit/2026-05-01/inventory.md"], "head", "base")
+
+        self.assertEqual(left, right)
+
+    def test_glob_match_supports_recursive_patterns_on_normalized_paths(self):
+        self.assertTrue(glob_match("projects/client/deep/SALES_ANALYTICS_REPORT.md", ["projects/**/*ANALYTICS*.md"]))
+        self.assertTrue(glob_match("\\docs\\policy.md", ["**/*.md"]))
 
     def test_ai_data_policy_scope_requires_policy_check(self):
         event = base_event()


### PR DESCRIPTION
## Summary

Adds the policy-engine implementation that backs the `merglbot.final_merge_readiness` policy gate landed in PR #530. The implementation is stdlib-only Python and the workflow now pins Python 3.11 explicitly through SHA-pinned `actions/setup-python`.

Latest closeout fixes after Merglbot review:

- final merge readiness receipts no longer echo raw `changed_files`; they emit only `changed_files_summary` with count + stable digest marker
- Terraform approval receipts no longer echo raw `allowed_targets`; they emit only `allowed_targets_summary`
- `repo_scope` from `policy-manifest.json` is now fail-safe enforced against incoming repository evidence
- tests cover out-of-scope repository blocking and redaction of denied changed-file / Terraform target values
- removed stale advisory-provider metadata from the required review receipt manifest; Merglbot is the only review-bot authority
- policy-engine CI now uses explicit Python 3.11 instead of runner-default `python3`; the script docstring records the runtime contract

Files:

- `scripts/policy-engine/final_merge_readiness.py`
- `scripts/policy-engine/policy-manifest.json`
- `tests/test_final_merge_readiness.py`
- `.github/workflows/policy-engine-tests.yml`

## AI And Client Data

- AI-assisted: yes
- Client data exposure class: `internal` (policy-engine code + tests only)
- Raw client data sent to AI: **No**
- AI input mode: not applicable
- No raw event/user/session rows, click IDs, raw query strings, raw SQL, warehouse identifiers, PII, secrets, pricing/margins, or raw exports touched.

Policy dependency: `MERGLBOT_AI_DATA_WORKFLOW_POLICY.md` in `merglbot-public/docs#790` and runtime enforcement in `merglbot-core/agents-orchestrator#606`.

## Verification

- [x] `python3 -m unittest discover -s tests -p 'test_*.py'` — 9 tests pass
- [x] `actionlint .github/workflows/policy-engine-tests.yml`
- [x] `git diff --check`
- [ ] Policy Engine Tests workflow rerun on current head
- [ ] Final Merge Readiness rerun after Merglbot approval
- [ ] Merglbot PR Assistant approves current head

## Workstream

`ai-data-safety-policy-2026-05:github-policy-engine` (F05 of the AI Data Safety Policy Flow Program).
