### PR TITLE
chore: temporary PR Assistant v5 audit canary 20260610T075110Z

### DIFF
--- a/docs/merglbot-v5-product-readiness-canary-20260610T075110Z.md
+++ b/docs/merglbot-v5-product-readiness-canary-20260610T075110Z.md
@@ -1,0 +1,6 @@
+# PR Assistant v5 product-readiness canary
+
+Created at: `20260610T075110Z`
+Repository: `merglbot-core/github`
+
+Replacement target for prior existing PR #611 because existing same-head reruns may suppress PR comments. This temporary docs-only marker verifies current production v5 comment receipt publishing.


### PR DESCRIPTION
Temporary replacement canary for V5RCB fresh 45/45 audit. Prior existing PR #611 is not used for final comment-receipt acceptance because same-head reruns may suppress PR comments. This PR is docs-only, not intended for merge, and will be closed after v5 receipt capture.