### PR TITLE
fix(security): pin docs-governance code to caller-pinned hub SHA (transitive supply-chain gap)

### DIFF
--- a/.github/workflows/reusable-docs-governance.yml
+++ b/.github/workflows/reusable-docs-governance.yml
@@ -26,12 +26,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-      - uses: actions/checkout@v4
+      # Pin the governance CODE + config to the SAME hub commit the caller pinned
+      # this reusable workflow to (job.workflow_sha / job.workflow_repository reflect
+      # the CALLED workflow file — unlike github.workflow_sha, which is the caller's).
+      # Without this, a consumer pinned to hub@SHA_X still executed check.mjs and
+      # ssot-map.snapshot.json from mutable hub main (transitive supply-chain gap).
+      - name: Resolve pinned hub governance ref
+        id: hubref
+        env:
+          JOB_WORKFLOW_SHA: ${{ job.workflow_sha }}
+          JOB_WORKFLOW_REPO: ${{ job.workflow_repository }}
+        run: |
+          # Fall back to the hub repo + this workflow's SHA if job.workflow_* is
+          # unavailable on this runner version, so the checkout always pins a commit.
+          repo="${JOB_WORKFLOW_REPO:-merglbot-core/github}"
+          ref="${JOB_WORKFLOW_SHA:-${GITHUB_SHA}}"
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "docs-governance code pinned to $repo@$ref"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: merglbot-core/github
+          repository: ${{ steps.hubref.outputs.repo }}
+          ref: ${{ steps.hubref.outputs.ref }}
           path: .docs-governance-hub
           sparse-checkout: |
             actions/docs-governance


### PR DESCRIPTION
## Problem (v6 CONFIRMED finding — e.g. forecast-engine#56)

`reusable-docs-governance.yml` runs a **second `actions/checkout` of `merglbot-core/github` with no `ref:`**, so it always pulls `actions/docs-governance/check.mjs` + `config/ssot-map.snapshot.json` from **mutable hub `main`**. A consumer that pins this reusable workflow to `hub@SHA_X` freezes only the workflow YAML — the governance **code it actually executes** floats on current main. That's a transitive supply-chain pinning gap.

## Fix

Pin the governance checkout to the **caller-pinned hub commit** using the `job` context:
- `repository: ${{ job.workflow_repository }}` → `merglbot-core/github`
- `ref: ${{ job.workflow_sha }}` → the exact commit the caller pinned this reusable workflow to

`job.workflow_*` reflect the **called** workflow file (unlike `github.workflow_sha`, which resolves to the *caller's* repo+commit and would fail a cross-repo checkout). A small resolve step falls back to `merglbot-core/github` + `GITHUB_SHA` if `job.workflow_*` is unpopulated on this runner version, so the checkout always pins a real commit.

Also **SHA-pin both checkouts** to `actions/checkout@9c091bb…` (v7.0.0) — this was the only hub workflow still on the unpinned `@v4` tag, which fails the `policy-validation` SHA-pin rego.

## Safety / blast radius

- **Backward compatible, zero immediate consumer breakage**: old pinned SHAs are immutable git objects (unchanged), and the fix doesn't move `actions/docs-governance/` or the config, so pre-fix pins keep resolving. All ~15 consumers call in `mode: advisory` — even a hypothetical classifier hiccup can't fail their builds.
- **No runtime/prod surface** — CI-governance workflow only.
- **Rollout**: natural — dependabot re-pins consumers to this fix SHA; keeper trusted lane auto-merges. Rollback = revert this PR.

## Validation
- YAML valid; both `uses:` are 40-hex SHA-pinned (policy-validation rego passes).
- Post-merge canary: bump the pin in `merglbot-core/forecast-engine` and confirm the docs-governance run log shows the second checkout at `ref=<this fix SHA>` and `job.workflow_sha` populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)