### PR TITLE
[codex] Admit Proteinaco GMC feed enhancer to PR Assistant manifest

### DIFF
--- a/scripts/pr-assistant/repo-policy-manifest.json
+++ b/scripts/pr-assistant/repo-policy-manifest.json
@@ -492,6 +492,18 @@
       "notes": ""
     },
     {
+      "repo": "merglbot-proteinaco/proteinaco-gmc-feed-enhancer",
+      "enabled": true,
+      "rollout_tier": "client",
+      "admission_state": "baseline_only",
+      "human_merge_only": true,
+      "review_owner_policy": "hard_gate",
+      "deploy_mode": "copy_target",
+      "expected_workflow": ".github/workflows/merglbot-pr-v3-on-demand.yml",
+      "expected_step1": "scripts/pr-assistant/pr-assistant-step1-parallel-api-calls.sh",
+      "notes": "New Proteinaco GMC feed migration repo; bootstrap PR installs repo-local PR Assistant workflow before runtime implementation."
+    },
+    {
       "repo": "merglbot-proteinaco/proteinaco-web",
       "enabled": true,
       "rollout_tier": "client",

--- a/scripts/pr-assistant/target-repos.txt
+++ b/scripts/pr-assistant/target-repos.txt
@@ -59,6 +59,8 @@ merglbot-proteinaco/btf-viz
 # NOTE: No active PR Assistant review owner in the 2026-05-31 rollout audit; keep out of required-check scope until ownership is deployed.
 merglbot-proteinaco/cac-crc-exporter
 merglbot-proteinaco/proteinaco-forecast-exporter
+# NOTE: New Proteinaco GMC feed migration repo; bootstrap PR installs repo-local PR Assistant workflow before runtime implementation.
+merglbot-proteinaco/proteinaco-gmc-feed-enhancer
 merglbot-proteinaco/proteinaco-web
 merglbot-proteinaco/viz-api
 


### PR DESCRIPTION
## Summary

- Adds `merglbot-proteinaco/proteinaco-gmc-feed-enhancer` to `scripts/pr-assistant/repo-policy-manifest.json`.
- Refreshes `scripts/pr-assistant/target-repos.txt` with the canonical sync command.
- Keeps admission at `baseline_only`, `human_merge_only=true`, and `review_owner_policy=hard_gate`.

## Tracking

- Runtime repo epic: https://github.com/merglbot-proteinaco/proteinaco-gmc-feed-enhancer/issues/1
- Bootstrap PR: https://github.com/merglbot-proteinaco/proteinaco-gmc-feed-enhancer/pull/17
- Docs SSOT PR: https://github.com/merglbot-public/docs/pull/959

## Verification

- [x] `jq empty scripts/pr-assistant/repo-policy-manifest.json`
- [x] `python3 scripts/pr-assistant/repo-policy-manifest.py sync-target-repos --write`
- [x] `python3 scripts/pr-assistant/repo-policy-manifest.py verify-manifest`
- [x] `git diff --check`

## Boundary

This PR only updates PR Assistant manifest/compatibility metadata. It does not deploy, merge, enable v4 command ownership, mutate GCP, or run Terraform.
