### PR TITLE
chore(dependabot): group merglbot-core/github reusable-workflow bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,19 @@ updates:
       prefix: "ci"
       include: "scope"
     groups:
+      merglbot-reusable-workflows:
+        # Fold all merglbot-core/github reusable-workflow SHA/major bumps into ONE
+        # PR (keeper trusted-lane eligible). No update-types = every update type.
+        patterns:
+          - "merglbot-core/github"
       # Group actions minor/patch bumps into one PR: fewer PRs means fewer
       # CI+CodeQL runs (Actions-minutes optimization, round 2). Majors stay
       # individual; the update interval is unchanged.
       actions-minor-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "merglbot-core/github"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
         # Fold all merglbot-core/github reusable-workflow SHA/major bumps into ONE
         # PR (keeper trusted-lane eligible). No update-types = every update type.
         patterns:
-          - "merglbot-core/github"
+          - "merglbot-core/github/.github/workflows/*"
       # Group actions minor/patch bumps into one PR: fewer PRs means fewer
       # CI+CodeQL runs (Actions-minutes optimization, round 2). Majors stay
       # individual; the update interval is unchanged.
@@ -20,7 +20,7 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "merglbot-core/github"
+          - "merglbot-core/github/.github/workflows/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
Groups `merglbot-core/github` reusable-workflow bumps into a single weekly PR (keeper trusted-lane eligible), instead of one PR per pinned workflow file. Third-party actions keep their existing group. Config-only, no runtime surface; transform: hub-group inserted; exclude-patterns added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)