### PR TITLE
fix(docs-governance): full-history checkout so PR merge-base resolves

### DIFF
--- a/.github/workflows/reusable-docs-governance.yml
+++ b/.github/workflows/reusable-docs-governance.yml
@@ -28,7 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 1
+          # Full history: PR runs check out a SHALLOW synthetic merge commit, so
+          # base...HEAD merge-base is unsatisfiable at depth 1 — check.mjs only
+          # deepens the BASE side and silently degrades to
+          # DOCS_GOVERNANCE_STATE: unknown (fail-open) on every consumer (#724).
+          fetch-depth: 0
       # Pin the governance CODE + config to the SAME hub commit the caller pinned
       # this reusable workflow to (job.workflow_sha / job.workflow_repository reflect
       # the CALLED workflow file — unlike github.workflow_sha, which is the caller's).


### PR DESCRIPTION
Fixes #724. PR consumer runs of `reusable-docs-governance` check out the caller's synthetic merge commit at `fetch-depth: 1` — a parentless shallow graft, so `git merge-base base...HEAD` is unsatisfiable by construction; `check.mjs` only deepens the *base* side and then degrades to `DOCS_GOVERNANCE_STATE: unknown` (fail-open, `REASON: changed_files_unavailable`) on every consumer. Evidence: run 30047259877 (`fatal: no merge base` ×2) on proteinaco-web#326.

Fix = `fetch-depth: 0` on the caller checkout (single-line + comment). Governance-code checkout (2nd, pinned via `job.workflow_sha`) untouched. Cost: full-history clone in docs-governance jobs (seconds on estate repos). Alternative (API changed-file listing in check.mjs) deliberately not taken here — bigger surface, tracked in #724 if clone cost ever bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)