### PR TITLE
fix(length-check): waive title/body budget for dependabot PRs

### DIFF
--- a/.github/workflows/length-check.yml
+++ b/.github/workflows/length-check.yml
@@ -16,8 +16,18 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
           BODY: ${{ github.event.pull_request.body }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
+          # Dependabot PR bodies are machine-generated changelogs and routinely
+          # exceed the human-PR body budget; the check made every dependabot PR
+          # permanently UNSTABLE (non-required failure), so the CLEAN-only
+          # merge-babysitter could never merge an approved cohort (2026-07-06).
+          # Waive length limits for dependabot; humans keep the budget.
+          if [ "$AUTHOR" = "dependabot[bot]" ]; then
+            echo "✅ dependabot PR — machine-generated body, length check waived"
+            exit 0
+          fi
           max_title=100
           max_body=4000
           [ ${#TITLE} -le $max_title ] || { echo "❌ PR title too long (${#TITLE} > $max_title)"; exit 1; }


### PR DESCRIPTION
Dependabot PR bodies are machine-generated changelogs and routinely exceed the 4000-char budget → every dependabot PR is permanently **UNSTABLE** (non-required `length-check` failure), so the CLEAN-only merge-babysitter can never merge a v6-approved cohort (hit live 2026-07-06 on the workflow sweep: 24 approved PRs needed a manual owner-authorized bulk merge).

Fix: waive the length limits when `user.login == dependabot[bot]` (author passed via env — no expression injection; same pattern as TITLE/BODY). Human PRs keep the existing budget.

Rollout note: consumer repos pin this reusable workflow by SHA — after merge, dependabot's own workflow-pin bumps will roll it out (workflow-authority gate applies per policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)