### PR TITLE
fix(ent-dependabot): trigger v6 review via @merglbot review comment (not retired v3 dispatch)

### DIFF
--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -31,6 +31,9 @@ MERGLBOT_REVIEW_WORKFLOW_NAME = "Merglbot PR Assistant v3 (On-Demand Multi-Model
 # v6 (the local worker fleet) is comment-triggered; the retired v3 workflow_dispatch workflow
 # above no longer exists in enrolled repos. This is the canonical trigger the fleet listens for.
 MERGLBOT_REVIEW_TRIGGER_COMMENT = os.environ.get("ENT_DEPENDABOT_REVIEW_TRIGGER_COMMENT", "@merglbot review")
+# The gate ignores bot/app-authored trigger comments (anti-loop floor); only flip this to true
+# when the job posts comments with an owner-attributed credential the gate trusts.
+MERGLBOT_REVIEW_TRIGGER_TRUSTED = os.environ.get("ENT_DEPENDABOT_REVIEW_TRIGGER_TRUSTED", "false").strip().lower() in {"1", "true", "yes"}
 OWNER_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 REPOSITORY_RE = re.compile(r"\[`([^`]+/[^`]+)`\]\(https://github.com/[^)]+\).*\|\s*Active\s*\|")
 MERGLBOT_REVIEW_WAIT_SECONDS = int(os.environ.get("ENT_DEPENDABOT_REVIEW_WAIT_SECONDS", "1500"))
@@ -1737,6 +1740,11 @@ def latest_merglbot_dispatch_run(repo: str, workflow_id: int | str, head_ref: st
 
 
 def classify_merglbot_trigger_error(message: str) -> str:
+    if "review_trigger_unavailable_app_author" in message:
+        # Not an error: the gate ignores app-authored trigger comments (anti-loop floor), so the
+        # closeout waits for the trusted review producers (auto-fire on open/sync, local keeper)
+        # instead of pretending it dispatched one.
+        return "review_pending_trusted_trigger:app_author_untrusted"
     if "403" in message or "Resource not accessible" in message:
         return "app_capability:issue_comment_write_missing_or_denied"
     return f"merglbot_review_comment_failed:{message}"
@@ -1747,9 +1755,23 @@ def trigger_merglbot_review(repo: str, number: int, head_ref: str, head_sha: str
     # which is triggered by a `@merglbot review` comment (and auto-fires on PR open/sync). The old
     # dispatch path raised merglbot_review_workflow_missing in every enrolled repo (the v3 workflow
     # is retired), which surfaced as repo_enrollment:merglbot_workflow_dispatch_missing and blocked
-    # the whole closeout. Post the canonical trigger comment instead; the fleet reviews the current
-    # head and publishes the check-run/receipt that verify_merglbot() reads in wait_for_merglbot()'s
-    # poll loop. Merge safety is unchanged — the closeout still only merges on an approved receipt.
+    # the whole closeout.
+    #
+    # TRIGGER TRUST CONTRACT: the gate webhook accepts `@merglbot review` only from human
+    # OWNER/MEMBER/COLLABORATOR senders and rejects every bot/app author (anti-loop floor in
+    # merglbot-core/platform services/pr_assistant_app/api — `bot_sender`). This closeout
+    # authenticates as a GitHub App, so a comment it posts is IGNORED by the gate. Posting it
+    # anyway and polling would silently burn the whole MERGLBOT_REVIEW_WAIT_SECONDS budget per PR.
+    # Therefore, by default the closeout does NOT claim a comment trigger. Reviews for dependabot
+    # PRs are produced by the trusted machine paths that already exist: the gate's auto-fire on
+    # PR open/sync (the closeout's own update-branch of BEHIND PRs lands here) and the local
+    # dependabot-keeper's owner-authored daily triggers; the weekly closeout then consumes their
+    # receipts. Set ENT_DEPENDABOT_REVIEW_TRIGGER_TRUSTED=true only when this job is wired to an
+    # owner-attributed credential (or the gate allowlists this app) — then the canonical comment
+    # trigger is posted and polled. Merge safety is unchanged either way — the closeout still only
+    # merges on an approved current-head receipt.
+    if not MERGLBOT_REVIEW_TRIGGER_TRUSTED:
+        raise GhError("review_trigger_unavailable_app_author")
     comment_url = post_comment_with_stdin(repo, number, MERGLBOT_REVIEW_TRIGGER_COMMENT)
     return {
         "method": "comment_trigger",
@@ -3298,12 +3320,14 @@ The following **2 organizations** are in ENT scope.
         ["empty diff"],
         "https://github.com/o/r/actions/runs/1",
     )
-    # comment-trigger review path (v6): trigger posts the canonical comment and reports it
+    # comment-trigger review path (v6): failure mapping + trust-contract gating
     assert classify_merglbot_trigger_error("HTTP 403: Forbidden") == "app_capability:issue_comment_write_missing_or_denied"
     assert classify_merglbot_trigger_error("Resource not accessible by integration") == "app_capability:issue_comment_write_missing_or_denied"
     assert classify_merglbot_trigger_error("boom") == "merglbot_review_comment_failed:boom"
-    global post_comment_with_stdin
+    assert classify_merglbot_trigger_error("review_trigger_unavailable_app_author") == "review_pending_trusted_trigger:app_author_untrusted"
+    global post_comment_with_stdin, MERGLBOT_REVIEW_TRIGGER_TRUSTED
     previous_post_comment = post_comment_with_stdin
+    previous_trigger_trusted = MERGLBOT_REVIEW_TRIGGER_TRUSTED
     stub_calls: list[tuple[str, int, str]] = []
 
     def _stub_post_comment(repo: str, number: int, body: str) -> str:
@@ -3312,9 +3336,20 @@ The following **2 organizations** are in ENT scope.
 
     post_comment_with_stdin = _stub_post_comment
     try:
+        # default (untrusted app author): no comment is posted, the sentinel error is raised
+        MERGLBOT_REVIEW_TRIGGER_TRUSTED = False
+        try:
+            trigger_merglbot_review("o/r", 7, "dependabot/x", "a" * 40)
+            raise AssertionError("expected GhError for untrusted app-author trigger")
+        except GhError as exc:
+            assert "review_trigger_unavailable_app_author" in str(exc)
+        assert stub_calls == []
+        # trusted credential configured: the canonical comment is posted and reported
+        MERGLBOT_REVIEW_TRIGGER_TRUSTED = True
         dispatch = trigger_merglbot_review("o/r", 7, "dependabot/x", "a" * 40)
     finally:
         post_comment_with_stdin = previous_post_comment
+        MERGLBOT_REVIEW_TRIGGER_TRUSTED = previous_trigger_trusted
     assert stub_calls == [("o/r", 7, MERGLBOT_REVIEW_TRIGGER_COMMENT)]
     assert dispatch == {
         "method": "comment_trigger",

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -1736,6 +1736,12 @@ def latest_merglbot_dispatch_run(repo: str, workflow_id: int | str, head_ref: st
     return None
 
 
+def classify_merglbot_trigger_error(message: str) -> str:
+    if "403" in message or "Resource not accessible" in message:
+        return "app_capability:issue_comment_write_missing_or_denied"
+    return f"merglbot_review_comment_failed:{message}"
+
+
 def trigger_merglbot_review(repo: str, number: int, head_ref: str, head_sha: str) -> dict[str, Any]:
     # v6 migrated PR review from the v3 `workflow_dispatch` workflow to the local worker fleet,
     # which is triggered by a `@merglbot review` comment (and auto-fires on PR open/sync). The old
@@ -1770,11 +1776,7 @@ def wait_for_merglbot(repo: str, number: int, head_ref: str, head_sha: str, *, a
     try:
         dispatch = trigger_merglbot_review(repo, number, head_ref, head_sha)
     except GhError as exc:
-        message = str(exc)
-        if "403" in message or "Resource not accessible" in message:
-            blocker = "app_capability:issue_comment_write_missing_or_denied"
-        else:
-            blocker = f"merglbot_review_comment_failed:{message}"
+        blocker = classify_merglbot_trigger_error(str(exc))
         return {
             "ok": False,
             "blockers": [blocker],
@@ -3296,6 +3298,31 @@ The following **2 organizations** are in ENT scope.
         ["empty diff"],
         "https://github.com/o/r/actions/runs/1",
     )
+    # comment-trigger review path (v6): trigger posts the canonical comment and reports it
+    assert classify_merglbot_trigger_error("HTTP 403: Forbidden") == "app_capability:issue_comment_write_missing_or_denied"
+    assert classify_merglbot_trigger_error("Resource not accessible by integration") == "app_capability:issue_comment_write_missing_or_denied"
+    assert classify_merglbot_trigger_error("boom") == "merglbot_review_comment_failed:boom"
+    global post_comment_with_stdin
+    previous_post_comment = post_comment_with_stdin
+    stub_calls: list[tuple[str, int, str]] = []
+
+    def _stub_post_comment(repo: str, number: int, body: str) -> str:
+        stub_calls.append((repo, number, body))
+        return "https://github.com/o/r/pull/7#issuecomment-1"
+
+    post_comment_with_stdin = _stub_post_comment
+    try:
+        dispatch = trigger_merglbot_review("o/r", 7, "dependabot/x", "a" * 40)
+    finally:
+        post_comment_with_stdin = previous_post_comment
+    assert stub_calls == [("o/r", 7, MERGLBOT_REVIEW_TRIGGER_COMMENT)]
+    assert dispatch == {
+        "method": "comment_trigger",
+        "trigger_comment": MERGLBOT_REVIEW_TRIGGER_COMMENT,
+        "comment_url": "https://github.com/o/r/pull/7#issuecomment-1",
+        "ref": "dependabot/x",
+        "head_sha": "a" * 40,
+    }
     print(json.dumps({"ok": True, "self_test": "passed"}))
     return 0
 

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -28,6 +28,9 @@ from urllib.request import Request, urlopen
 
 DEPENDABOT_LOGINS = {"dependabot[bot]", "app/dependabot"}
 MERGLBOT_REVIEW_WORKFLOW_NAME = "Merglbot PR Assistant v3 (On-Demand Multi-Model)"
+# v6 (the local worker fleet) is comment-triggered; the retired v3 workflow_dispatch workflow
+# above no longer exists in enrolled repos. This is the canonical trigger the fleet listens for.
+MERGLBOT_REVIEW_TRIGGER_COMMENT = os.environ.get("ENT_DEPENDABOT_REVIEW_TRIGGER_COMMENT", "@merglbot review")
 OWNER_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 REPOSITORY_RE = re.compile(r"\[`([^`]+/[^`]+)`\]\(https://github.com/[^)]+\).*\|\s*Active\s*\|")
 MERGLBOT_REVIEW_WAIT_SECONDS = int(os.environ.get("ENT_DEPENDABOT_REVIEW_WAIT_SECONDS", "1500"))
@@ -1734,32 +1737,20 @@ def latest_merglbot_dispatch_run(repo: str, workflow_id: int | str, head_ref: st
 
 
 def trigger_merglbot_review(repo: str, number: int, head_ref: str, head_sha: str) -> dict[str, Any]:
-    workflow = find_merglbot_review_workflow(repo)
-    workflow_id = workflow.get("id") or workflow.get("path")
-    if not workflow_id:
-        raise GhError("merglbot_review_workflow_id_missing")
-    payload = {
-        "ref": head_ref,
-        "inputs": merglbot_dispatch_inputs(number, head_sha),
-    }
-    endpoint = repo_endpoint(repo, f"actions/workflows/{workflow_id}/dispatches")
-    gh_api_json_with_input(endpoint, payload, method="POST")
-    run: dict[str, Any] | None = None
-    deadline = time.time() + min(MERGLBOT_REVIEW_POLL_SECONDS * 2, 120)
-    while time.time() <= deadline:
-        time.sleep(5)
-        run = latest_merglbot_dispatch_run(repo, workflow_id, head_ref, head_sha)
-        if run:
-            break
+    # v6 migrated PR review from the v3 `workflow_dispatch` workflow to the local worker fleet,
+    # which is triggered by a `@merglbot review` comment (and auto-fires on PR open/sync). The old
+    # dispatch path raised merglbot_review_workflow_missing in every enrolled repo (the v3 workflow
+    # is retired), which surfaced as repo_enrollment:merglbot_workflow_dispatch_missing and blocked
+    # the whole closeout. Post the canonical trigger comment instead; the fleet reviews the current
+    # head and publishes the check-run/receipt that verify_merglbot() reads in wait_for_merglbot()'s
+    # poll loop. Merge safety is unchanged — the closeout still only merges on an approved receipt.
+    comment_url = post_comment_with_stdin(repo, number, MERGLBOT_REVIEW_TRIGGER_COMMENT)
     return {
-        "method": "workflow_dispatch",
-        "workflow_name": workflow.get("name"),
-        "workflow_id": workflow_id,
-        "workflow_path": workflow.get("path"),
+        "method": "comment_trigger",
+        "trigger_comment": MERGLBOT_REVIEW_TRIGGER_COMMENT,
+        "comment_url": comment_url,
         "ref": head_ref,
         "head_sha": head_sha,
-        "run_url": None if not run else run.get("html_url"),
-        "run_id": None if not run else run.get("id"),
     }
 
 
@@ -1780,19 +1771,15 @@ def wait_for_merglbot(repo: str, number: int, head_ref: str, head_sha: str, *, a
         dispatch = trigger_merglbot_review(repo, number, head_ref, head_sha)
     except GhError as exc:
         message = str(exc)
-        if "merglbot_review_workflow_missing" in message:
-            blocker = "repo_enrollment:merglbot_workflow_dispatch_missing"
-        elif "workflow_dispatch" in message and "trigger" in message:
-            blocker = "repo_enrollment:merglbot_workflow_dispatch_missing"
-        elif "403" in message or "Resource not accessible" in message:
-            blocker = "app_capability:actions_write_missing_or_denied"
+        if "403" in message or "Resource not accessible" in message:
+            blocker = "app_capability:issue_comment_write_missing_or_denied"
         else:
-            blocker = f"merglbot_workflow_dispatch_failed:{message}"
+            blocker = f"merglbot_review_comment_failed:{message}"
         return {
             "ok": False,
             "blockers": [blocker],
             "dispatch": {
-                "method": "workflow_dispatch",
+                "method": "comment_trigger",
                 "ref": head_ref,
                 "head_sha": head_sha,
             },


### PR DESCRIPTION
## Problem

The ENT weekly dependabot closeout has merged **0 PRs since 2026-04-17**; blocked grew 33→270. **144 of 270** blocked PRs carry `repo_enrollment:merglbot_workflow_dispatch_missing`.

## Root cause

`trigger_merglbot_review()` dispatched a `workflow_dispatch` workflow named **`Merglbot PR Assistant v3 (On-Demand Multi-Model)`** — retired when v6 migrated to the comment-triggered local worker fleet. The dispatch raised `merglbot_review_workflow_missing` in every enrolled repo → the closeout could never obtain a fresh verdict and blocked.

## Fix (trust-contract aware)

The gate webhook **rejects bot/app-authored trigger comments** (anti-loop floor: `bot_sender` + OWNER/MEMBER/COLLABORATOR gate). Since this closeout authenticates as a GitHub App, it must not pretend a comment trigger works:

- **Default:** the closeout does NOT post a trigger. A missing current-head verdict maps to the honest blocker `review_pending_trusted_trigger:app_author_untrusted` (no wasted 25-min poll per PR). Reviews are produced by the **trusted machine paths**: gate auto-fire on PR open/sync (the closeout's own `update-branch` of BEHIND PRs lands there) and the local dependabot-keeper's owner-authored daily triggers; the weekly run then consumes their receipts and merges.
- **Opt-in:** `ENT_DEPENDABOT_REVIEW_TRIGGER_TRUSTED=true` enables posting the canonical `@merglbot review` comment once the job is wired to an owner-attributed credential the gate trusts.
- Dead v3 dispatch path removed from the trigger flow; failure mapping updated (`issue_comment_write` semantics).

## Safety

**Merge gate unchanged** — merges still require an approved current-head receipt + green required checks. `--self-test` covers the trigger trust gating (untrusted default posts nothing; trusted posts the canonical comment) and the blocker mapping.

## Validation

Post-merge: `gh workflow run ent-dependabot-weekly.yml -f mode=apply -f scope=single_repo -f repo=<owner/repo>` on a repo whose dependabot PRs already carry current-head approved receipts → confirm the `repo_enrollment` blocker is gone and approved PRs merge; PRs without receipts must surface `review_pending_trusted_trigger:app_author_untrusted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)