### PR TITLE
ci: align codeql-action autobuild+analyze to v4.36.3 (fix estate-wide CodeQL skew)

### DIFF
--- a/.github/workflows/reusable-codeql-analysis.yml
+++ b/.github/workflows/reusable-codeql-analysis.yml
@@ -42,9 +42,9 @@ jobs:
         token: ${{ env.CODEQL_AUTH_TOKEN }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
+      uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
       with:
         token: ${{ env.CODEQL_AUTH_TOKEN }}


### PR DESCRIPTION
## Root cause

Dependabot **#684** bumped `github/codeql-action/init` `4.35.1` → `4.36.3` but left `autobuild` + `analyze` pinned at `4.35.1`, creating a version skew in this reusable workflow.

The CodeQL Action writes a config file tagged with the `init` version and reads it back during `analyze`. The mismatch fails every run with:

```
##[error]... Loaded a configuration file for version '4.36.3', but running version '4.35.1'
CodeQL job status was configuration error.
```

## Blast radius

`codeql / Analyze (actions)` is a **required** status check. This skew makes it RED on the **default branch of every repo that consumes this reusable workflow** (e.g. `merglbot-public/docs` — verified failing on `main` @ 2026-07-06T21:12), so those repos cannot merge any PR until this is fixed.

## Fix

`init`/`autobuild`/`analyze` are all paths inside the single `github/codeql-action` repo and must share one commit per release. This pins all three to `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a` (`v4.36.3`), matching `init`. Two-line change, no behavior change beyond removing the skew.

After merge, consuming repos re-pin this reusable workflow to the new hub SHA (Dependabot will do so per-repo; the docs re-pin is being fast-tracked to unblock docs#1055).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
