### PR TITLE
chore(ent): remove dead v3 workflow_dispatch remediation path

### DIFF
--- a/docs/ent-dependabot-autonomous-closeout.md
+++ b/docs/ent-dependabot-autonomous-closeout.md
@@ -61,11 +61,15 @@ Platform policy authority remains in `merglbot-public/docs`:
   short-lived installation tokens per repository owner and fails closed when the
   app is not installed for a target owner. `ENTERPRISE_GITHUB_TOKEN` remains only
   a legacy fallback for non-ENT/single-owner tests.
-- Missing or stale Merglbot evidence is remediated through the target repo's
-  active `Merglbot PR Assistant v3 (On-Demand Multi-Model)` workflow via
-  `workflow_dispatch` on the PR head ref with `expected_head_sha`. The legacy
-  `@merglbot review --light` comment path is not used by the ENT weekly apply
-  lane because GitHub App comments do not carry a trusted author association.
+- Missing or stale Merglbot evidence is produced by the trusted v6 machine
+  paths: the review gate's auto-fire on PR open/sync (the closeout's own
+  update-branch of BEHIND PRs lands here) and the local dependabot-keeper's
+  owner-authored `@merglbot review` triggers; the closeout then consumes their
+  receipts. The closeout itself does not post trigger comments by default —
+  it authenticates as a GitHub App and the gate ignores bot/app-authored
+  triggers (anti-loop floor). Set `ENT_DEPENDABOT_REVIEW_TRIGGER_TRUSTED=true`
+  only when the job is wired to an owner-attributed credential. (The retired
+  v3 `workflow_dispatch` remediation path was removed from the engine.)
 - When `autonomous_fix_loop=true`, current-head Merglbot `changes_required`,
   third-party review-bot blockers, and real CI failures are not treated as final closeout
   blockers in dry-run. They are classified as `WOULD_START_AUTONOMOUS_FIX_LOOP`

--- a/scripts/dependabot/ent_dependabot_closeout.py
+++ b/scripts/dependabot/ent_dependabot_closeout.py
@@ -27,9 +27,8 @@ from urllib.request import Request, urlopen
 
 
 DEPENDABOT_LOGINS = {"dependabot[bot]", "app/dependabot"}
-MERGLBOT_REVIEW_WORKFLOW_NAME = "Merglbot PR Assistant v3 (On-Demand Multi-Model)"
-# v6 (the local worker fleet) is comment-triggered; the retired v3 workflow_dispatch workflow
-# above no longer exists in enrolled repos. This is the canonical trigger the fleet listens for.
+# v6 (the local worker fleet) is comment-triggered; the retired v3 workflow_dispatch path was
+# removed. This is the canonical trigger the fleet listens for.
 MERGLBOT_REVIEW_TRIGGER_COMMENT = os.environ.get("ENT_DEPENDABOT_REVIEW_TRIGGER_COMMENT", "@merglbot review")
 # The gate ignores bot/app-authored trigger comments (anti-loop floor); only flip this to true
 # when the job posts comments with an owner-attributed credential the gate trusts.
@@ -1737,33 +1736,6 @@ def mark_fix_loop_candidate(
     receipt.evidence.append(evidence)
     receipt.evidence.append(f"max_fix_iterations={max_fix_iterations}")
     receipt.evidence.append(f"max_review_iterations={max_review_iterations}")
-
-
-def find_merglbot_review_workflow(repo: str) -> dict[str, Any]:
-    workflows = gh_api_json(repo_endpoint(repo, "actions/workflows?per_page=100"))
-    for workflow in workflows.get("workflows", []):
-        if workflow.get("name") == MERGLBOT_REVIEW_WORKFLOW_NAME and workflow.get("state") == "active":
-            return workflow
-    for workflow in workflows.get("workflows", []):
-        if workflow.get("name") == MERGLBOT_REVIEW_WORKFLOW_NAME:
-            return workflow
-    raise GhError(f"merglbot_review_workflow_missing:{MERGLBOT_REVIEW_WORKFLOW_NAME}")
-
-
-def latest_merglbot_dispatch_run(repo: str, workflow_id: int | str, head_ref: str, head_sha: str) -> dict[str, Any] | None:
-    encoded_ref = quote(head_ref, safe="")
-    runs = gh_api_json(repo_endpoint(repo, f"actions/workflows/{workflow_id}/runs?event=workflow_dispatch&branch={encoded_ref}&per_page=10"))
-    for run in runs.get("workflow_runs", []):
-        if run.get("head_sha") == head_sha:
-            return {
-                "id": run.get("id"),
-                "status": run.get("status"),
-                "conclusion": run.get("conclusion"),
-                "html_url": run.get("html_url"),
-                "head_sha": run.get("head_sha"),
-                "head_branch": run.get("head_branch"),
-            }
-    return None
 
 
 def classify_merglbot_trigger_error(message: str) -> str:


### PR DESCRIPTION
## What

Removes the **dead v3 `workflow_dispatch` remediation path** from the ENT dependabot closeout engine:

- `MERGLBOT_REVIEW_WORKFLOW_NAME` constant (the retired "Merglbot PR Assistant v3 (On-Demand Multi-Model)" name),
- `find_merglbot_review_workflow()`,
- `latest_merglbot_dispatch_run()`.

Repo-wide grep: **zero call sites** for all three symbols (the v6 `trigger_merglbot_review` path replaced them; the v3 workflow no longer exists in any enrolled repo). The only remaining reference was a stale bullet in `docs/ent-dependabot-autonomous-closeout.md` describing the removed dispatch flow as the active remediation — rewritten to the real v6 flow (gate auto-fire on PR open/sync + owner-authored keeper triggers; app-authored comments ignored by the anti-loop floor; `ENT_DEPENDABOT_REVIEW_TRIGGER_TRUSTED` opt-in unchanged).

No behavior change: the removed code was unreachable.

## Verification

Exactly as CI (`ci.yml`): `python3 -m py_compile` clean + `--self-test` → `{"ok": true, "self_test": "passed"}`. Post-removal grep of `scripts/` + `tests/`: no references remain.
