### PR TITLE
ci: advisory docs-governance check

### DIFF
--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -1,0 +1,11 @@
+name: docs-governance
+on:
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  docs-governance:
+    uses: merglbot-core/github/.github/workflows/reusable-docs-governance.yml@5722b4d6af20631726641ef758f988cc39c6c706
+    with:
+      mode: advisory


### PR DESCRIPTION
Adds the estate-wide **advisory** docs-governance check (never fails builds — warnings only). Reusable workflow: `merglbot-core/github/reusable-docs-governance.yml@5722b4d6af20631726641ef758f988cc39c6c706`. Evidence routes: same-PR markdown / `MERGLBOT_DOCS_SYNC: merglbot-public/docs#<pr>` / `docs-impact: none` label + reason. Flip to enforce follows after 1–2 weeks clean soak (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)