### PR TITLE
fix(ent-scope): per-org App tokens + fail-closed resolver (stop weekly scope collapse)

### DIFF
--- a/.github/workflows/ent-scope-refresh.yml
+++ b/.github/workflows/ent-scope-refresh.yml
@@ -56,7 +56,12 @@ jobs:
             --jq '.content' | base64 -d > .ent-scope/ENT_ORG_ALLOWLIST.md
           echo "Fetched ENT_ORG_ALLOWLIST.md $(wc -l < .ent-scope/ENT_ORG_ALLOWLIST.md) lines"
 
-      - name: Get app token for all allowlisted orgs (read-only repos:read)
+      # This token is used ONLY for pushing the branch / opening the PR in THIS repo.
+      # It must NOT be used for cross-org repo listing: an App installation token is
+      # always scoped to a single org, so a merglbot-core token silently sees nothing
+      # in the other 11 orgs (the 2026-05..07 scope-collapse regression). The resolver
+      # below mints its own per-org installation tokens from the App key instead.
+      - name: Get app installation token for merglbot-core (push/PR in this repo)
         id: all_orgs_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
@@ -64,22 +69,32 @@ jobs:
           private-key: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
           owner: merglbot-core
 
-      - name: Resolve ENT scope via API
+      - name: Resolve ENT scope via API (per-org App installation tokens)
         id: resolve
         env:
-          GH_TOKEN: ${{ steps.all_orgs_token.outputs.token }}
+          ENT_APP_CLIENT_ID: ${{ secrets.ENT_DEPENDABOT_APP_CLIENT_ID }}
+          ENT_APP_PRIVATE_KEY: ${{ secrets.ENT_DEPENDABOT_APP_PRIVATE_KEY }}
           ALLOWLIST_FILE: ${{ github.workspace }}/.ent-scope/ENT_ORG_ALLOWLIST.md
         run: |
           set -euo pipefail
           bash scripts/ent-scope/resolve-ent-scope.sh > .ent-scope/scope.json
           repo_count=$(jq '.repo_count' .ent-scope/scope.json)
+          # Shrink guard: the committed scope is the last known-good baseline. A big
+          # shrink means a credential/visibility regression, never real estate decay —
+          # fail closed instead of opening a scope-collapsing PR (v6 caught exactly
+          # this class on the 2026-07 weekly PRs).
+          old_count=$(grep -c '^merglbot-' scripts/dependabot/ent_repository_scope.txt || echo 0)
+          if [ "$old_count" -gt 0 ] && [ $((repo_count * 10)) -lt $((old_count * 6)) ]; then
+            echo "::error ::Resolved $repo_count repos but committed baseline has $old_count (>40% shrink) — failing closed."
+            exit 1
+          fi
           echo "repo_count=$repo_count" >> "$GITHUB_OUTPUT"
           {
             echo 'scope_json<<ENDSCOPE'
             cat .ent-scope/scope.json
             echo 'ENDSCOPE'
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved $repo_count repos"
+          echo "Resolved $repo_count repos (baseline $old_count)"
 
       - name: Regenerate downstream SSOT files
         id: regen
@@ -141,6 +156,23 @@ jobs:
           name: ent-scope
           path: .ent-scope/
           retention-days: 90
+
+      - name: Close superseded weekly scope PRs (dedup)
+        if: steps.diff.outputs.drift_detected == 'true' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ steps.all_orgs_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # Each weekly run supersedes any still-open older scope PR (same generated
+          # files, staler data). Close them so skeletons never accumulate again.
+          gh pr list --repo "${{ github.repository }}" --state open \
+            --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("merglbot/ent-scope-refresh-")) | .number' \
+          | while read -r pr; do
+            gh pr close "$pr" --repo "${{ github.repository }}" \
+              --comment "Superseded by this week's ent-scope-refresh run (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}); a fresh scope PR follows. Branch kept."
+            echo "closed superseded scope PR #$pr"
+          done
 
       - name: Open PR if drift detected (not dry-run)
         if: steps.diff.outputs.drift_detected == 'true' && github.event.inputs.dry_run != 'true'

--- a/scripts/ent-scope/resolve-ent-scope.sh
+++ b/scripts/ent-scope/resolve-ent-scope.sh
@@ -6,10 +6,15 @@
 # then enumerates all non-archived, non-fork repositories in each allowed org via the
 # GitHub REST API, applies per-repo exclusions, and prints a canonical JSON scope.
 #
-# Requires:
-#   - gh CLI authenticated with a token that can `gh api /orgs/<org>/repos` for every
-#     allowlisted org. In GitHub Actions this must be the
-#     merglbot-ent-dependabot-closeout App installation token (never a PAT).
+# Auth (two modes):
+#   - App mode (CI): set ENT_APP_CLIENT_ID + ENT_APP_PRIVATE_KEY (PEM). The script mints
+#     an App JWT (openssl RS256), maps installations, and mints a PER-ORG installation
+#     token for every allowlisted org. A single installation token can NEVER span orgs —
+#     that was the 2026-05..07 regression: a merglbot-core-only token silently collapsed
+#     the scope to core repos (the /orgs/<org>/repos call returns only what the token can
+#     see, with no error).
+#   - Ambient mode (local/dev): neither env set -> uses the caller's gh auth, which must
+#     be able to `gh api /orgs/<org>/repos` for every allowlisted org.
 #
 # Outputs (stdout): one JSON object with the shape:
 #   {
@@ -21,10 +26,12 @@
 #   }
 #
 # Exit codes:
-#   0 — success
+#   0 — success (JSON on stdout)
 #   1 — missing allowlist file
 #   2 — missing org table in allowlist
-#   3 — github api error for one or more orgs (partial output still written to stdout)
+#   3 — FAIL-CLOSED: at least one allowlisted org could not be fully resolved
+#       (missing App installation, API error, or zero repos). NO JSON is written —
+#       a partial scope must never reach the SSOT files.
 set -euo pipefail
 
 ALLOWLIST_FILE="${ALLOWLIST_FILE:-}"
@@ -84,55 +91,154 @@ while IFS= read -r line; do
   fi
 done < "$ALLOWLIST_FILE"
 
-tier_for_repo() {
+# --- Working dir (per-org listings, App key) ------------------------------------
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+# --- Auth: App mode (per-org installation tokens) or ambient gh auth ------------
+APP_MODE=0
+declare -A ORG_INSTALLATION_ID=()
+_b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+if [[ -n "${ENT_APP_CLIENT_ID:-}" && -n "${ENT_APP_PRIVATE_KEY:-}" ]]; then
+  APP_MODE=1
+  key_file="$work_dir/app-key.pem"
+  (umask 077; printf '%s' "$ENT_APP_PRIVATE_KEY" > "$key_file")
+  now=$(date +%s)
+  jwt_header=$(printf '{"alg":"RS256","typ":"JWT"}' | _b64url)
+  jwt_payload=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((now - 30))" "$((now + 540))" "$ENT_APP_CLIENT_ID" | _b64url)
+  jwt_sig=$(printf '%s.%s' "$jwt_header" "$jwt_payload" | openssl dgst -sha256 -sign "$key_file" -binary | _b64url)
+  app_jwt="$jwt_header.$jwt_payload.$jwt_sig"
+  installations=$(curl -sf \
+    -H "Authorization: Bearer $app_jwt" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/app/installations?per_page=100")
+  while IFS=$'\t' read -r login inst_id; do
+    ORG_INSTALLATION_ID["$login"]="$inst_id"
+  done < <(echo "$installations" | jq -r '.[] | [.account.login, (.id | tostring)] | @tsv')
+  echo "INFO: App mode — ${#ORG_INSTALLATION_ID[@]} installations visible" >&2
+else
+  echo "INFO: ambient mode — using caller's gh auth (local/dev only)" >&2
+fi
+
+org_token() {
+  # Prints an installation access token for the org (App mode), or nothing (ambient).
   local org="$1"
-  case "$org" in
-    merglbot-milan-private) echo "personal_experimental" ;;
-    *) echo "ent_production" ;;
-  esac
+  if [[ "$APP_MODE" -eq 0 ]]; then return 0; fi
+  local inst_id="${ORG_INSTALLATION_ID[$org]:-}"
+  if [[ -z "$inst_id" ]]; then
+    return 1
+  fi
+  curl -sf -X POST \
+    -H "Authorization: Bearer $app_jwt" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/app/installations/${inst_id}/access_tokens" | jq -r '.token'
 }
 
 generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-repos_json='[]'
 any_fail=0
+fail_reasons=()
 
 for org in "${allowed_orgs[@]}"; do
-  # Fetch all repos, filter archived + fork
-  resp=$(gh api "/orgs/$org/repos?per_page=100" --paginate 2>/dev/null || true)
-  if [[ -z "$resp" || "$resp" == "null" ]]; then
-    echo "WARN: could not list repos for $org (org empty or api error)" >&2
+  # Per-org credential: a single installation token can never span orgs.
+  if [[ "$APP_MODE" -eq 1 ]]; then
+    if ! tok=$(org_token "$org") || [[ -z "$tok" || "$tok" == "null" ]]; then
+      fail_reasons+=("$org: no App installation (install merglbot-ent-dependabot-closeout on this org)")
+      any_fail=1
+      continue
+    fi
+    resp=$(GH_TOKEN="$tok" gh api "/orgs/$org/repos?per_page=100" --paginate 2>/dev/null || true)
+  else
+    resp=$(gh api "/orgs/$org/repos?per_page=100" --paginate 2>/dev/null || true)
+  fi
+  # Fail-closed contract: the listing must be a NON-EMPTY JSON array.
+  #  - `[]` means the credential sees nothing in the org (unauthorized tokens get
+  #    200+[] for private orgs — the exact 2026-05..07 silent-collapse mode), never
+  #    that the org is empty: a legitimately all-archived org still returns its
+  #    repos here and is filtered in the assembly step below.
+  #  - a non-array body is gh printing an HTTP error payload (404/403) to stdout.
+  if [[ -z "$resp" || "$resp" == "null" || "$resp" == "[]" || "$resp" != \[* ]]; then
+    fail_reasons+=("$org: repo listing empty, non-array, or api error")
     any_fail=1
     continue
   fi
-  repos_json=$(jq --argjson existing "$repos_json" --arg org "$org" --arg tier "$(tier_for_repo "$org")" --argjson excluded "$(printf '%s\n' "${excluded_repos[@]:-}" | jq -R . | jq -s .)" '
-    [. + $existing | .[] ]  # merge
-    | unique_by(.full_name // (.org + "/" + .name))
-  ' <<< "$(echo "$resp" | jq --arg org "$org" --arg tier "$(tier_for_repo "$org")" --argjson excluded "$(printf '%s\n' "${excluded_repos[@]:-}" | jq -R . | jq -s . 2>/dev/null || echo '[]')" '
-    [ .[] | select(.archived == false and .fork == false) | select((.full_name // "") as $fn | ($excluded | index($fn) | not)) |
-      { full_name: .full_name, org: $org, name: .name, tier: $tier, default_branch: .default_branch, archived: .archived, fork: .fork }
-    ]
-  ')")
+  printf '%s' "$resp" > "$work_dir/org-$org.json"
 done
 
-# Sort deterministically
-repos_json=$(echo "$repos_json" | jq 'sort_by(.full_name)')
+if [[ "$any_fail" -ne 0 ]]; then
+  echo "ERR: scope resolution FAILED CLOSED — refusing to emit a partial scope:" >&2
+  printf '  - %s\n' "${fail_reasons[@]}" >&2
+  exit 3
+fi
 
-# Build final JSON
-jq -n \
-  --arg generated_at "$generated_at" \
-  --argjson allowed "$(printf '%s\n' "${allowed_orgs[@]}" | jq -R . | jq -s .)" \
-  --argjson excluded_orgs '["Merglevsky-cz"]' \
-  --argjson excluded_repos "$(printf '%s\n' "${excluded_repos[@]:-}" | jq -R . | jq -s . 2>/dev/null || echo '[]')" \
-  --argjson repos "$repos_json" \
-  '{
-    generated_at: $generated_at,
-    allowlist_source: "merglbot-public/docs/ENT_ORG_ALLOWLIST.md",
-    allowed_orgs: $allowed,
-    excluded_orgs: $excluded_orgs,
-    excluded_repos: $excluded_repos,
-    repos: $repos,
-    repo_count: ($repos | length),
-    org_counts: ($repos | group_by(.org) | map({ (.[0].org): length }) | add)
-  }'
+# Assemble the final scope JSON deterministically (stdlib python3; replaces the
+# former nested-jq merge, whose quoting made failures untraceable).
+GENERATED_AT="$generated_at" \
+WORK_DIR="$work_dir" \
+ALLOWED_ORGS="$(printf '%s\n' "${allowed_orgs[@]}")" \
+EXCLUDED_REPOS="$(printf '%s\n' "${excluded_repos[@]:-}")" \
+python3 <<'PY'
+import json, os, sys
 
-exit "$any_fail"
+work_dir = os.environ["WORK_DIR"]
+allowed = [o for o in os.environ["ALLOWED_ORGS"].splitlines() if o]
+excluded = {r for r in os.environ["EXCLUDED_REPOS"].splitlines() if r}
+tiers = {"merglbot-milan-private": "personal_experimental"}
+
+repos = {}
+for org in allowed:
+    raw = open(os.path.join(work_dir, f"org-{org}.json")).read()
+    # `gh api --paginate` concatenates one JSON array per page; parse them all.
+    decoder = json.JSONDecoder()
+    idx, items = 0, []
+    while idx < len(raw):
+        while idx < len(raw) and raw[idx].isspace():
+            idx += 1
+        if idx >= len(raw):
+            break
+        page, end = decoder.raw_decode(raw, idx)
+        if not isinstance(page, list):
+            sys.stderr.write(f"ERR: {org}: repo listing page is not a JSON array — failing closed\n")
+            sys.exit(3)
+        items.extend(page)
+        idx = end
+    for r in items:
+        full = r.get("full_name") or f"{org}/{r.get('name')}"
+        if r.get("archived") or r.get("fork") or full in excluded:
+            continue
+        repos[full] = {
+            "full_name": full,
+            "org": org,
+            "name": r.get("name"),
+            "tier": tiers.get(org, "ent_production"),
+            "default_branch": r.get("default_branch"),
+            "archived": False,
+            "fork": False,
+        }
+
+repo_list = [repos[k] for k in sorted(repos)]
+org_counts = {}
+for r in repo_list:
+    org_counts[r["org"]] = org_counts.get(r["org"], 0) + 1
+
+json.dump(
+    {
+        "generated_at": os.environ["GENERATED_AT"],
+        "allowlist_source": "merglbot-public/docs/ENT_ORG_ALLOWLIST.md",
+        "allowed_orgs": allowed,
+        "excluded_orgs": ["Merglevsky-cz"],
+        "excluded_repos": sorted(excluded),
+        "repos": repo_list,
+        "repo_count": len(repo_list),
+        "org_counts": org_counts,
+    },
+    sys.stdout,
+    indent=2,
+    sort_keys=False,
+)
+sys.stdout.write("\n")
+PY
+
+exit 0


### PR DESCRIPTION
Diagnosed during the owner-approved estate PR-skeleton triage (2026-07-29).

**Root cause of the never-merging weekly scope PRs (#712, #731, ... since May):** the resolve step used a single **merglbot-core installation token** - an App installation token can never span orgs, and `GET /orgs/<org>/repos` returns `200 + []` for orgs the token cannot see. The weekly regen therefore silently collapsed the scope to core-only (18 repos), v6 correctly blocked every such PR, and the scope SSOT on main has been stale since 2026-05-01 (missing 29 repos of estate growth; dependabot closeout + pr-assistant targeting fly blind on them).

**Fix:**
- `resolve-ent-scope.sh`: App mode mints a JWT (openssl RS256) and a **per-org installation token** for every allowlisted org (mirrors the proven verify-step pattern); ambient `gh` auth kept for local runs. **Fail-closed:** empty/`[]`/non-array listing for any org → exit 3 with NO output. Nested-jq merge replaced by deterministic stdlib-python assembly (handles `--paginate` page concatenation).
- `ent-scope-refresh.yml`: resolve step gets App creds; core token kept only for push/PR (renamed honestly); **shrink guard** (>40% below committed baseline → fail); **dedup step** closes superseded older weekly scope PRs so skeletons never accumulate again.

**Tested locally:** ambient E2E = 73 repos / 11 orgs (merglbot-shared legitimately all-archived, matches baseline); injected nonexistent org → exit 3 + zero stdout; shellcheck + actionlint clean; healthy-regen preview vs baseline = **+29 / −1** (the −1 is archived ruzovyslon/data-pipelines) with shrink guard passing.

**Post-merge plan:** dispatch with `dry_run=true` to validate App mode E2E, then a real dispatch → first healthy scope PR (dedup auto-closes #731) → review → merge → scope current again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)