### PR TITLE
ci(governance): retarget required-check sync from v5 to v6 (U1 W2/W3)

### DIFF
--- a/.github/workflows/v5-required-check-sync.yml
+++ b/.github/workflows/v5-required-check-sync.yml
@@ -1,9 +1,9 @@
-name: v5 Required Check Sync (Merglbot PR Assistant v5)
+name: v6 Required Check Sync (Merglbot PR Assistant v6)
 
-# Ensures "Merglbot PR Assistant v5" is a required status check across the
+# Ensures "Merglbot PR Assistant v6" is a required status check across the
 # App-installed orgs, ADDITIVELY + IDEMPOTENTLY (existing checks + enforce_admins
 # preserved). Cron runs in DRY-RUN and fails on drift (a repo with branch
-# protection but missing v5 = a new repo to cover); dispatch with apply=true to
+# protection but missing v6 = a new repo to cover); dispatch with apply=true to
 # enforce. Repos without branch protection are skipped (not force-created).
 # Merglevsky-cz + lrtch are intentionally excluded until the App is installed
 # (a required check the App never runs would hard-block all merges there).
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   sync:
-    name: Sync v5 required check
+    name: Sync v6 required check
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -45,7 +45,7 @@ jobs:
           echo "gh:  $(gh --version | head -1)"
           echo "jq:  $(jq --version)"
 
-      - name: Sync / detect drift for the v5 required check
+      - name: Sync / detect drift for the v6 required check
         env:
           # Enterprise token with administration:write across the App-installed
           # orgs (branch-protection PUT requires admin). Same secret the ENT
@@ -63,20 +63,20 @@ jobs:
           for o in "${orgs[@]}"; do args+=(--org "$o"); done
           chmod +x scripts/governance/apply-v5-required-check.sh
           if [ "${{ inputs.apply }}" = "true" ]; then
-            scripts/governance/apply-v5-required-check.sh "${args[@]}" --apply --yes | tee /tmp/v5sync.log
+            scripts/governance/apply-v5-required-check.sh "${args[@]}" --apply --yes | tee /tmp/v6sync.log
           else
-            scripts/governance/apply-v5-required-check.sh "${args[@]}" --dry-run | tee /tmp/v5sync.log
+            scripts/governance/apply-v5-required-check.sh "${args[@]}" --dry-run | tee /tmp/v6sync.log
           fi
 
       - name: Fail on drift (dry-run only)
         if: ${{ github.event_name == 'schedule' || inputs.apply != true }}
         run: |
           set -euo pipefail
-          missing="$(grep -c 'WOULD-ADD' /tmp/v5sync.log || true)"
-          nobp="$(grep -c 'SKIP ' /tmp/v5sync.log || true)"
-          echo "Repos with branch protection but missing v5: ${missing:-0}"
-          echo "Repos without branch protection (cannot enforce v5): ${nobp:-0}"
+          missing="$(grep -c 'WOULD-ADD' /tmp/v6sync.log || true)"
+          nobp="$(grep -c 'SKIP ' /tmp/v6sync.log || true)"
+          echo "Repos with branch protection but missing v6: ${missing:-0}"
+          echo "Repos without branch protection (cannot enforce v6): ${nobp:-0}"
           if [ "${missing:-0}" -gt 0 ]; then
-            echo "::error::${missing} repo(s) require the v5 check but do not have it — re-run with apply=true (or let the next cron apply)."
+            echo "::error::${missing} repo(s) require the v6 check but do not have it — re-run with apply=true (or let the next cron apply)."
             exit 1
           fi

--- a/scripts/governance/apply-v5-required-check.sh
+++ b/scripts/governance/apply-v5-required-check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Purpose: Ensure "Merglbot PR Assistant v5" is a REQUIRED status check on each
+# Purpose: Ensure "Merglbot PR Assistant v6" is a REQUIRED status check on each
 # target repo's default branch — ADDITIVELY (all existing required checks are
 # preserved) and IDEMPOTENTLY (repos that already require it are skipped).
 #
@@ -20,7 +20,7 @@
 # Default mode is dry-run. --apply requires --yes.
 set -euo pipefail
 
-V5_CHECK="Merglbot PR Assistant v5"
+V6_CHECK="Merglbot PR Assistant v6"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SETTER="${SCRIPT_DIR}/update-branch-protection.sh"
 
@@ -36,7 +36,7 @@ err()  { printf '%s %s\n' "[$(date +'%Y-%m-%d %H:%M:%S')] [ERROR]" "$*" >&2; }
 
 usage() {
   cat <<'EOF'
-Ensure "Merglbot PR Assistant v5" is a required status check across the fleet,
+Ensure "Merglbot PR Assistant v6" is a required status check across the fleet,
 additively and idempotently, preserving all other branch-protection settings.
 
 Usage:
@@ -54,7 +54,7 @@ Options:
 Notes:
   - Repos without existing branch protection are SKIPPED (logged), never created.
   - enforce_admins is never modified (owner break-glass preserved).
-  - The exact check context is "Merglbot PR Assistant v5" (byte-for-byte the name
+  - The exact check context is "Merglbot PR Assistant v6" (byte-for-byte the name
     the gate publishes).
 EOF
 }
@@ -104,7 +104,7 @@ while IFS= read -r r; do [ -n "$r" ] && uniq+=("$r"); done < <(printf '%s\n' "${
 repos=("${uniq[@]}")
 
 mode="DRY-RUN"; [ "$APPLY" = true ] && mode="APPLY"
-log "Mode=${mode} | targets=${#repos[@]} | check='${V5_CHECK}'"
+log "Mode=${mode} | targets=${#repos[@]} | check='${V6_CHECK}'"
 
 count_ok=0 count_added=0 count_skip_nobp=0 count_fail=0
 for full in "${repos[@]}"; do
@@ -140,7 +140,7 @@ for full in "${repos[@]}"; do
     | (if ($c|length)>0 then $c else [ .required_status_checks.checks[]?.context // empty ] end)[]')
 
   for c in "${existing[@]:-}"; do
-    if [ "$c" = "$V5_CHECK" ]; then
+    if [ "$c" = "$V6_CHECK" ]; then
       log "OK   ${full}:${branch} (already requires v5)"; count_ok=$((count_ok+1)); continue 2
     fi
   done
@@ -148,7 +148,7 @@ for full in "${repos[@]}"; do
   # Build the full desired set = existing ∪ v5, passed to the canonical setter.
   setter_args=(--repo "$full" --branch "$branch")
   for c in "${existing[@]:-}"; do [ -n "$c" ] && setter_args+=(--check "$c"); done
-  setter_args+=(--check "$V5_CHECK")
+  setter_args+=(--check "$V6_CHECK")
 
   if [ "$APPLY" = true ]; then
     if "$SETTER" "${setter_args[@]}" --apply --yes >/dev/null; then


### PR DESCRIPTION
## Účel (Úklid 2026 — U1 W2→W3, u1.2/u1.3)

Fleet gate je od cutoveru **Merglbot PR Assistant v6**, ale týdenní drift guard `v5-required-check-sync.yml` stále synchronizuje retired v5 kontext → failuje na každém runu (poslední 2026-06-29).

Změny (32 řádků, žádné file renames — cosmetic rename tracked v U1 ledgeru):
- `.github/workflows/v5-required-check-sync.yml`: check kontext + názvy/komentáře v5→v6
- `scripts/governance/apply-v5-required-check.sh`: `V5_CHECK`→`V6_CHECK` = "Merglbot PR Assistant v6"

Guard po merge poslouží W3 branch-protection paritě (dispatch `apply=true` = aditivní + idempotentní enforce v6 required checku fleet-wide; enforce_admins i existující checks zachovány, repos bez BP se přeskakují).

Program: [GITHUB_CONSOLIDATION_PROGRAM.md](https://github.com/merglbot-public/docs/blob/main/projects/GITHUB_CONSOLIDATION_PROGRAM.md) · board u1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)