### PR TITLE
ci: scope final-merge-readiness self-test to evaluator paths

### DIFF
--- a/.github/workflows/final-merge-readiness.yml
+++ b/.github/workflows/final-merge-readiness.yml
@@ -3,6 +3,16 @@ name: Final Merge Readiness
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    # Self-test scope: this repo hosts the evaluator source; the readiness
+    # check is NOT a required check here (required = ci + Merglbot PR
+    # Assistant v6). Run it only when the evaluator surface changes to stop
+    # paying ~17 billed min on every unrelated PR sync (incl. Dependabot
+    # bursts). Repos where the gate is the real closeout surface (the two
+    # acquisition-analysis repos) have their own workflow copies - unaffected.
+    paths:
+      - 'scripts/pr-assistant/final-merge-readiness.py'
+      - '.github/policies/final-merge-readiness.json'
+      - '.github/workflows/final-merge-readiness.yml'
 
 permissions:
   actions: read


### PR DESCRIPTION
## Co

Přidává `paths:` filtr na `pull_request` trigger workflow `final-merge-readiness.yml` — self-test poběží jen při změně evaluator povrchu (`scripts/pr-assistant/final-merge-readiness.py`, `.github/policies/final-merge-readiness.json`, workflow sám).

## Proč

- V tomto repu je workflow **jen self-test evaluátoru** — check **není required** (required na main = `ci` + `Merglbot PR Assistant v6`) a ~89 % runů končí červeně, zatímco PRy se normálně mergují.
- Každý run = ~17 billed minut (sleep-poll smyčka až 24×30 s), ~1 060 min/týden na PRech, kterých se evaluator vůbec netýká (vč. Dependabot bursts).
- Úspora **~2 500 billed min/měsíc**; self-test zůstává přesně tam, kde má signál.

## Co se NEmění

- 2 acquisition-analysis repa, kde je Final Merge Readiness reálný closeout gate, mají **vlastní kopie workflow** — tímto PR nedotčené.
- Evaluator, policy i chování checku při změně evaluator souborů — beze změny.

## Evidence (živě 2026-07-07)

- Branch protection main → required: `ci`, `Merglbot PR Assistant v6` (FMR není)
- 61 runs/týden, ~17,4 min/run, 89 % failure (Actions billing analýza, TIER A safe, verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
