### PR TITLE
chore(v5pbf): high-risk negative canary

### DIFF
--- a/.github/workflows/v5pbf-negative-control-canary.yml
+++ b/.github/workflows/v5pbf-negative-control-canary.yml
@@ -1,0 +1,14 @@
+name: V5PBF Negative Control Canary
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  explain:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain negative control
+        run: echo "Temporary workflow-file canary for PR Assistant v5 high-risk fail-closed validation."


### PR DESCRIPTION
Validation-only V5PBF negative-control canary. Do not merge.

Purpose:
- Verify a workflow-file high-risk change fails closed and is not treated as a safe low-risk fallback.
- Expected: exact high-risk/security/workflow blocker, no false green.

Cleanup: close this PR and delete branch after evidence capture.

Evidence artifact root: /tmp/v5pbf-immediate-audit-20260613T131011Z