### PR TITLE
ci(canary): V5SHS high-risk negative control

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -327,3 +327,5 @@ jobs:
           curl -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             -d "$PAYLOAD"
+
+# V5SHS high-risk negative-control canary marker (temporary; removed in cleanup)


### PR DESCRIPTION
Temporary HIGH-RISK negative-control canary (touches .github/workflows) to confirm unsafe lanes fail closed on the new runtime. Will be closed and branch deleted during V5SHS08 cleanup. No real workflow logic change (comment marker only).