### PR TITLE
feat(governance): v6 required-check sync workflow + apply script

### DIFF
--- a/.github/workflows/v6-required-check-sync.yml
+++ b/.github/workflows/v6-required-check-sync.yml
@@ -1,0 +1,82 @@
+name: v6 Required Check Sync (Merglbot PR Assistant v6)
+
+# Ensures "Merglbot PR Assistant v6" is a required status check across the
+# App-installed orgs, ADDITIVELY + IDEMPOTENTLY (existing checks + enforce_admins
+# preserved). Cron runs in DRY-RUN and fails on drift (a repo with branch
+# protection but missing v6 = a new repo to cover); dispatch with apply=true to
+# enforce. Repos without branch protection are skipped (not force-created).
+# Merglevsky-cz + lrtch are intentionally excluded until the App is installed
+# (a required check the App never runs would hard-block all merges there).
+
+on:
+  schedule:
+    - cron: "30 7 * * 1"  # weekly Monday 07:30 UTC
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Apply (enforce) instead of dry-run drift report."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v6-required-check-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync v6 required check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout merglbot-core/github (self)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Preflight runtime prerequisites (gh, jq)
+        run: |
+          set -euo pipefail
+          command -v gh >/dev/null || { echo "::error::gh not found on runner"; exit 1; }
+          command -v jq >/dev/null || { echo "::error::jq not found on runner"; exit 1; }
+          echo "gh:  $(gh --version | head -1)"
+          echo "jq:  $(jq --version)"
+
+      - name: Sync / detect drift for the v6 required check
+        env:
+          # Enterprise token with administration:write across the App-installed
+          # orgs (branch-protection PUT requires admin). Same secret the ENT
+          # governance workflows use.
+          GH_TOKEN: ${{ secrets.ENTERPRISE_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          orgs=(
+            merglbot-core merglbot-public merglbot-denatura merglbot-shared
+            merglbot-proteinaco merglbot-ruzovyslon merglbot-milan-private
+            merglbot-extractors merglbot-autodoplnky merglbot-hodinarstvibechyne
+            merglbot-kiteboarding merglbot-cerano
+          )
+          args=()
+          for o in "${orgs[@]}"; do args+=(--org "$o"); done
+          chmod +x scripts/governance/apply-v6-required-check.sh
+          if [ "${{ inputs.apply }}" = "true" ]; then
+            scripts/governance/apply-v6-required-check.sh "${args[@]}" --apply --yes | tee /tmp/v6sync.log
+          else
+            scripts/governance/apply-v6-required-check.sh "${args[@]}" --dry-run | tee /tmp/v6sync.log
+          fi
+
+      - name: Fail on drift (dry-run only)
+        if: ${{ github.event_name == 'schedule' || inputs.apply != true }}
+        run: |
+          set -euo pipefail
+          missing="$(grep -c 'WOULD-ADD' /tmp/v6sync.log || true)"
+          nobp="$(grep -c 'SKIP ' /tmp/v6sync.log || true)"
+          echo "Repos with branch protection but missing v6: ${missing:-0}"
+          echo "Repos without branch protection (cannot enforce v6): ${nobp:-0}"
+          if [ "${missing:-0}" -gt 0 ]; then
+            echo "::error::${missing} repo(s) require the v6 check but do not have it — re-run with apply=true (or let the next cron apply)."
+            exit 1
+          fi

--- a/scripts/governance/apply-v6-required-check.sh
+++ b/scripts/governance/apply-v6-required-check.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Purpose: Ensure "Merglbot PR Assistant v6" is a REQUIRED status check on each
+# target repo's default branch — ADDITIVELY (all existing required checks are
+# preserved) and IDEMPOTENTLY (repos that already require it are skipped).
+#
+# Design:
+#   - Wraps the canonical scripts/governance/update-branch-protection.sh, which
+#     preserves every other protection setting (PR reviews, restrictions, …) and
+#     NEVER changes enforce_admins. We compute the full desired context set
+#     (existing ∪ v5) and pass it through, because the setter REPLACES the
+#     context list with the provided --check values.
+#   - Repos WITHOUT branch protection are skipped and logged (a 404 means
+#     "no branch protection configured", NOT "weak" — never force-create one here).
+#   - Archived/fork repos are excluded.
+#
+# Usage:
+#   apply-v5-required-check.sh [--org ORG]... [--repo ORG/REPO]... [--branch B] [--dry-run]
+#   apply-v5-required-check.sh [--org ORG]... [--repo ORG/REPO]... --apply --yes
+#
+# Default mode is dry-run. --apply requires --yes.
+set -euo pipefail
+
+V6_CHECK="Merglbot PR Assistant v6"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETTER="${SCRIPT_DIR}/update-branch-protection.sh"
+
+APPLY=false
+ASSUME_YES=false
+SPECIFIC_BRANCH=""
+TARGET_ORGS=()
+TARGET_REPOS=()
+
+log()  { printf '%s %s\n' "[$(date +'%Y-%m-%d %H:%M:%S')]" "$*"; }
+warn() { printf '%s %s\n' "[$(date +'%Y-%m-%d %H:%M:%S')] [WARN]" "$*" >&2; }
+err()  { printf '%s %s\n' "[$(date +'%Y-%m-%d %H:%M:%S')] [ERROR]" "$*" >&2; }
+
+usage() {
+  cat <<'EOF'
+Ensure "Merglbot PR Assistant v6" is a required status check across the fleet,
+additively and idempotently, preserving all other branch-protection settings.
+
+Usage:
+  apply-v5-required-check.sh [--org ORG]... [--repo ORG/REPO]... [--branch B] [--dry-run]
+  apply-v5-required-check.sh [--org ORG]... [--repo ORG/REPO]... --apply --yes
+
+Options:
+  --org ORG        Target all non-archived, non-fork repos in an org (repeatable).
+  --repo ORG/REPO  Target a specific repo (repeatable).
+  --branch BRANCH  Branch to protect. Default: each repo's default branch.
+  --apply          Apply changes (default is dry-run). Requires --yes.
+  --yes            Confirm --apply.
+  -h, --help       Show help.
+
+Notes:
+  - Repos without existing branch protection are SKIPPED (logged), never created.
+  - enforce_admins is never modified (owner break-glass preserved).
+  - The exact check context is "Merglbot PR Assistant v6" (byte-for-byte the name
+    the gate publishes).
+EOF
+}
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { err "Missing dependency: $1"; exit 1; }; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --org)    [ -z "${2:-}" ] && { err "Missing arg for $1"; exit 2; }; TARGET_ORGS+=("$2"); shift 2;;
+    --repo)   [ -z "${2:-}" ] && { err "Missing arg for $1"; exit 2; }; TARGET_REPOS+=("$2"); shift 2;;
+    --branch) [ -z "${2:-}" ] && { err "Missing arg for $1"; exit 2; }; SPECIFIC_BRANCH="$2"; shift 2;;
+    --apply)  APPLY=true; shift;;
+    --yes)    ASSUME_YES=true; shift;;
+    --dry-run) APPLY=false; shift;;
+    -h|--help) usage; exit 0;;
+    *) err "Unknown argument: $1"; usage; exit 2;;
+  esac
+done
+
+need_cmd gh; need_cmd jq
+[ -x "$SETTER" ] || { err "Setter not found/executable: $SETTER"; exit 1; }
+
+if [ "${#TARGET_ORGS[@]}" -eq 0 ] && [ "${#TARGET_REPOS[@]}" -eq 0 ]; then
+  err "Specify at least one --org or --repo target"; usage; exit 2
+fi
+if [ "$APPLY" = true ] && [ "$ASSUME_YES" != true ]; then
+  err "--apply requires --yes"; exit 2
+fi
+
+# Resolve the target repo set (non-archived, non-fork).
+declare -a repos=()
+if [ "${#TARGET_REPOS[@]}" -gt 0 ]; then repos+=("${TARGET_REPOS[@]}"); fi
+for org in "${TARGET_ORGS[@]:-}"; do
+  [ -z "$org" ] && continue
+  json="$(gh repo list "$org" --limit 1000 --json name,isArchived,isFork)"
+  if [ "$(printf '%s' "$json" | jq 'length')" -ge 1000 ]; then
+    err "${org}: gh repo list hit 1000-limit; narrow scope (results may be truncated)"; exit 2
+  fi
+  while IFS= read -r name; do [ -n "$name" ] && repos+=("${org}/${name}"); done < <(
+    printf '%s' "$json" | jq -r '.[] | select(.isArchived==false) | select(.isFork==false) | .name'
+  )
+done
+
+# Dedup.
+declare -a uniq=()
+while IFS= read -r r; do [ -n "$r" ] && uniq+=("$r"); done < <(printf '%s\n' "${repos[@]}" | awk 'NF' | sort -u)
+repos=("${uniq[@]}")
+
+mode="DRY-RUN"; [ "$APPLY" = true ] && mode="APPLY"
+log "Mode=${mode} | targets=${#repos[@]} | check='${V6_CHECK}'"
+
+count_ok=0 count_added=0 count_skip_nobp=0 count_fail=0
+for full in "${repos[@]}"; do
+  branch="$SPECIFIC_BRANCH"
+  if [ -z "$branch" ]; then
+    branch="$(gh api "repos/${full}" --jq '.default_branch' 2>/dev/null || true)"
+    [ -z "$branch" ] && { err "${full}: cannot resolve default branch"; count_fail=$((count_fail+1)); continue; }
+  fi
+
+  # Classify branch protection by the EXPLICIT `.protected` boolean on the branch
+  # object — never by text-matching an API error message (which a locale change,
+  # rate-limit, or transient/auth error could spoof into a false "absent"). A
+  # failure to READ the branch is a real error and fails CLOSED (never a silent
+  # skip that would leave the v6 gate unenforced).
+  if ! protected="$(gh api "repos/${full}/branches/${branch}" --jq '.protected' 2>/dev/null)"; then
+    err "${full}:${branch}: branch read FAILED (missing/permission/API — failing closed, not skipped)"
+    count_fail=$((count_fail+1)); continue
+  fi
+  if [ "$protected" != "true" ]; then
+    log "SKIP ${full}:${branch} (branch protection absent: .protected=${protected}; not weakened, just absent)"
+    count_skip_nobp=$((count_skip_nobp+1)); continue
+  fi
+  # Protected → read the full protection config (succeeds for a protected branch;
+  # a failure here is also a real error and fails closed).
+  if ! prot="$(gh api "repos/${full}/branches/${branch}/protection" 2>/dev/null)"; then
+    err "${full}:${branch}: protected=true but protection read FAILED (failing closed)"
+    count_fail=$((count_fail+1)); continue
+  fi
+
+  # Existing contexts (new 'contexts' array OR legacy 'checks[].context').
+  mapfile -t existing < <(printf '%s' "$prot" | jq -r '
+    (.required_status_checks.contexts // []) as $c
+    | (if ($c|length)>0 then $c else [ .required_status_checks.checks[]?.context // empty ] end)[]')
+
+  for c in "${existing[@]:-}"; do
+    if [ "$c" = "$V6_CHECK" ]; then
+      log "OK   ${full}:${branch} (already requires v5)"; count_ok=$((count_ok+1)); continue 2
+    fi
+  done
+
+  # Build the full desired set = existing ∪ v5, passed to the canonical setter.
+  setter_args=(--repo "$full" --branch "$branch")
+  for c in "${existing[@]:-}"; do [ -n "$c" ] && setter_args+=(--check "$c"); done
+  setter_args+=(--check "$V6_CHECK")
+
+  if [ "$APPLY" = true ]; then
+    if "$SETTER" "${setter_args[@]}" --apply --yes >/dev/null; then
+      log "ADDED ${full}:${branch} (v5 now required; ${#existing[@]} existing preserved)"; count_added=$((count_added+1))
+    else
+      err "${full}:${branch}: setter failed"; count_fail=$((count_fail+1))
+    fi
+  else
+    if "$SETTER" "${setter_args[@]}" --dry-run >/dev/null; then
+      log "WOULD-ADD ${full}:${branch} (existing=${#existing[@]} + v5)"; count_added=$((count_added+1))
+    else
+      err "${full}:${branch}: setter dry-run failed"; count_fail=$((count_fail+1))
+    fi
+  fi
+done
+
+log "Summary: already=${count_ok} ${mode}-add=${count_added} skip-no-bp=${count_skip_nobp} fail=${count_fail}"
+[ "$count_fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Adds the v6 counterpart to `scripts/governance/apply-v5-required-check.sh` and `.github/workflows/v5-required-check-sync.yml` so that `Merglbot PR Assistant v6` can become a required status check additively across the fleet, mirroring the v5 plumbing exactly.

## Cutover plan

- **This PR** lands the v6 workflow + script (no functional fleet impact; the workflow is dry-run on cron + workflow_dispatch with `apply=false` default, same as v5).
- **Owner** runs the swap to require v6 instead of v5 across the fleet.
- **Follow-up** drops the v5 workflow + script once v6 is the canonical required check across all in-scope repos.

The v5 workflow + script remain in place for safety during cutover; once v6 is universal, a follow-up PR removes them.

## Scope + merge guidance

Sensitive scope (`governance`): touches the fleet-wide required-check baseline. Per the platform autonomy contract this PR requires owner sign-off.

## Test plan

- [ ] Owner reviews the diff
- [ ] CI green
- [ ] Owner merges
- [ ] Owner runs `bash /tmp/swap-v5-to-v6-required-check.sh --apply --yes` (or the equivalent IaC) to flip BP fleet-wide
- [ ] Agent switches gate traffic to v6 revisions
- [ ] Once stable, follow-up PR drops v5 workflow + script