### PR TITLE
fix(agent-helpers): probe admin /healthz instead of the SPA /health route

### DIFF
--- a/scripts/agent-helpers/gcp-ops.sh
+++ b/scripts/agent-helpers/gcp-ops.sh
@@ -120,7 +120,13 @@ health_check() {
 
     local endpoints=(
         "https://www.merglbot.ai/health"
-        "https://admin.merglbot.ai/health"
+        # admin-portal: use the real backend health endpoint, not the SPA route.
+        # `/health` on admin is not an endpoint at all — it falls through to the SPA
+        # fallback and returns 200 text/html even when the backend is dead (false green),
+        # and it sits inside the static surface that merglbot-admin#688 is hardening.
+        # `/healthz` is the server-implemented JSON health check (see the admin Dockerfile
+        # HEALTHCHECK, which already probes /healthz).
+        "https://admin.merglbot.ai/healthz"
         "https://www.merglbot.ai/api/viz/denatura/health"
     )
 


### PR DESCRIPTION
## What changed

`scripts/agent-helpers/gcp-ops.sh` — the admin health probe in `health_check()` moves from `https://admin.merglbot.ai/health` to `https://admin.merglbot.ai/healthz`. One endpoint in the array; the two sibling probes are untouched.

## Why

`/health` is **not an endpoint** on `admin-portal`. It falls through to the SPA fallback (`res.sendFile(dist/index.html)`) and returns `200 text/html` no matter what the backend is doing — a pre-existing false green that only proves `dist/index.html` is on disk. `/healthz` is the real server-implemented JSON health check; the admin `Dockerfile` HEALTHCHECK already probes it.

It is also inside the static surface that merglbot-core/merglbot-admin#688 is hardening, so moving it now removes any coupling between the probe and that change.

Verified live 2026-08-08:

```
https://admin.merglbot.ai/healthz -> 200 application/json; charset=utf-8
https://admin.merglbot.ai/health  -> 200 text/html; charset=utf-8   (SPA fallback)
```

## Merge order

**This PR merges before merglbot-core/merglbot-admin#706 deploys.**

Honest framing: under the design in that PR the gate never touches `/health`, so this is **not a technical blocker**. It is sequenced first because the issue's acceptance criteria require it, it is one line with zero coupling, and it fixes a real false-green independently.

## Verification after merge

```
bash scripts/agent-helpers/gcp-ops.sh health
```
Expect all three endpoints green. `bash -n` passes; no behaviour change beyond the URL.

merge != deploy — this is a script in a helpers repo, nothing is deployed by merging it.

Refs merglbot-core/merglbot-admin#688
