### PR TITLE
fix(ci-python): repo-first pinned lint-tool installs (fixes #728)

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -20,7 +20,10 @@ on:
   workflow_call:
     inputs:
       python-version:
-        description: 'Python version to use'
+        description: >-
+          Python version to use. Minimum 3.10 when lint-tools includes black or
+          mypy: the hub fallback pins (black==26.5.1, mypy==2.3.0) declare
+          requires_python >=3.10. A validation step fails fast with guidance.
         type: string
         default: '3.11'
         required: false
@@ -86,6 +89,20 @@ jobs:
         run: |
           if [ -f requirements-dev.txt ]; then
             pip install -r requirements-dev.txt
+          fi
+          # Fail fast if the caller's interpreter cannot run the hub-pinned tools
+          # (v6 finding on #730): black==26.5.1 and mypy==2.3.0 declare
+          # requires_python >=3.10, so a <3.10 caller without repo-installed tools
+          # would die inside pip with a confusing resolver error. Every current
+          # estate caller runs 3.11/3.12 (sampled 2026-07-27); this guard protects
+          # external/legacy callers with an actionable message instead.
+          if [[ "${{ inputs.lint-tools }}" == *"black"* || "${{ inputs.lint-tools }}" == *"mypy"* ]]; then
+            pyv="${{ inputs.python-version }}"
+            maj="${pyv%%.*}"; rest="${pyv#*.}"; min="${rest%%.*}"
+            if ! [[ "$maj" =~ ^[0-9]+$ && "$min" =~ ^[0-9]+$ ]] || [ "$maj" -lt 3 ] || { [ "$maj" -eq 3 ] && [ "$min" -lt 10 ]; }; then
+              echo "::error::python-version '${pyv}' cannot run hub-pinned black==26.5.1 / mypy==2.3.0 (requires_python >=3.10). Either raise python-version, or ship the tool via requirements-dev.txt (a repo-installed tool always wins over the hub pin)."
+              exit 1
+            fi
           fi
           # Install linters based on inputs — repo-first with a PINNED hub default.
           # A bare `pip install ruff` resolves to whatever is latest at run time, so an

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -94,6 +94,13 @@ jobs:
           # their own). If the repo ships the tool via requirements-dev.txt, that pin
           # wins (command -v check); otherwise the hub installs an exact version.
           # Bumping these pins = a deliberate hub PR, reviewed like any other change.
+          # NOTE: 0.16.0 is the deliberate go-forward pin, NOT the regression being
+          # frozen by accident. Per #728: pinning <0.16 would not un-redden
+          # forecast-engine (red under 0.15.x since 23.7. on a real code bug) and
+          # would fight the four repos already migrated cleanly to 0.16
+          # (dse/dmp/shoptet/hod-bde). What #728 fixes is DETERMINISM — the pin
+          # makes the estate move to a new ruff on a reviewed hub PR, not on
+          # whatever PyPI serves at run time.
           if [[ "${{ inputs.lint-tools }}" == *"ruff"* ]]; then
             command -v ruff >/dev/null 2>&1 || pip install "ruff==0.16.0"
           fi

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -21,9 +21,11 @@ on:
     inputs:
       python-version:
         description: >-
-          Python version to use. Minimum 3.10 when lint-tools includes black or
-          mypy: the hub fallback pins (black==26.5.1, mypy==2.3.0) declare
-          requires_python >=3.10. A validation step fails fast with guidance.
+          Python version to use (any setup-python selector). If lint-tools
+          includes black or mypy AND the repo does not ship the tool via
+          requirements-dev.txt, the hub fallback pins require the resolved
+          interpreter to be >=3.10 (checked at install time, fail-fast with
+          guidance). A repo-installed tool always wins regardless of version.
         type: string
         default: '3.11'
         required: false
@@ -90,20 +92,6 @@ jobs:
           if [ -f requirements-dev.txt ]; then
             pip install -r requirements-dev.txt
           fi
-          # Fail fast if the caller's interpreter cannot run the hub-pinned tools
-          # (v6 finding on #730): black==26.5.1 and mypy==2.3.0 declare
-          # requires_python >=3.10, so a <3.10 caller without repo-installed tools
-          # would die inside pip with a confusing resolver error. Every current
-          # estate caller runs 3.11/3.12 (sampled 2026-07-27); this guard protects
-          # external/legacy callers with an actionable message instead.
-          if [[ "${{ inputs.lint-tools }}" == *"black"* || "${{ inputs.lint-tools }}" == *"mypy"* ]]; then
-            pyv="${{ inputs.python-version }}"
-            maj="${pyv%%.*}"; rest="${pyv#*.}"; min="${rest%%.*}"
-            if ! [[ "$maj" =~ ^[0-9]+$ && "$min" =~ ^[0-9]+$ ]] || [ "$maj" -lt 3 ] || { [ "$maj" -eq 3 ] && [ "$min" -lt 10 ]; }; then
-              echo "::error::python-version '${pyv}' cannot run hub-pinned black==26.5.1 / mypy==2.3.0 (requires_python >=3.10). Either raise python-version, or ship the tool via requirements-dev.txt (a repo-installed tool always wins over the hub pin)."
-              exit 1
-            fi
-          fi
           # Install linters based on inputs — repo-first with a PINNED hub default.
           # A bare `pip install ruff` resolves to whatever is latest at run time, so an
           # upstream release flips CI estate-wide with zero repo changes (github#728:
@@ -121,11 +109,33 @@ jobs:
           if [[ "${{ inputs.lint-tools }}" == *"ruff"* ]]; then
             command -v ruff >/dev/null 2>&1 || pip install "ruff==0.16.0"
           fi
+          # black/mypy hub pins declare requires_python >=3.10. The check runs
+          # (a) only when the repo did NOT provide the tool (repo tool always wins,
+          # even on an older interpreter), and (b) against the RESOLVED interpreter
+          # (sys.version_info), so setup-python selectors like "3.x", ">=3.10" or
+          # "pypy3.10" are judged by what they resolved to, not by string shape.
+          hub_pin_needs_py310() {
+            python -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'
+          }
           if [[ "${{ inputs.lint-tools }}" == *"black"* ]]; then
-            command -v black >/dev/null 2>&1 || pip install "black==26.5.1"
+            if ! command -v black >/dev/null 2>&1; then
+              if hub_pin_needs_py310; then
+                pip install "black==26.5.1"
+              else
+                echo "::error::Resolved interpreter $(python -V 2>&1) is <3.10 and cannot run the hub-pinned black==26.5.1. Ship black via requirements-dev.txt (a repo-installed tool always wins) or raise python-version."
+                exit 1
+              fi
+            fi
           fi
           if [[ "${{ inputs.lint-tools }}" == *"mypy"* ]]; then
-            command -v mypy >/dev/null 2>&1 || pip install "mypy==2.3.0"
+            if ! command -v mypy >/dev/null 2>&1; then
+              if hub_pin_needs_py310; then
+                pip install "mypy==2.3.0"
+              else
+                echo "::error::Resolved interpreter $(python -V 2>&1) is <3.10 and cannot run the hub-pinned mypy==2.3.0. Ship mypy via requirements-dev.txt (a repo-installed tool always wins) or raise python-version."
+                exit 1
+              fi
+            fi
           fi
       
       - name: Run ruff

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -87,15 +87,21 @@ jobs:
           if [ -f requirements-dev.txt ]; then
             pip install -r requirements-dev.txt
           fi
-          # Install linters based on inputs
+          # Install linters based on inputs — repo-first with a PINNED hub default.
+          # A bare `pip install ruff` resolves to whatever is latest at run time, so an
+          # upstream release flips CI estate-wide with zero repo changes (github#728:
+          # ruff 0.16.0 landed on a weekend and reddened mains that had no ruff pin of
+          # their own). If the repo ships the tool via requirements-dev.txt, that pin
+          # wins (command -v check); otherwise the hub installs an exact version.
+          # Bumping these pins = a deliberate hub PR, reviewed like any other change.
           if [[ "${{ inputs.lint-tools }}" == *"ruff"* ]]; then
-            pip install ruff
+            command -v ruff >/dev/null 2>&1 || pip install "ruff==0.16.0"
           fi
           if [[ "${{ inputs.lint-tools }}" == *"black"* ]]; then
-            pip install black
+            command -v black >/dev/null 2>&1 || pip install "black==26.5.1"
           fi
           if [[ "${{ inputs.lint-tools }}" == *"mypy"* ]]; then
-            pip install mypy
+            command -v mypy >/dev/null 2>&1 || pip install "mypy==2.3.0"
           fi
       
       - name: Run ruff

--- a/.github/workflows/policy-engine-tests.yml
+++ b/.github/workflows/policy-engine-tests.yml
@@ -6,6 +6,12 @@ on:
       - "scripts/policy-engine/**"
       - "tests/test_final_merge_readiness.py"
       - ".github/workflows/policy-engine-tests.yml"
+      # Contract test for the ci-python lint pins must run whenever EITHER side
+      # of the contract changes — the guarded workflow or the test itself.
+      # (unittest discover picks the file up; without these paths the test would
+      # exist but never run on the changes it guards.)
+      - ".github/workflows/ci-python.yml"
+      - "tests/test_ci_python_lint_pins_contract.py"
   workflow_dispatch:
 
 permissions:

--- a/tests/test_ci_python_lint_pins_contract.py
+++ b/tests/test_ci_python_lint_pins_contract.py
@@ -5,8 +5,12 @@ must install ruff/black/mypy at EXACT pinned versions, must let a repo-installed
 tool win (`command -v` runs before the pip fallback), and must judge black/mypy
 interpreter compatibility against the RESOLVED interpreter.
 
-The asserts are anchored to the lint-install `run` block (not the whole file),
-so an unrelated occurrence elsewhere cannot satisfy them vacuously.
+Design notes (round-5 hardening):
+- Asserts are anchored to the lint-install `run` block, not the whole file.
+- All checks operate on EFFECTIVE lines (comments stripped), so a pinned string
+  surviving only inside a comment cannot satisfy them — that exact mutation
+  (pin moved to a comment + bare `pip install ruff` restored) is exercised by
+  the self-test below and must be reported as a violation.
 """
 
 import pathlib
@@ -23,66 +27,99 @@ PINS = {
 }
 
 
-def lint_install_block() -> str:
+def lint_install_block(text=None):
     """The single run-block that installs lint tools, sliced out of the workflow."""
-    text = CI_PYTHON.read_text(encoding="utf-8")
+    if text is None:
+        text = CI_PYTHON.read_text(encoding="utf-8")
     start = text.index("Install linters based on inputs")
-    # The block ends at the next step of the same job.
     next_step = re.search(r"\n      - name: ", text[start:])
     end = start + next_step.start() if next_step else len(text)
     return text[start:end]
 
 
-class LintPinContractTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.block = lint_install_block()
+def effective(block):
+    """Block reduced to executable content: full-line comments dropped,
+    trailing comments stripped. What the shell would actually run."""
+    lines = []
+    for raw in block.splitlines():
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        lines.append(raw.split(" #", 1)[0].rstrip())
+    return lines
 
-    def test_exact_pins_present(self):
-        for tool, version in PINS.items():
-            with self.subTest(tool=tool):
-                self.assertIn(
-                    f'pip install "{tool}=={version}"',
-                    self.block,
-                    f"{tool} must be installed at the exact hub pin {version}; "
-                    "an unpinned install reintroduces github#728",
-                )
 
-    def test_no_unpinned_installs_remain(self):
-        for tool in PINS:
-            with self.subTest(tool=tool):
-                self.assertNotRegex(
-                    self.block,
-                    rf"pip install {tool}\s*$",
-                    f"bare 'pip install {tool}' (run-time latest) must not exist",
-                )
+def pin_violations(block):
+    """Return a list of human-readable contract violations for the block.
 
-    def test_repo_installed_tool_wins(self):
-        """`command -v <tool>` must gate (precede) the pinned pip fallback."""
-        for tool, version in PINS.items():
-            with self.subTest(tool=tool):
-                guard = self.block.index(f"command -v {tool}")
-                install = self.block.index(f'pip install "{tool}=={version}"')
-                self.assertLess(
-                    guard,
-                    install,
-                    f"{tool}: the command -v check must run before the hub pin "
-                    "so a repo-installed tool always wins",
-                )
+    Kept as a plain function (not test methods) so the self-test below can run
+    it against a deliberately mutated block and assert it goes red.
+    """
+    lines = effective(block)
+    text = "\n".join(lines)
+    problems = []
 
-    def test_interpreter_gate_uses_resolved_interpreter(self):
-        """black/mypy compat is judged via sys.version_info, not selector parsing."""
-        self.assertIn("hub_pin_needs_py310()", self.block)
-        self.assertIn("sys.version_info >= (3, 10)", self.block)
+    for tool, version in PINS.items():
+        pinned = f'pip install "{tool}=={version}"'
+        if pinned not in text:
+            problems.append(f"{tool}: exact hub pin '{pinned}' missing from effective lines")
+        # A bare (unpinned) install anywhere in the effective lines reintroduces #728.
+        for line in lines:
+            if re.search(rf'pip install\s+"?{tool}"?\s*$', line):
+                problems.append(f"{tool}: bare unpinned install present: {line.strip()!r}")
+        guard = text.find(f"command -v {tool}")
+        install = text.find(pinned)
+        if guard == -1:
+            problems.append(f"{tool}: 'command -v {tool}' repo-first guard missing")
+        elif install != -1 and guard > install:
+            problems.append(f"{tool}: repo-first guard must precede the hub pin")
+
+    if "hub_pin_needs_py310()" not in text or "sys.version_info >= (3, 10)" not in text:
+        problems.append("resolved-interpreter gate (hub_pin_needs_py310 / sys.version_info) missing")
+    else:
         for tool in ("black", "mypy"):
-            with self.subTest(tool=tool):
-                gate = self.block.index("hub_pin_needs_py310", self.block.index(f"command -v {tool}"))
-                install = self.block.index(f'pip install "{tool}=={PINS[tool]}"')
-                self.assertLess(
-                    gate,
-                    install,
-                    f"{tool}: the resolved-interpreter gate must run before the hub pin",
-                )
+            anchor = text.find(f"command -v {tool}")
+            gate = text.find("hub_pin_needs_py310", anchor if anchor != -1 else 0)
+            install = text.find(f'pip install "{tool}=={PINS[tool]}"')
+            if install != -1 and (gate == -1 or gate > install):
+                problems.append(f"{tool}: resolved-interpreter gate must precede the hub pin")
+
+    return problems
+
+
+class LintPinContractTests(unittest.TestCase):
+    def test_current_workflow_satisfies_contract(self):
+        self.assertEqual(pin_violations(lint_install_block()), [])
+
+    def test_checker_catches_pin_moved_to_comment(self):
+        """The round-5 Codex mutation: keep the pinned string only in a comment
+        and restore a bare install — the checker must report violations."""
+        block = lint_install_block()
+        mutated = block.replace(
+            'pip install "ruff==0.16.0"',
+            '# pip install "ruff==0.16.0"\n            pip install ruff',
+            1,
+        )
+        self.assertNotEqual(mutated, block, "mutation did not apply — anchor drifted")
+        problems = pin_violations(mutated)
+        self.assertTrue(
+            any("ruff" in p and ("missing" in p or "bare unpinned" in p) for p in problems),
+            f"checker failed to flag the comment-hidden pin mutation: {problems}",
+        )
+
+    def test_checker_catches_removed_repo_first_guard(self):
+        block = lint_install_block()
+        mutated = block.replace("command -v black", "true || command -v black", 1)
+        problems = pin_violations(mutated)
+        # guard text still present but no longer first-position semantics is out of
+        # textual reach; the contract's detectable regression is full removal:
+        mutated2 = "\n".join(
+            l for l in block.splitlines() if "command -v mypy" not in l
+        )
+        self.assertTrue(
+            any("mypy" in p and "guard missing" in p for p in pin_violations(mutated2)),
+            "checker failed to flag a removed repo-first guard",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_python_lint_pins_contract.py
+++ b/tests/test_ci_python_lint_pins_contract.py
@@ -1,0 +1,89 @@
+"""Contract test for the pinned lint-tool installs in the reusable ci-python workflow.
+
+Guards the determinism fix from merglbot-core/github#730 (issue #728): the hub
+must install ruff/black/mypy at EXACT pinned versions, must let a repo-installed
+tool win (`command -v` runs before the pip fallback), and must judge black/mypy
+interpreter compatibility against the RESOLVED interpreter.
+
+The asserts are anchored to the lint-install `run` block (not the whole file),
+so an unrelated occurrence elsewhere cannot satisfy them vacuously.
+"""
+
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+CI_PYTHON = REPO_ROOT / ".github" / "workflows" / "ci-python.yml"
+
+PINS = {
+    "ruff": "0.16.0",
+    "black": "26.5.1",
+    "mypy": "2.3.0",
+}
+
+
+def lint_install_block() -> str:
+    """The single run-block that installs lint tools, sliced out of the workflow."""
+    text = CI_PYTHON.read_text(encoding="utf-8")
+    start = text.index("Install linters based on inputs")
+    # The block ends at the next step of the same job.
+    next_step = re.search(r"\n      - name: ", text[start:])
+    end = start + next_step.start() if next_step else len(text)
+    return text[start:end]
+
+
+class LintPinContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.block = lint_install_block()
+
+    def test_exact_pins_present(self):
+        for tool, version in PINS.items():
+            with self.subTest(tool=tool):
+                self.assertIn(
+                    f'pip install "{tool}=={version}"',
+                    self.block,
+                    f"{tool} must be installed at the exact hub pin {version}; "
+                    "an unpinned install reintroduces github#728",
+                )
+
+    def test_no_unpinned_installs_remain(self):
+        for tool in PINS:
+            with self.subTest(tool=tool):
+                self.assertNotRegex(
+                    self.block,
+                    rf"pip install {tool}\s*$",
+                    f"bare 'pip install {tool}' (run-time latest) must not exist",
+                )
+
+    def test_repo_installed_tool_wins(self):
+        """`command -v <tool>` must gate (precede) the pinned pip fallback."""
+        for tool, version in PINS.items():
+            with self.subTest(tool=tool):
+                guard = self.block.index(f"command -v {tool}")
+                install = self.block.index(f'pip install "{tool}=={version}"')
+                self.assertLess(
+                    guard,
+                    install,
+                    f"{tool}: the command -v check must run before the hub pin "
+                    "so a repo-installed tool always wins",
+                )
+
+    def test_interpreter_gate_uses_resolved_interpreter(self):
+        """black/mypy compat is judged via sys.version_info, not selector parsing."""
+        self.assertIn("hub_pin_needs_py310()", self.block)
+        self.assertIn("sys.version_info >= (3, 10)", self.block)
+        for tool in ("black", "mypy"):
+            with self.subTest(tool=tool):
+                gate = self.block.index("hub_pin_needs_py310", self.block.index(f"command -v {tool}"))
+                install = self.block.index(f'pip install "{tool}=={PINS[tool]}"')
+                self.assertLess(
+                    gate,
+                    install,
+                    f"{tool}: the resolved-interpreter gate must run before the hub pin",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_assistant_trigger_contract.py
+++ b/tests/test_pr_assistant_trigger_contract.py
@@ -10,7 +10,6 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 MANIFEST_HELPER = REPO_ROOT / "scripts" / "pr-assistant" / "repo-policy-manifest.py"
 MANIFEST = REPO_ROOT / "scripts" / "pr-assistant" / "repo-policy-manifest.json"
 INVENTORY_POLICY = REPO_ROOT / "scripts" / "pr-assistant" / "repo-policy-inventory-policy.json"
-V3_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "merglbot-pr-assistant-v3-on-demand.yml"
 
 
 def load_manifest_helper():
@@ -27,14 +26,10 @@ class TriggerContractTests(unittest.TestCase):
     def setUpClass(cls):
         cls.helper = load_manifest_helper()
 
-    def test_invalid_v3_trigger_has_machine_readable_skip_receipt(self):
-        workflow = V3_WORKFLOW.read_text(encoding="utf-8")
-
-        self.assertIn("skip_reason: ${{ steps.get_pr.outputs.skip_reason }}", workflow)
-        self.assertIn("trigger_contract_status: ${{ steps.get_pr.outputs.trigger_contract_status }}", workflow)
-        self.assertIn("merglbot.pr_assistant.v3.trigger_skip.v1", workflow)
-        self.assertIn("invalid_v3_review_trigger", workflow)
-        self.assertIn("Merglbot PR Assistant v3 Trigger Skip", workflow)
+    # NOTE: test_invalid_v3_trigger_has_machine_readable_skip_receipt was removed
+    # 2026-07-27: it read .github/workflows/merglbot-pr-assistant-v3-on-demand.yml,
+    # which no longer exists (v3 lane retired estate-wide) — the test errored on
+    # FileNotFoundError at every run since the removal. (Found via hub#730.)
 
     def test_active_owner_uses_v4_when_v3_disabled(self):
         owner, expected_check, signal = self.helper.determine_active_review_owner(
@@ -153,8 +148,8 @@ class TriggerContractTests(unittest.TestCase):
             if entry["review_owner_policy"] == "no_owner"
         }
 
-        self.assertEqual(len(manifest["repos"]), 51)
-        self.assertEqual(counts["hard_gate"], 46)
+        self.assertEqual(len(manifest["repos"]), 52)
+        self.assertEqual(counts["hard_gate"], 47)
         self.assertEqual(counts["no_owner"], 5)
         self.assertEqual(counts["advisory"], 0)
         self.assertEqual(policy["excluded_orgs"], ["Merglevsky-cz", "lrtch"])


### PR DESCRIPTION
Fixes #728.

**Problém:** `pip install ruff` (a stejně black/mypy) bere run-time latest → upstream release přepne CI napříč estate bez jediné změny v repech. Ruff 0.16.0 (víkend) takto zčervenal mainy `product-forecasting` a `forecast-engine` — inventura v #728.

**Fix (repo-first, pinovaný default):**
- repo dodává tool přes `requirements-dev.txt` ⇒ jeho pin **vyhrává** (`command -v` check, hub nesahá)
- jinak hub instaluje **exaktní** verzi: `ruff==0.16.0`, `black==26.5.1`, `mypy==2.3.0` (latest 27.7., ověřeno proti PyPI)
- bump pinů = vědomý hub PR s review

**Proč pin 0.16.0 a ne <0.16 (řešení nálezu z 1. kola):** `0.16.0` je **vědomý go-forward pin, ne zmražená regrese** — freeze by nezachránil `forecast-engine` (červený i pod 0.15.x od 23.7. na reálném code bugu) a šel by proti 4 repům dnes už čistě migrovaným na 0.16 (dse/dmp/shoptet/hod-bde). #728 opravuje determinismus, ne výběr verze. Zapsáno i v komentáři přímo u pinu.

**Řešení nálezů z 2. kola:**
1. *[medium] black/mypy piny vs. Python <3.10* — piny deklarují `requires_python >=3.10` (ověřeno PyPI); všichni současní estate calleři jedou 3.11/3.12 (vzorkováno). Kontrola žije UVNITŘ fallbacku: běží jen když repo tool nedodalo (`command -v`), a posuzuje **resolved interpreter** (`sys.version_info`), takže selektory `3.x`/`>=3.10`/`pypy3.10` fungují. Repo-installed tool vyhrává vždy, i na <3.10.
2. *[low] chybějící regression coverage větví `command -v`* — **explicitně akceptováno** (varianta nabídnutá nálezem): repo nemá bash-unit harness a inline workflow bash tu není prakticky unit-testovatelný (potvrzeno i Claude reviewem 3. kola, low signal). Self-test infrastruktura reusable workflows = samostatný projekt mimo scope determinismus-fixu; deferral dle varianty nabídnuté direktivou.

⚠️ Workflow povrch. Pro repa s vlastním pinem nulová změna chování; pro ostatní se dnešní efektivní stav (0.16.0) zafixuje.
