### PR TITLE
feat(governance): enforce v5 PR Assistant as required check (IaC)

### DIFF
--- a/.github/workflows/v5-required-check-sync.yml
+++ b/.github/workflows/v5-required-check-sync.yml
@@ -1,0 +1,74 @@
+name: v5 Required Check Sync (Merglbot PR Assistant v5)
+
+# Ensures "Merglbot PR Assistant v5" is a required status check across the
+# App-installed orgs, ADDITIVELY + IDEMPOTENTLY (existing checks + enforce_admins
+# preserved). Cron runs in DRY-RUN and fails on drift (a repo with branch
+# protection but missing v5 = a new repo to cover); dispatch with apply=true to
+# enforce. Repos without branch protection are skipped (not force-created).
+# Merglevsky-cz + lrtch are intentionally excluded until the App is installed
+# (a required check the App never runs would hard-block all merges there).
+
+on:
+  schedule:
+    - cron: "30 7 * * 1"  # weekly Monday 07:30 UTC
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Apply (enforce) instead of dry-run drift report."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v5-required-check-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync v5 required check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout merglbot-core/github (self)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Sync / detect drift for the v5 required check
+        env:
+          # Enterprise token with administration:write across the App-installed
+          # orgs (branch-protection PUT requires admin). Same secret the ENT
+          # governance workflows use.
+          GH_TOKEN: ${{ secrets.ENTERPRISE_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          orgs=(
+            merglbot-core merglbot-public merglbot-denatura merglbot-shared
+            merglbot-proteinaco merglbot-ruzovyslon merglbot-milan-private
+            merglbot-extractors merglbot-autodoplnky merglbot-hodinarstvibechyne
+            merglbot-kiteboarding merglbot-cerano
+          )
+          args=()
+          for o in "${orgs[@]}"; do args+=(--org "$o"); done
+          chmod +x scripts/governance/apply-v5-required-check.sh
+          if [ "${{ inputs.apply }}" = "true" ]; then
+            scripts/governance/apply-v5-required-check.sh "${args[@]}" --apply --yes | tee /tmp/v5sync.log
+          else
+            scripts/governance/apply-v5-required-check.sh "${args[@]}" --dry-run | tee /tmp/v5sync.log
+          fi
+
+      - name: Fail on drift (dry-run only)
+        if: ${{ github.event_name == 'schedule' || inputs.apply != true }}
+        run: |
+          set -euo pipefail
+          missing="$(grep -c 'WOULD-ADD' /tmp/v5sync.log || true)"
+          nobp="$(grep -c 'SKIP ' /tmp/v5sync.log || true)"
+          echo "Repos with branch protection but missing v5: ${missing:-0}"
+          echo "Repos without branch protection (cannot enforce v5): ${nobp:-0}"
+          if [ "${missing:-0}" -gt 0 ]; then
+            echo "::error::${missing} repo(s) require the v5 check but do not have it — re-run with apply=true (or let the next cron apply)."
+            exit 1
+          fi

--- a/.github/workflows/v5-required-check-sync.yml
+++ b/.github/workflows/v5-required-check-sync.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Preflight runtime prerequisites (gh, jq)
+        run: |
+          set -euo pipefail
+          command -v gh >/dev/null || { echo "::error::gh not found on runner"; exit 1; }
+          command -v jq >/dev/null || { echo "::error::jq not found on runner"; exit 1; }
+          echo "gh:  $(gh --version | head -1)"
+          echo "jq:  $(jq --version)"
+
       - name: Sync / detect drift for the v5 required check
         env:
           # Enterprise token with administration:write across the App-installed

--- a/scripts/governance/apply-v5-required-check.sh
+++ b/scripts/governance/apply-v5-required-check.sh
@@ -114,21 +114,23 @@ for full in "${repos[@]}"; do
     [ -z "$branch" ] && { err "${full}: cannot resolve default branch"; count_fail=$((count_fail+1)); continue; }
   fi
 
-  # Read existing protection. Distinguish a genuine 404 (no branch protection →
-  # safe to skip) from permission / rate-limit / transient API errors (fail
-  # CLOSED — never silently skip a repo we could not read, which would leave the
-  # v5 gate unenforced). gh prints the error body to stdout, so we inspect the
-  # exit code + the stderr detail, not emptiness.
-  prot_err="$(mktemp)"
-  if prot="$(gh api "repos/${full}/branches/${branch}/protection" 2>"$prot_err")"; then
-    rm -f "$prot_err"
-  else
-    detail="$(tr '\n' ' ' < "$prot_err" 2>/dev/null)"; rm -f "$prot_err"
-    if printf '%s' "$detail" | grep -qiE "HTTP 404|Not Found|Branch not protected"; then
-      log "SKIP ${full}:${branch} (no branch protection — 404; not weakened, just absent)"
-      count_skip_nobp=$((count_skip_nobp+1)); continue
-    fi
-    err "${full}:${branch}: branch-protection read FAILED (not 404 — permission/API error; failing closed): ${detail}"
+  # Classify branch protection by the EXPLICIT `.protected` boolean on the branch
+  # object — never by text-matching an API error message (which a locale change,
+  # rate-limit, or transient/auth error could spoof into a false "absent"). A
+  # failure to READ the branch is a real error and fails CLOSED (never a silent
+  # skip that would leave the v5 gate unenforced).
+  if ! protected="$(gh api "repos/${full}/branches/${branch}" --jq '.protected' 2>/dev/null)"; then
+    err "${full}:${branch}: branch read FAILED (missing/permission/API — failing closed, not skipped)"
+    count_fail=$((count_fail+1)); continue
+  fi
+  if [ "$protected" != "true" ]; then
+    log "SKIP ${full}:${branch} (branch protection absent: .protected=${protected}; not weakened, just absent)"
+    count_skip_nobp=$((count_skip_nobp+1)); continue
+  fi
+  # Protected → read the full protection config (succeeds for a protected branch;
+  # a failure here is also a real error and fails closed).
+  if ! prot="$(gh api "repos/${full}/branches/${branch}/protection" 2>/dev/null)"; then
+    err "${full}:${branch}: protected=true but protection read FAILED (failing closed)"
     count_fail=$((count_fail+1)); continue
   fi
 

--- a/scripts/governance/apply-v5-required-check.sh
+++ b/scripts/governance/apply-v5-required-check.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Purpose: Ensure "Merglbot PR Assistant v5" is a REQUIRED status check on each
+# target repo's default branch — ADDITIVELY (all existing required checks are
+# preserved) and IDEMPOTENTLY (repos that already require it are skipped).
+#
+# Design:
+#   - Wraps the canonical scripts/governance/update-branch-protection.sh, which
+#     preserves every other protection setting (PR reviews, restrictions, …) and
+#     NEVER changes enforce_admins. We compute the full desired context set
+#     (existing ∪ v5) and pass it through, because the setter REPLACES the
+#     context list with the provided --check values.
+#   - Repos WITHOUT branch protection are skipped and logged (a 404 means
+#     "no branch protection configured", NOT "weak" — never force-create one here).
+#   - Archived/fork repos are excluded.
+#
+# Usage:
+#   apply-v5-required-check.sh [--org ORG]... [--repo ORG/REPO]... [--branch B] [--dry-run]
+#   apply-v5-required-check.sh [--org ORG]... [--repo ORG/REPO]... --apply --yes
+#
+# Default mode is dry-run. --apply requires --yes.
+set -euo pipefail
+
+V5_CHECK="Merglbot PR Assistant v5"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETTER="${SCRIPT_DIR}/update-branch-protection.sh"
+
+APPLY=false
+ASSUME_YES=false
+SPECIFIC_BRANCH=""
+TARGET_ORGS=()
+TARGET_REPOS=()
+
+log()  { printf '%s %s\n' "[$(date +'%Y-%m-%d %H:%M:%S')]" "$*"; }
+warn() { printf '%s %s\n' "[$(date +'%Y-%m-%d %H:%M:%S')] [WARN]" "$*" >&2; }
+err()  { printf '%s %s\n' "[$(date +'%Y-%m-%d %H:%M:%S')] [ERROR]" "$*" >&2; }
+
+usage() {
+  cat <<'EOF'
+Ensure "Merglbot PR Assistant v5" is a required status check across the fleet,
+additively and idempotently, preserving all other branch-protection settings.
+
+Usage:
+  apply-v5-required-check.sh [--org ORG]... [--repo ORG/REPO]... [--branch B] [--dry-run]
+  apply-v5-required-check.sh [--org ORG]... [--repo ORG/REPO]... --apply --yes
+
+Options:
+  --org ORG        Target all non-archived, non-fork repos in an org (repeatable).
+  --repo ORG/REPO  Target a specific repo (repeatable).
+  --branch BRANCH  Branch to protect. Default: each repo's default branch.
+  --apply          Apply changes (default is dry-run). Requires --yes.
+  --yes            Confirm --apply.
+  -h, --help       Show help.
+
+Notes:
+  - Repos without existing branch protection are SKIPPED (logged), never created.
+  - enforce_admins is never modified (owner break-glass preserved).
+  - The exact check context is "Merglbot PR Assistant v5" (byte-for-byte the name
+    the gate publishes).
+EOF
+}
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { err "Missing dependency: $1"; exit 1; }; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --org)    [ -z "${2:-}" ] && { err "Missing arg for $1"; exit 2; }; TARGET_ORGS+=("$2"); shift 2;;
+    --repo)   [ -z "${2:-}" ] && { err "Missing arg for $1"; exit 2; }; TARGET_REPOS+=("$2"); shift 2;;
+    --branch) [ -z "${2:-}" ] && { err "Missing arg for $1"; exit 2; }; SPECIFIC_BRANCH="$2"; shift 2;;
+    --apply)  APPLY=true; shift;;
+    --yes)    ASSUME_YES=true; shift;;
+    --dry-run) APPLY=false; shift;;
+    -h|--help) usage; exit 0;;
+    *) err "Unknown argument: $1"; usage; exit 2;;
+  esac
+done
+
+need_cmd gh; need_cmd jq
+[ -x "$SETTER" ] || { err "Setter not found/executable: $SETTER"; exit 1; }
+
+if [ "${#TARGET_ORGS[@]}" -eq 0 ] && [ "${#TARGET_REPOS[@]}" -eq 0 ]; then
+  err "Specify at least one --org or --repo target"; usage; exit 2
+fi
+if [ "$APPLY" = true ] && [ "$ASSUME_YES" != true ]; then
+  err "--apply requires --yes"; exit 2
+fi
+
+# Resolve the target repo set (non-archived, non-fork).
+declare -a repos=()
+if [ "${#TARGET_REPOS[@]}" -gt 0 ]; then repos+=("${TARGET_REPOS[@]}"); fi
+for org in "${TARGET_ORGS[@]:-}"; do
+  [ -z "$org" ] && continue
+  json="$(gh repo list "$org" --limit 1000 --json name,isArchived,isFork)"
+  if [ "$(printf '%s' "$json" | jq 'length')" -ge 1000 ]; then
+    err "${org}: gh repo list hit 1000-limit; narrow scope (results may be truncated)"; exit 2
+  fi
+  while IFS= read -r name; do [ -n "$name" ] && repos+=("${org}/${name}"); done < <(
+    printf '%s' "$json" | jq -r '.[] | select(.isArchived==false) | select(.isFork==false) | .name'
+  )
+done
+
+# Dedup.
+declare -a uniq=()
+while IFS= read -r r; do [ -n "$r" ] && uniq+=("$r"); done < <(printf '%s\n' "${repos[@]}" | awk 'NF' | sort -u)
+repos=("${uniq[@]}")
+
+mode="DRY-RUN"; [ "$APPLY" = true ] && mode="APPLY"
+log "Mode=${mode} | targets=${#repos[@]} | check='${V5_CHECK}'"
+
+count_ok=0 count_added=0 count_skip_nobp=0 count_fail=0
+for full in "${repos[@]}"; do
+  branch="$SPECIFIC_BRANCH"
+  if [ -z "$branch" ]; then
+    branch="$(gh api "repos/${full}" --jq '.default_branch' 2>/dev/null || true)"
+    [ -z "$branch" ] && { err "${full}: cannot resolve default branch"; count_fail=$((count_fail+1)); continue; }
+  fi
+
+  # Detect "no branch protection" by EXIT CODE: gh api prints the 404 error body
+  # to stdout, so an emptiness check is unreliable.
+  if ! prot="$(gh api "repos/${full}/branches/${branch}/protection" 2>/dev/null)"; then
+    log "SKIP ${full}:${branch} (no branch protection — 404; not weakened, just absent)"
+    count_skip_nobp=$((count_skip_nobp+1)); continue
+  fi
+
+  # Existing contexts (new 'contexts' array OR legacy 'checks[].context').
+  mapfile -t existing < <(printf '%s' "$prot" | jq -r '
+    (.required_status_checks.contexts // []) as $c
+    | (if ($c|length)>0 then $c else [ .required_status_checks.checks[]?.context // empty ] end)[]')
+
+  for c in "${existing[@]:-}"; do
+    if [ "$c" = "$V5_CHECK" ]; then
+      log "OK   ${full}:${branch} (already requires v5)"; count_ok=$((count_ok+1)); continue 2
+    fi
+  done
+
+  # Build the full desired set = existing ∪ v5, passed to the canonical setter.
+  setter_args=(--repo "$full" --branch "$branch")
+  for c in "${existing[@]:-}"; do [ -n "$c" ] && setter_args+=(--check "$c"); done
+  setter_args+=(--check "$V5_CHECK")
+
+  if [ "$APPLY" = true ]; then
+    if "$SETTER" "${setter_args[@]}" --apply --yes >/dev/null; then
+      log "ADDED ${full}:${branch} (v5 now required; ${#existing[@]} existing preserved)"; count_added=$((count_added+1))
+    else
+      err "${full}:${branch}: setter failed"; count_fail=$((count_fail+1))
+    fi
+  else
+    if "$SETTER" "${setter_args[@]}" --dry-run >/dev/null; then
+      log "WOULD-ADD ${full}:${branch} (existing=${#existing[@]} + v5)"; count_added=$((count_added+1))
+    else
+      err "${full}:${branch}: setter dry-run failed"; count_fail=$((count_fail+1))
+    fi
+  fi
+done
+
+log "Summary: already=${count_ok} ${mode}-add=${count_added} skip-no-bp=${count_skip_nobp} fail=${count_fail}"
+[ "$count_fail" -eq 0 ] || exit 1

--- a/scripts/governance/apply-v5-required-check.sh
+++ b/scripts/governance/apply-v5-required-check.sh
@@ -114,11 +114,22 @@ for full in "${repos[@]}"; do
     [ -z "$branch" ] && { err "${full}: cannot resolve default branch"; count_fail=$((count_fail+1)); continue; }
   fi
 
-  # Detect "no branch protection" by EXIT CODE: gh api prints the 404 error body
-  # to stdout, so an emptiness check is unreliable.
-  if ! prot="$(gh api "repos/${full}/branches/${branch}/protection" 2>/dev/null)"; then
-    log "SKIP ${full}:${branch} (no branch protection — 404; not weakened, just absent)"
-    count_skip_nobp=$((count_skip_nobp+1)); continue
+  # Read existing protection. Distinguish a genuine 404 (no branch protection →
+  # safe to skip) from permission / rate-limit / transient API errors (fail
+  # CLOSED — never silently skip a repo we could not read, which would leave the
+  # v5 gate unenforced). gh prints the error body to stdout, so we inspect the
+  # exit code + the stderr detail, not emptiness.
+  prot_err="$(mktemp)"
+  if prot="$(gh api "repos/${full}/branches/${branch}/protection" 2>"$prot_err")"; then
+    rm -f "$prot_err"
+  else
+    detail="$(tr '\n' ' ' < "$prot_err" 2>/dev/null)"; rm -f "$prot_err"
+    if printf '%s' "$detail" | grep -qiE "HTTP 404|Not Found|Branch not protected"; then
+      log "SKIP ${full}:${branch} (no branch protection — 404; not weakened, just absent)"
+      count_skip_nobp=$((count_skip_nobp+1)); continue
+    fi
+    err "${full}:${branch}: branch-protection read FAILED (not 404 — permission/API error; failing closed): ${detail}"
+    count_fail=$((count_fail+1)); continue
   fi
 
   # Existing contexts (new 'contexts' array OR legacy 'checks[].context').

--- a/scripts/governance/v5-required-check-runbook.md
+++ b/scripts/governance/v5-required-check-runbook.md
@@ -1,0 +1,57 @@
+# Runbook: v5 Required-Check enforcement
+
+Enforces `Merglbot PR Assistant v5` as a required status check across the
+App-installed orgs, via `apply-v5-required-check.sh` (wrapping the canonical
+`update-branch-protection.sh`) and the `v5-required-check-sync.yml` workflow.
+
+## Who may apply
+- **Dry-run / drift report**: anyone with read; runs on the weekly cron and fails
+  if any protected repo is missing v5.
+- **`--apply` (mutation)**: only via `workflow_dispatch` with `apply=true`, which
+  requires write/dispatch on `merglbot-core/github`, OR a maintainer running the
+  script locally with an admin-scoped token. Bulk branch-protection changes are
+  **never** automatic — the cron path is dry-run only.
+
+## Token / IAM
+- Uses `secrets.ENTERPRISE_GITHUB_TOKEN` (the same enterprise token the other ENT
+  governance workflows use). It needs `administration:write` on the target orgs
+  (branch-protection PUT). Store in repo/org secrets only; rotate per the ENT
+  secret-rotation policy; never echo the value (names only).
+- Blast radius is high (cross-org branch protection) — prefer scoping a future
+  `environment:` with required reviewers on the apply path.
+
+## What it does / preserves
+- Computes `existing required checks ∪ "Merglbot PR Assistant v5"` per repo, so it
+  is **additive** and **idempotent** (repos already requiring v5 are skipped).
+- The setter preserves every other setting: `enforce_admins`, required reviews,
+  restrictions, bypass allowances, and all other required status checks. Verified
+  live on `merglbot-extractors/ga4-extractor` (enforce_admins=true preserved; the
+  3 existing checks kept, v5 appended).
+- Repos with **no branch protection** (`.protected=false`) are skipped (logged) —
+  never force-created. A failure to *read* a branch fails CLOSED (counted, non-zero
+  exit), never a silent skip.
+- `Merglevsky-cz` + `lrtch` are excluded until the App is installed there.
+
+## Dry-run
+```
+scripts/governance/apply-v5-required-check.sh --org merglbot-core --dry-run
+```
+Reports `WOULD-ADD` (protected repo missing v5), `OK` (already), `SKIP` (no BP).
+
+## Apply
+```
+scripts/governance/apply-v5-required-check.sh --org merglbot-core --apply --yes
+```
+or dispatch `v5-required-check-sync.yml` with `apply=true`.
+
+## Rollback
+A wrongly-added context can be removed by re-running `update-branch-protection.sh`
+for the repo with the desired `--check` set **excluding** v5 (it replaces the
+context list). For an `enforce_admins=true` repo where v5 is wedging a merge, use
+the owner break-glass (temporary `enforce_admins=false` → merge → restore), never a
+permanent protection weakening.
+
+## Audit
+`apply-v5-required-check.sh` prints a per-repo `ADDED/OK/SKIP/ERROR` line and a
+summary; the setter writes before/after/diff artifacts under
+`tmp/agent/branch-protection/<date>/<ts>/` (gitignored).


### PR DESCRIPTION
Adds IaC to enforce `Merglbot PR Assistant v5` as a required status check fleet-wide (additive, idempotent, enforce_admins preserved, no-BP repos skipped). Already applied live to the 4 gap repos; 45 already had it. Excludes Merglevsky-cz/lrtch until App install (P2). See commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)