### PR TITLE
fix(finops): make cost monitoring fail closed

### DIFF
--- a/.github/workflows/cost-monitoring.yml
+++ b/.github/workflows/cost-monitoring.yml
@@ -93,6 +93,10 @@ jobs:
 
       - name: AI Usage Telemetry Alerts (Budgets)
         id: ai_usage_alerts
+        # This is a separate notifier path from the main CLI. A workflow-dispatch
+        # dry run must suppress both paths; scheduled runs and normal dispatches
+        # still execute the budget alerts.
+        if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
         working-directory: platform/tools/cost-monitoring
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cost-monitoring.yml
+++ b/.github/workflows/cost-monitoring.yml
@@ -70,35 +70,26 @@ jobs:
       - name: Generate cost report
         id: generate
         working-directory: platform/tools/cost-monitoring
-        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MONITOR_MONTH: ${{ inputs.month }}
+          MONITOR_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          
-          # Build command
-          CMD="python -m cost_monitoring.cli generate --outdir reports"
-          
-          # Add month if specified
-          if [ -n "${{ inputs.month }}" ]; then
-            CMD="$CMD --month ${{ inputs.month }}"
+
+          CMD=(python -m cost_monitoring.cli generate --outdir reports --soft-fail)
+
+          if [ -n "$MONITOR_MONTH" ]; then
+            CMD+=(--month "$MONITOR_MONTH")
           fi
-          
-          # Add dry-run if specified
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            CMD="$CMD --dry-run"
+
+          if [ "$MONITOR_DRY_RUN" = "true" ]; then
+            CMD+=(--dry-run)
           fi
-          
-          # Run with soft-fail to continue even if thresholds exceeded
-          CMD="$CMD --soft-fail"
-          
-          echo "Running: $CMD"
-          EXIT=0
-          $CMD || EXIT=$?
-          
+
           echo "reports_dir=$(pwd)/reports" >> "$GITHUB_OUTPUT"
-          echo "exit_code=${EXIT}" >> "$GITHUB_OUTPUT"
+          "${CMD[@]}"
 
       - name: AI Usage Telemetry Alerts (Budgets)
         id: ai_usage_alerts
@@ -126,28 +117,28 @@ jobs:
         if: always()
         working-directory: platform/tools/cost-monitoring
         run: |
-          echo "## 💰 Cost Monitoring Report" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          
-          # Check if markdown report exists
-          MD_FILE=$(find reports -name "*.md" -type f | head -1)
-          if [ -f "$MD_FILE" ]; then
-            # Add the markdown report to summary (truncate if too long)
-            head -n 200 "$MD_FILE" >> "$GITHUB_STEP_SUMMARY"
-            
-            if [ $(wc -l < "$MD_FILE") -gt 200 ]; then
-              echo "" >> "$GITHUB_STEP_SUMMARY"
-              echo "*... Report truncated. See artifacts for full report.*" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## 💰 Cost Monitoring Report"
+            echo ""
+
+            MD_FILE=$(find reports -name "*.md" -type f | head -1)
+            if [ -f "$MD_FILE" ]; then
+              head -n 200 "$MD_FILE"
+
+              if [ "$(wc -l < "$MD_FILE")" -gt 200 ]; then
+                echo ""
+                echo "*... Report truncated. See artifacts for full report.*"
+              fi
+            else
+              echo "❌ No report generated"
             fi
-          else
-            echo "❌ No report generated" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "---" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Exit code: ${{ steps.generate.outputs.exit_code }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- AI usage alerts exit code: ${{ steps.ai_usage_alerts.outputs.exit_code }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Reports directory: ${{ steps.generate.outputs.reports_dir }}" >> "$GITHUB_STEP_SUMMARY"
+
+            echo ""
+            echo "---"
+            echo "- Generate outcome: ${{ steps.generate.outcome }}"
+            echo "- AI usage alerts exit code: ${{ steps.ai_usage_alerts.outputs.exit_code }}"
+            echo "- Reports directory: ${{ steps.generate.outputs.reports_dir }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload cost reports
         if: always()
@@ -156,9 +147,3 @@ jobs:
           name: cost-reports-${{ github.run_id }}
           path: platform/tools/cost-monitoring/reports/
           retention-days: 90
-
-      - name: Check exit code
-        if: steps.generate.outputs.exit_code != '0'
-        run: |
-          echo "⚠️ Cost monitoring detected issues (exit code: ${{ steps.generate.outputs.exit_code }})"
-          echo "Review the reports and GitHub issue for details."

--- a/platform/tools/cost-monitoring/README.md
+++ b/platform/tools/cost-monitoring/README.md
@@ -71,9 +71,10 @@ github:
 gcp:
   billing_account_id: "XXXX-XXXX-XXXX"
   billing_export:
-    project_id: "billing-project"
-    dataset: "billing_export"
+    project_id: "merglbot-platform-prd"
+    dataset: "billing_export_euw1"
     table_pattern: "gcp_billing_export_v1_*"
+    currency: "CZK"
 ```
 
 3. Configure thresholds in `config/thresholds.yml`:
@@ -85,11 +86,12 @@ github:
       max: 30
 
 gcp:
+  currency: CZK
   defaults:
-    total_monthly_usd: 1000
+    total_monthly: 23000
   projects:
     production-project:
-      total_monthly_usd: 2000
+      total_monthly: 46000
 ```
 
 ## 🔑 Authentication
@@ -110,7 +112,7 @@ For local development:
 gcloud auth application-default login
 ```
 
-For CI/CD, use Workload Identity Federation (recommended) or service account key.
+For CI/CD, use Workload Identity Federation. Service account JSON keys are not supported.
 
 ### Slack (Optional)
 Set the webhook URL:
@@ -167,12 +169,12 @@ Structured data with columns:
 - `service`: Service name
 - `metric`: Metric type
 - `value`: Numeric value
-- `currency`: USD/count
+- `currency`: source currency (`USD` for GitHub, billing-account currency for GCP) or `count`
 - `month`: Report month
 
 ### Markdown Report
 Human-readable report with:
-- Executive summary
+- Currency-separated executive summary (no invalid cross-currency grand total)
 - GitHub Enterprise breakdown
 - GCP project costs
 - Top services by cost
@@ -244,6 +246,8 @@ cost-monitoring/
 - Store secrets in GitHub Secrets or Secret Manager
 - Mask sensitive values in logs
 - Use minimal required permissions
+- Keep billing queries partition- and usage-time bounded with a 5 GiB maximum-bytes guard
+- Fail closed on missing data, query/schema errors, or mixed export currencies
 
 ## 🧪 Testing
 
@@ -311,7 +315,7 @@ MIT License - see LICENSE file for details.
 
 ## 🎯 Roadmap
 
-- [ ] Multi-currency support
+- [x] Currency-aware source reporting without cross-currency aggregation
 - [ ] Predictive cost modeling
 - [ ] Custom report templates
 - [ ] Cost optimization recommendations

--- a/platform/tools/cost-monitoring/config/settings.example.yml
+++ b/platform/tools/cost-monitoring/config/settings.example.yml
@@ -12,8 +12,9 @@ gcp:
   billing_account_id: "XXXX-XXXX-XXXX"
   billing_export:
     project_id: "merglbot-platform-prd"
-    dataset: "billing_export"
+    dataset: "billing_export_euw1"
     table_pattern: "gcp_billing_export_v1_*"
+    currency: "CZK"
   projects:
     core:
       - "merglbot-seed"

--- a/platform/tools/cost-monitoring/config/thresholds.example.yml
+++ b/platform/tools/cost-monitoring/config/thresholds.example.yml
@@ -8,21 +8,24 @@ github:
       max: 60
 
 gcp:
+  # GCP billing export values are reported in the billing-account currency.
+  # Existing sample guardrails were rebased at 23 CZK/USD; review them as policy, not as an exchange-rate feed.
+  currency: CZK
   defaults:
-    total_monthly_usd: 300
-    per_service_monthly_usd:
-      Cloud Run: 150
-      BigQuery: 150
-      Cloud Storage: 80
-      Compute Engine: 80
+    total_monthly: 6900
+    per_service_monthly:
+      Cloud Run: 3450
+      BigQuery: 3450
+      Cloud Storage: 1840
+      Compute Engine: 1840
   projects:
     mb-portal-prd:
-      total_monthly_usd: 800
-      per_service_monthly_usd:
-        Cloud Run: 500
-        BigQuery: 150
+      total_monthly: 18400
+      per_service_monthly:
+        Cloud Run: 11500
+        BigQuery: 3450
     denatura-btf-prd:
-      total_monthly_usd: 1200
-      per_service_monthly_usd:
-        BigQuery: 800
-        Cloud Run: 300
+      total_monthly: 27600
+      per_service_monthly:
+        BigQuery: 18400
+        Cloud Run: 6900

--- a/platform/tools/cost-monitoring/cost_monitoring/alerting/notifiers.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/alerting/notifiers.py
@@ -2,12 +2,12 @@
 Notification handlers for Slack and GitHub Issues.
 """
 
-import os
-import json
-import requests
-from typing import Dict, Any, List, Optional
 import logging
+import os
 from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
 
 from .thresholds import format_alert_message
 
@@ -20,179 +20,128 @@ def send_slack(webhook_url: str, markdown: str, blocks: Optional[List[Dict[str, 
         if not webhook_url or not webhook_url.startswith("https://hooks.slack.com/"):
             logger.error("Invalid Slack webhook URL format")
             return False
-        
+
         payload = {"text": markdown}
         if blocks:
             payload["blocks"] = blocks
-        
+
         response = requests.post(webhook_url, json=payload, timeout=15)
-        
+
         if response.ok:
             logger.info("Slack notification sent successfully")
             return True
         else:
             logger.error(f"Failed to send Slack notification: {response.status_code}")
             return False
-            
+
     except Exception as e:
         logger.error(f"Error sending Slack notification: {str(e)}")
         return False
 
 
 def format_slack_cost_report(
-    github_data: Dict[str, Any],
-    gcp_data: Dict[str, Any],
-    alerts: List[Dict[str, Any]],
-    month: str
+    github_data: Dict[str, Any], gcp_data: Dict[str, Any], alerts: List[Dict[str, Any]], month: str
 ) -> Dict[str, Any]:
     """Format cost report for Slack with rich blocks."""
-    
-    blocks = [
-        {
-            "type": "header",
-            "text": {
-                "type": "plain_text",
-                "text": f"💰 Cost Report - {month}",
-                "emoji": True
-            }
-        }
-    ]
-    
+
+    blocks = [{"type": "header", "text": {"type": "plain_text", "text": f"💰 Cost Report - {month}", "emoji": True}}]
+
     # Summary section
     github_total = github_data.get("total_monthly_cost_usd", 0)
-    gcp_total = gcp_data.get("total_net_usd", 0)
-    grand_total = github_total + gcp_total
-    
-    blocks.append({
-        "type": "section",
-        "fields": [
-            {
-                "type": "mrkdwn",
-                "text": f"*Total Monthly Cost:*\n${grand_total:,.2f}"
-            },
-            {
-                "type": "mrkdwn",
-                "text": f"*Alert Count:*\n{len(alerts)} ⚠️"
-            }
-        ]
-    })
-    
-    blocks.append({"type": "divider"})
-    
-    # GitHub section
-    blocks.append({
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": "*GitHub Enterprise Costs*"
+    gcp_total = gcp_data.get("total_net", 0)
+    gcp_currency = gcp_data.get("currency", "")
+
+    blocks.append(
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": f"*GitHub Cost:*\n${github_total:,.2f} USD"},
+                {"type": "mrkdwn", "text": f"*GCP Cost:*\n{gcp_total:,.2f} {gcp_currency}"},
+                {"type": "mrkdwn", "text": f"*Alert Count:*\n{len(alerts)} ⚠️"},
+            ],
         }
-    })
-    
+    )
+
+    blocks.append({"type": "divider"})
+
+    # GitHub section
+    blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "*GitHub Enterprise Costs*"}})
+
     copilot = github_data.get("copilot", {})
     ec = github_data.get("enterprise_cloud", {})
-    
+
     github_fields = [
         {
             "type": "mrkdwn",
-            "text": f"*Copilot:*\n${copilot.get('monthly_cost_usd', 0):,.2f} ({copilot.get('seats_assigned', 0)} seats)"
+            "text": (
+                f"*Copilot:*\n${copilot.get('monthly_cost_usd', 0):,.2f} " f"({copilot.get('seats_assigned', 0)} seats)"
+            ),
         },
         {
             "type": "mrkdwn",
-            "text": f"*Enterprise Cloud:*\n${ec.get('monthly_cost_usd', 0):,.2f} ({ec.get('seats', 0)} seats)"
-        }
+            "text": f"*Enterprise Cloud:*\n${ec.get('monthly_cost_usd', 0):,.2f} ({ec.get('seats', 0)} seats)",
+        },
     ]
-    
-    blocks.append({
-        "type": "section",
-        "fields": github_fields
-    })
-    
+
+    blocks.append({"type": "section", "fields": github_fields})
+
     blocks.append({"type": "divider"})
-    
+
     # GCP section
-    blocks.append({
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": "*GCP Costs*"
-        }
-    })
-    
+    blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "*GCP Costs*"}})
+
     gcp_fields = [
-        {
-            "type": "mrkdwn",
-            "text": f"*Projects Monitored:*\n{gcp_data.get('projects_monitored', 0)}"
-        },
-        {
-            "type": "mrkdwn",
-            "text": f"*Total Net Cost:*\n${gcp_data.get('total_net_usd', 0):,.2f}"
-        }
+        {"type": "mrkdwn", "text": f"*Projects Monitored:*\n{gcp_data.get('projects_monitored', 0)}"},
+        {"type": "mrkdwn", "text": f"*Total Net Cost:*\n{gcp_data.get('total_net', 0):,.2f} {gcp_currency}"},
     ]
-    
-    blocks.append({
-        "type": "section",
-        "fields": gcp_fields
-    })
-    
+
+    blocks.append({"type": "section", "fields": gcp_fields})
+
     # Alerts section if any
     if alerts:
         blocks.append({"type": "divider"})
-        blocks.append({
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "*🚨 Threshold Alerts*"
-            }
-        })
-        
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "*🚨 Threshold Alerts*"}})
+
         # Show top 5 alerts
         for alert in alerts[:5]:
             alert_text = format_alert_message(alert)
-            blocks.append({
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": alert_text
-                }
-            })
-    
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": alert_text}})
+
     # Footer
     blocks.append({"type": "divider"})
-    blocks.append({
-        "type": "context",
-        "elements": [
-            {
-                "type": "mrkdwn",
-                "text": f"Generated at {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} | View full report in GitHub Actions"
-            }
-        ]
-    })
-    
-    text = f"Cost Report {month}: Total ${grand_total:,.2f} with {len(alerts)} alerts"
-    
-    return {
-        "text": text,
-        "blocks": blocks
-    }
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"Generated at {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} | "
+                        "View full report in GitHub Actions"
+                    ),
+                }
+            ],
+        }
+    )
+
+    text = (
+        f"Cost Report {month}: GitHub ${github_total:,.2f} USD; "
+        f"GCP {gcp_total:,.2f} {gcp_currency}; {len(alerts)} alerts"
+    )
+
+    return {"text": text, "blocks": blocks}
 
 
 def send_cost_report_to_slack(
-    github_data: Dict[str, Any],
-    gcp_data: Dict[str, Any],
-    alerts: List[Dict[str, Any]],
-    month: str
+    github_data: Dict[str, Any], gcp_data: Dict[str, Any], alerts: List[Dict[str, Any]], month: str
 ) -> bool:
     """Send formatted cost report to Slack."""
-    
+
     webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
     if not webhook_url:
         logger.warning("SLACK_WEBHOOK_URL not set, skipping Slack notification")
         return False
-    
+
     formatted = format_slack_cost_report(github_data, gcp_data, alerts, month)
-    
-    return send_slack(
-        webhook_url,
-        formatted["text"],
-        formatted["blocks"]
-    )
+
+    return send_slack(webhook_url, formatted["text"], formatted["blocks"])

--- a/platform/tools/cost-monitoring/cost_monitoring/alerting/thresholds.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/alerting/thresholds.py
@@ -2,171 +2,185 @@
 Cost threshold evaluation and alerting logic.
 """
 
-from typing import Dict, Any, List, Optional
 import logging
+from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 
 
-def evaluate_github_thresholds(
-    github_data: Dict[str, Any],
-    thresholds: Dict[str, Any]
-) -> List[Dict[str, Any]]:
+def evaluate_github_thresholds(github_data: Dict[str, Any], thresholds: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Evaluate GitHub cost thresholds."""
     alerts = []
-    
+
     github_thresholds = thresholds.get("github", {})
-    
+
     # Check Copilot thresholds
     copilot_thresholds = github_thresholds.get("copilot", {})
     copilot_data = github_data.get("copilot", {})
-    
+
     # Check total monthly cost
     if "total_monthly_usd" in copilot_thresholds:
         threshold = copilot_thresholds["total_monthly_usd"]
         actual = copilot_data.get("monthly_cost_usd", 0)
-        
+
         if actual > threshold:
-            alerts.append({
-                "scope": "github",
-                "item": "copilot",
-                "type": "total_usd",
-                "value": actual,
-                "threshold": threshold,
-                "severity": "high" if actual > threshold * 1.5 else "medium"
-            })
-    
+            alerts.append(
+                {
+                    "scope": "github",
+                    "item": "copilot",
+                    "type": "total_usd",
+                    "value": actual,
+                    "threshold": threshold,
+                    "severity": "high" if actual > threshold * 1.5 else "medium",
+                }
+            )
+
     # Check seats
     if "seats" in copilot_thresholds:
         seats_threshold = copilot_thresholds["seats"].get("max", 0)
         seats_actual = copilot_data.get("seats_assigned", 0)
-        
+
         if seats_threshold and seats_actual > seats_threshold:
-            alerts.append({
-                "scope": "github",
-                "item": "copilot",
-                "type": "seats",
-                "value": seats_actual,
-                "threshold": seats_threshold,
-                "severity": "medium"
-            })
-    
+            alerts.append(
+                {
+                    "scope": "github",
+                    "item": "copilot",
+                    "type": "seats",
+                    "value": seats_actual,
+                    "threshold": seats_threshold,
+                    "severity": "medium",
+                }
+            )
+
     # Check Enterprise Cloud thresholds
     ec_thresholds = github_thresholds.get("enterprise_cloud", {})
     ec_data = github_data.get("enterprise_cloud", {})
-    
+
     if "seats" in ec_thresholds:
         ec_seats_threshold = ec_thresholds["seats"].get("max", 0)
         ec_seats_actual = ec_data.get("seats", 0)
-        
+
         if ec_seats_threshold and ec_seats_actual > ec_seats_threshold:
-            alerts.append({
-                "scope": "github",
-                "item": "enterprise_cloud",
-                "type": "seats",
-                "value": ec_seats_actual,
-                "threshold": ec_seats_threshold,
-                "severity": "medium"
-            })
-    
+            alerts.append(
+                {
+                    "scope": "github",
+                    "item": "enterprise_cloud",
+                    "type": "seats",
+                    "value": ec_seats_actual,
+                    "threshold": ec_seats_threshold,
+                    "severity": "medium",
+                }
+            )
+
     return alerts
 
 
-def evaluate_gcp_thresholds(
-    gcp_data: Dict[str, Any],
-    thresholds: Dict[str, Any]
-) -> List[Dict[str, Any]]:
+def evaluate_gcp_thresholds(gcp_data: Dict[str, Any], thresholds: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Evaluate GCP cost thresholds."""
     alerts = []
-    
+
     gcp_thresholds = thresholds.get("gcp", {})
+    configured_currency = str(gcp_thresholds.get("currency", "")).upper()
+    source_currency = str(gcp_data.get("currency", "")).upper()
+    if not configured_currency:
+        raise ValueError("gcp.currency is required in threshold configuration")
+    if source_currency != configured_currency:
+        raise ValueError(
+            "GCP threshold currency mismatch: "
+            f"configured {configured_currency}, observed {source_currency or 'missing'}"
+        )
+
     defaults = gcp_thresholds.get("defaults", {})
     project_thresholds = gcp_thresholds.get("projects", {})
-    
+
     project_costs = gcp_data.get("project_costs", [])
-    
+
     for project_cost in project_costs:
         project_id = project_cost["project_id"]
-        total_cost = project_cost["total_net_usd"]
+        total_cost = project_cost["total_net"]
         services = project_cost["services"]
-        
+
         # Get project-specific thresholds or use defaults
         if project_id in project_thresholds:
             project_specific = project_thresholds[project_id]
         else:
             project_specific = defaults
-        
+
         # Check total monthly cost
-        total_threshold = project_specific.get("total_monthly_usd", 0)
+        total_threshold = project_specific.get("total_monthly", 0)
         if total_threshold and total_cost > total_threshold:
-            alerts.append({
-                "scope": "gcp",
-                "project": project_id,
-                "type": "total_usd",
-                "value": total_cost,
-                "threshold": total_threshold,
-                "severity": "high" if total_cost > total_threshold * 1.5 else "medium"
-            })
-        
+            alerts.append(
+                {
+                    "scope": "gcp",
+                    "project": project_id,
+                    "type": "total_cost",
+                    "currency": source_currency,
+                    "value": total_cost,
+                    "threshold": total_threshold,
+                    "severity": "high" if total_cost > total_threshold * 1.5 else "medium",
+                }
+            )
+
         # Check per-service costs
-        service_thresholds = project_specific.get("per_service_monthly_usd", {})
-        
+        service_thresholds = project_specific.get("per_service_monthly", {})
+
         for service_cost in services:
             service_name = service_cost["service"]
-            service_cost_value = service_cost["net_cost_usd"]
-            
+            service_cost_value = service_cost["net_cost"]
+
             if service_name in service_thresholds:
                 service_threshold = service_thresholds[service_name]
-                
+
                 if service_cost_value > service_threshold:
-                    alerts.append({
-                        "scope": "gcp",
-                        "project": project_id,
-                        "type": "service",
-                        "service": service_name,
-                        "value": service_cost_value,
-                        "threshold": service_threshold,
-                        "severity": "medium"
-                    })
-    
+                    alerts.append(
+                        {
+                            "scope": "gcp",
+                            "project": project_id,
+                            "type": "service",
+                            "currency": source_currency,
+                            "service": service_name,
+                            "value": service_cost_value,
+                            "threshold": service_threshold,
+                            "severity": "medium",
+                        }
+                    )
+
     return alerts
 
 
 def evaluate_all_thresholds(
-    github_data: Dict[str, Any],
-    gcp_data: Dict[str, Any],
-    thresholds: Dict[str, Any]
+    github_data: Dict[str, Any], gcp_data: Dict[str, Any], thresholds: Dict[str, Any]
 ) -> Dict[str, Any]:
     """Evaluate all thresholds and return alerts."""
-    
+
     github_alerts = []
     gcp_alerts = []
-    
+
     if github_data:
         github_alerts = evaluate_github_thresholds(github_data, thresholds)
     else:
         logger.warning("No GitHub data provided for threshold evaluation")
-        
+
     if gcp_data:
         gcp_alerts = evaluate_gcp_thresholds(gcp_data, thresholds)
     else:
         logger.warning("No GCP data provided for threshold evaluation")
-    
+
     all_alerts = github_alerts + gcp_alerts
-    
+
     # Ensure all alerts have a severity
     for alert in all_alerts:
         if "severity" not in alert:
             alert["severity"] = "low"
-    
+
     # Sort by severity
     severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
     all_alerts.sort(key=lambda x: severity_order.get(x.get("severity"), 3))
-    
+
     threshold_exceeded = len(all_alerts) > 0
-    
+
     logger.info(f"Threshold evaluation complete: {len(all_alerts)} alerts")
-    
+
     return {
         "alerts": all_alerts,
         "threshold_exceeded": threshold_exceeded,
@@ -174,35 +188,44 @@ def evaluate_all_thresholds(
         "gcp_alerts_count": len(gcp_alerts),
         "critical_count": sum(1 for a in all_alerts if a.get("severity") == "critical"),
         "high_count": sum(1 for a in all_alerts if a.get("severity") == "high"),
-        "medium_count": sum(1 for a in all_alerts if a.get("severity") == "medium")
+        "medium_count": sum(1 for a in all_alerts if a.get("severity") == "medium"),
     }
 
 
 def format_alert_message(alert: Dict[str, Any]) -> str:
     """Format an alert for display."""
     scope = alert.get("scope", "unknown")
-    
+
     if scope == "github":
         item = alert.get("item", "")
         type_ = alert.get("type", "")
         value = alert.get("value", 0)
         threshold = alert.get("threshold", 0)
-        
+
         if type_ == "total_usd":
             return f"🚨 GitHub {item.title()}: Monthly cost ${value:.2f} exceeds threshold ${threshold:.2f}"
         elif type_ == "seats":
             return f"⚠️ GitHub {item.title()}: {value} seats exceeds limit of {threshold}"
-    
+
     elif scope == "gcp":
         project = alert.get("project", "")
         type_ = alert.get("type", "")
         value = alert.get("value", 0)
         threshold = alert.get("threshold", 0)
-        
-        if type_ == "total_usd":
-            return f"🚨 GCP Project '{project}': Monthly cost ${value:.2f} exceeds threshold ${threshold:.2f}"
+        currency = alert.get("currency", "")
+
+        if type_ == "total_cost":
+            return (
+                f"🚨 GCP Project '{project}': Monthly cost {value:.2f} {currency} "
+                f"exceeds threshold {threshold:.2f} {currency}"
+            )
         elif type_ == "service":
             service = alert.get("service", "")
-            return f"⚠️ GCP '{project}' - {service}: ${value:.2f} exceeds limit ${threshold:.2f}"
-    
-    return f"Alert: {alert.get('scope', 'unknown')} - {alert.get('type', 'unknown')} (value: {alert.get('value', 'N/A')}, threshold: {alert.get('threshold', 'N/A')})"
+            return (
+                f"⚠️ GCP '{project}' - {service}: {value:.2f} {currency} " f"exceeds limit {threshold:.2f} {currency}"
+            )
+
+    return (
+        f"Alert: {alert.get('scope', 'unknown')} - {alert.get('type', 'unknown')} "
+        f"(value: {alert.get('value', 'N/A')}, threshold: {alert.get('threshold', 'N/A')})"
+    )

--- a/platform/tools/cost-monitoring/cost_monitoring/cli.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/cli.py
@@ -2,39 +2,36 @@
 Cost Monitoring CLI - Main entry point.
 """
 
-import os
-import sys
-import json
-import pathlib
 import datetime as dt
-from typing import Optional, Dict, Any
-import click
-from rich.console import Console
-from rich.table import Table
-from rich.panel import Panel
-import yaml
 import logging
+import os
+import pathlib
+import sys
+from typing import Any, Dict
+
+import click
+import yaml
 from github import Github
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
 
 # Import all local modules at module level
-from .monitor.github_monitor import collect_github
-from .monitor.gcp_monitor import collect_gcp
-from .alerting.thresholds import evaluate_all_thresholds, format_alert_message
 from .alerting.notifiers import send_cost_report_to_slack
+from .alerting.thresholds import evaluate_all_thresholds, format_alert_message
+from .monitor.gcp_monitor import collect_gcp
+from .monitor.github_monitor import collect_github
 from .report.writers import write_all_reports
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 console = Console()
 
 
 @click.group()
-@click.option('--debug', is_flag=True, help='Enable debug logging')
+@click.option("--debug", is_flag=True, help="Enable debug logging")
 def cli(debug):
     """Cost Monitoring Tool for Merglbot Enterprise."""
     if debug:
@@ -51,114 +48,80 @@ def cli(debug):
 @click.option("--soft-fail", is_flag=True, default=False, help="Exit 0 even if thresholds exceeded")
 def generate(month, config, thresholds, outdir, formats, dry_run, soft_fail):
     """Generate cost reports and evaluate thresholds."""
-    
+
     try:
         console.print(Panel.fit("🚀 [bold cyan]Starting Cost Monitoring[/bold cyan]"))
-        
+
         # 1. Load configurations
         console.print("[bold]Loading configuration...[/bold]")
         config_data = load_config(config)
         threshold_data = load_config(thresholds)
-        
+
         # 2. Determine month
         if not month:
             month = dt.datetime.now().strftime("%Y-%m")
         console.print(f"📅 Monitoring period: [bold green]{month}[/bold green]")
-        
+
         # 3. Collect GitHub data
         console.print("\n[bold]Collecting GitHub data...[/bold]")
-        try:
-            github_data = collect_github(
-                config_data["github"]["enterprise"],
-                config_data["github"]["orgs"],
-                config_data["github"]["pricing"]
-            )
-            console.print("✅ GitHub data collected successfully")
-            
-            # Display GitHub summary
-            display_github_summary(github_data)
-            
-        except Exception as e:
-            logger.error(f"Failed to collect GitHub data: {e}")
-            github_data = {
-                "error": str(e),
-                "total_monthly_cost_usd": 0,
-                "copilot": {"seats_assigned": 0, "monthly_cost_usd": 0},
-                "enterprise_cloud": {"seats": 0, "monthly_cost_usd": 0},
-                "total_members": 0,
-                "org_members": []
-            }
-            console.print(f"[red]❌ GitHub collection failed: {e}[/red]")
-        
+        github_data = collect_github(
+            config_data["github"]["enterprise"], config_data["github"]["orgs"], config_data["github"]["pricing"]
+        )
+        console.print("✅ GitHub data collected successfully")
+        display_github_summary(github_data)
+
         # 4. Collect GCP data
         console.print("\n[bold]Collecting GCP data...[/bold]")
-        try:
-            gcp_data = collect_gcp(config_data["gcp"], month)
-            console.print("✅ GCP data collected successfully")
-            
-            # Display GCP summary
-            display_gcp_summary(gcp_data)
-            
-        except Exception as e:
-            logger.error(f"Failed to collect GCP data: {e}")
-            gcp_data = {
-                "error": str(e),
-                "total_net_usd": 0,
-                "project_costs": []
-            }
-            console.print(f"[red]❌ GCP collection failed: {e}[/red]")
-        
+        gcp_data = collect_gcp(config_data["gcp"], month)
+        console.print("✅ GCP data collected successfully")
+        display_gcp_summary(gcp_data)
+
         # 5. Evaluate thresholds
         console.print("\n[bold]Evaluating thresholds...[/bold]")
         threshold_result = evaluate_all_thresholds(github_data, gcp_data, threshold_data)
-        
+
         if threshold_result["threshold_exceeded"]:
             console.print(f"[red]⚠️ {len(threshold_result['alerts'])} threshold(s) exceeded![/red]")
             display_alerts(threshold_result["alerts"])
         else:
             console.print("[green]✅ All costs within thresholds[/green]")
-        
+
         # 6. Write reports
         console.print("\n[bold]Generating reports...[/bold]")
-        
+
         # Prepare combined data
-        combined_data = {
-            "month": month,
-            "github": github_data,
-            "gcp": gcp_data,
-            "alerts": threshold_result["alerts"]
-        }
-        
+        combined_data = {"month": month, "github": github_data, "gcp": gcp_data, "alerts": threshold_result["alerts"]}
+
         # Write reports
         report_paths = write_all_reports(outdir, combined_data, month)
-        
+
         console.print("[green]✅ Reports generated:[/green]")
         for format_name, path in report_paths.items():
             console.print(f"   • {format_name.upper()}: {path}")
-        
+
         # 7. Send notifications if not dry-run and thresholds exceeded
         if not dry_run and threshold_result["threshold_exceeded"]:
             console.print("\n[bold]Sending notifications...[/bold]")
-            
+
             # Send Slack notification
             if send_cost_report_to_slack(github_data, gcp_data, threshold_result["alerts"], month):
                 console.print("[green]✅ Slack notification sent[/green]")
             else:
                 console.print("[yellow]⚠️ Slack notification skipped or failed[/yellow]")
-            
+
             # Create GitHub issue
             if create_github_issue_for_alerts(threshold_result["alerts"], month, combined_data):
                 console.print("[green]✅ GitHub issue created[/green]")
             else:
                 console.print("[yellow]⚠️ GitHub issue creation skipped or failed[/yellow]")
-        
+
         elif dry_run:
             console.print("\n[yellow]ℹ️ Dry-run mode: No notifications sent[/yellow]")
-        
+
         # 8. Print final summary
         console.print("\n" + "=" * 60)
         display_final_summary(github_data, gcp_data, threshold_result)
-        
+
         # 9. Exit code
         if threshold_result["threshold_exceeded"] and not soft_fail:
             console.print("\n[red]❌ Exiting with code 2 (thresholds exceeded)[/red]")
@@ -166,10 +129,12 @@ def generate(month, config, thresholds, outdir, formats, dry_run, soft_fail):
         else:
             console.print("\n[green]✅ Complete![/green]")
             sys.exit(0)
-            
+
     except Exception as e:
-        console.print(f"\n[red]Fatal error: {e}[/red]")
-        logger.exception("Fatal error in generate command")
+        # Provider exceptions can contain request details; emit only the class.
+        error_class = type(e).__name__
+        console.print(f"\n[red]Fatal cost-monitoring error ({error_class})[/red]")
+        logger.error("Fatal cost-monitoring error (%s)", error_class)
         sys.exit(1)
 
 
@@ -180,22 +145,24 @@ def validate_thresholds(config):
     try:
         console.print("[bold]Validating threshold configuration...[/bold]")
         data = load_config(config)
-        
+
         # Validate structure
         errors = []
-        
+
         if "github" not in data:
             errors.append("Missing 'github' section")
         else:
             if "copilot" not in data["github"]:
                 errors.append("Missing 'github.copilot' section")
-        
+
         if "gcp" not in data:
             errors.append("Missing 'gcp' section")
         else:
+            if "currency" not in data["gcp"]:
+                errors.append("Missing 'gcp.currency'")
             if "defaults" not in data["gcp"]:
                 errors.append("Missing 'gcp.defaults' section")
-        
+
         if errors:
             console.print("[red]❌ Validation errors:[/red]")
             for error in errors:
@@ -203,7 +170,7 @@ def validate_thresholds(config):
             sys.exit(1)
         else:
             console.print("[green]✅ Configuration valid[/green]")
-            
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         sys.exit(1)
@@ -215,15 +182,15 @@ def print_config(config):
     """Print effective configuration (without secrets)."""
     try:
         data = load_config(config)
-        
+
         # Mask sensitive values
         if "gcp" in data and "billing_account_id" in data["gcp"]:
             if data["gcp"]["billing_account_id"] != "XXXX-XXXX-XXXX":
                 data["gcp"]["billing_account_id"] = "****-****-****"
-        
+
         console.print(Panel.fit("[bold]Effective Configuration[/bold]"))
         console.print_json(data=data)
-        
+
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         sys.exit(1)
@@ -234,7 +201,7 @@ def load_config(path: str) -> Dict[str, Any]:
     config_path = pathlib.Path(path)
     if not config_path.exists():
         raise FileNotFoundError(f"Configuration file not found: {path}")
-    
+
     with open(config_path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
@@ -244,17 +211,17 @@ def display_github_summary(data: Dict[str, Any]):
     table = Table(title="GitHub Costs", show_header=True)
     table.add_column("Metric", style="cyan")
     table.add_column("Value", justify="right", style="green")
-    
+
     copilot = data.get("copilot", {})
     ec = data.get("enterprise_cloud", {})
-    
+
     table.add_row("Copilot Seats", str(copilot.get("seats_assigned", 0)))
     table.add_row("Copilot Cost", f"${copilot.get('monthly_cost_usd', 0):,.2f}")
     table.add_row("Enterprise Seats", str(ec.get("seats", 0)))
     table.add_row("Enterprise Cost", f"${ec.get('monthly_cost_usd', 0):,.2f}")
     table.add_row("Total Members", str(data.get("total_members", 0)))
     table.add_row("[bold]Total Cost[/bold]", f"[bold]${data.get('total_monthly_cost_usd', 0):,.2f}[/bold]")
-    
+
     console.print(table)
 
 
@@ -263,12 +230,13 @@ def display_gcp_summary(data: Dict[str, Any]):
     table = Table(title="GCP Costs", show_header=True)
     table.add_column("Metric", style="cyan")
     table.add_column("Value", justify="right", style="green")
-    
+
+    currency = data.get("currency", "")
     table.add_row("Projects Monitored", str(data.get("projects_monitored", 0)))
-    table.add_row("Total Cost", f"${data.get('total_cost_usd', 0):,.2f}")
-    table.add_row("Total Credits", f"${data.get('total_credits_usd', 0):,.2f}")
-    table.add_row("[bold]Net Cost[/bold]", f"[bold]${data.get('total_net_usd', 0):,.2f}[/bold]")
-    
+    table.add_row("Total Cost", f"{data.get('total_cost', 0):,.2f} {currency}")
+    table.add_row("Total Credits", f"{data.get('total_credits', 0):,.2f} {currency}")
+    table.add_row("[bold]Net Cost[/bold]", f"[bold]{data.get('total_net', 0):,.2f} {currency}[/bold]")
+
     console.print(table)
 
 
@@ -276,37 +244,41 @@ def display_alerts(alerts: list):
     """Display alerts table."""
     if not alerts:
         return
-    
+
     table = Table(title="Threshold Alerts", show_header=True)
     table.add_column("Severity", style="yellow")
     table.add_column("Scope", style="cyan")
     table.add_column("Item", style="white")
     table.add_column("Value", justify="right", style="red")
     table.add_column("Threshold", justify="right", style="green")
-    
+
     for alert in alerts[:10]:  # Show top 10
         severity = alert.get("severity", "medium")
         scope = alert.get("scope", "")
-        
+
         if scope == "github":
             item = f"{alert.get('item', '')} - {alert.get('type', '')}"
         else:  # gcp
             item = f"{alert.get('project', '')} - {alert.get('service', alert.get('type', ''))}"
-        
+
         value = alert.get("value", 0)
         threshold = alert.get("threshold", 0)
-        
-        if "usd" in alert.get("type", ""):
+
+        currency = alert.get("currency")
+        if currency:
+            value_str = f"{value:,.2f} {currency}"
+            threshold_str = f"{threshold:,.2f} {currency}"
+        elif "usd" in alert.get("type", ""):
             value_str = f"${value:,.2f}"
             threshold_str = f"${threshold:,.2f}"
         else:
             value_str = str(value)
             threshold_str = str(threshold)
-        
+
         table.add_row(severity.upper(), scope.upper(), item, value_str, threshold_str)
-    
+
     console.print(table)
-    
+
     if len(alerts) > 10:
         console.print(f"[yellow]... and {len(alerts) - 10} more alerts[/yellow]")
 
@@ -314,15 +286,15 @@ def display_alerts(alerts: list):
 def display_final_summary(github_data, gcp_data, threshold_result):
     """Display final summary panel."""
     github_total = github_data.get("total_monthly_cost_usd", 0)
-    gcp_total = gcp_data.get("total_net_usd", 0)
-    grand_total = github_total + gcp_total
-    
+    gcp_total = gcp_data.get("total_net", 0)
+    gcp_currency = gcp_data.get("currency", "")
+
     summary = f"""
 [bold cyan]Cost Monitoring Summary[/bold cyan]
 ━━━━━━━━━━━━━━━━━━━━━━━
 • GitHub Costs: ${github_total:,.2f}
-• GCP Costs: ${gcp_total:,.2f}
-• [bold]Grand Total: ${grand_total:,.2f}[/bold]
+• GCP Costs: {gcp_total:,.2f} {gcp_currency}
+• Cross-currency grand total: not calculated
 
 • Alerts: {len(threshold_result['alerts'])}
   - High: {threshold_result['high_count']}
@@ -330,7 +302,7 @@ def display_final_summary(github_data, gcp_data, threshold_result):
 
 Status: {"⚠️ THRESHOLDS EXCEEDED" if threshold_result['threshold_exceeded'] else "✅ WITHIN BUDGET"}
 """
-    
+
     console.print(Panel(summary, title="Final Summary", border_style="bold"))
 
 
@@ -341,55 +313,53 @@ def create_github_issue_for_alerts(alerts: list, month: str, data: Dict[str, Any
         if not token:
             logger.warning("GITHUB_TOKEN not set, skipping issue creation")
             return False
-        
+
         # Get repository from environment
         repo_name = os.environ.get("GITHUB_REPOSITORY")
         if not repo_name:
             logger.warning("GITHUB_REPOSITORY not set, skipping issue creation")
             return False
-        
+
         # Validate repo_name format (should be owner/repo)
         if not repo_name or "/" not in repo_name or not all(part for part in repo_name.split("/", 1)):
             logger.error("Invalid repository name format for GITHUB_REPOSITORY environment variable")
             return False
-        
+
         g = Github(token)
         repo = g.get_repo(repo_name)
-        
+
         # Format issue body
         body = f"""## Cost Threshold Alert - {month}
 
 ### Summary
 - **Total Alerts**: {len(alerts)}
 - **GitHub Costs**: ${data['github'].get('total_monthly_cost_usd', 0):,.2f}
-- **GCP Costs**: ${data['gcp'].get('total_net_usd', 0):,.2f}
+- **GCP Costs**: {data['gcp'].get('total_net', 0):,.2f} {data['gcp'].get('currency', '')}
 
 ### Alerts
 
 """
-        
+
         # Add alert details
         for alert in alerts[:20]:  # Limit to 20 in issue
             body += f"- {format_alert_message(alert)}\n"
-        
+
         if len(alerts) > 20:
             body += f"\n*... and {len(alerts) - 20} more alerts*\n"
-        
+
         body += "\n### Action Required\n"
         body += "Please review the cost reports and take appropriate action.\n\n"
         body += "---\n"
         body += "*This issue was automatically created by the Cost Monitoring tool.*"
-        
+
         # Create issue
         issue = repo.create_issue(
-            title=f"Cost Threshold Exceeded - {month}",
-            body=body,
-            labels=["cost-monitoring", "alert", "automated"]
+            title=f"Cost Threshold Exceeded - {month}", body=body, labels=["cost-monitoring", "alert", "automated"]
         )
-        
+
         logger.info(f"Created GitHub issue #{issue.number}")
         return True
-        
+
     except Exception as e:
         logger.error(f"Failed to create GitHub issue: {e}")
         return False

--- a/platform/tools/cost-monitoring/cost_monitoring/monitor/gcp_monitor.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/monitor/gcp_monitor.py
@@ -1,237 +1,248 @@
-"""
-GCP billing and cost monitoring via BigQuery export.
-"""
+"""GCP billing and cost monitoring via the canonical BigQuery export."""
 
-from typing import List, Dict, Any, Optional
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
 from google.cloud import bigquery
 from google.cloud.billing.budgets_v1 import BudgetServiceClient
-import logging
-from datetime import datetime
 
 logger = logging.getLogger(__name__)
+
+MAXIMUM_BYTES_BILLED = 5 * 1024 * 1024 * 1024
+
+
+class CostDataError(RuntimeError):
+    """Raised when cost evidence is missing, inconsistent, or unreadable."""
+
+
+def _month_bounds(month: Optional[str]) -> tuple[datetime, datetime]:
+    """Return inclusive/exclusive UTC bounds for a YYYY-MM reporting month."""
+
+    value = month or datetime.now(timezone.utc).strftime("%Y-%m")
+    try:
+        start = datetime.strptime(value, "%Y-%m").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise ValueError(f"Invalid month {value!r}; expected YYYY-MM") from exc
+
+    if start.month == 12:
+        end = start.replace(year=start.year + 1, month=1)
+    else:
+        end = start.replace(month=start.month + 1)
+    return start, end
+
+
+def _validate_table_reference(table_fqn: str) -> None:
+    """Validate a project.dataset.table-pattern reference before interpolation."""
+
+    try:
+        project_id, dataset, table_pattern = table_fqn.split(".")
+    except ValueError as exc:
+        raise ValueError(f"Invalid table reference format: {table_fqn}") from exc
+
+    identifiers_ok = all(part.replace("_", "").replace("-", "").isalnum() for part in (project_id, dataset))
+    table_ok = all(character.isalnum() or character in "_-*" for character in table_pattern)
+    if not identifiers_ok or not table_ok:
+        raise ValueError(f"Invalid table reference format: {table_fqn}")
 
 
 def query_month_costs_by_service(
     bq: bigquery.Client,
     table_fqn: str,
     project_ids: List[str],
-    month: Optional[str] = None
+    month: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """Query current month costs grouped by project and service."""
-    
-    # Build query with parameterized project IDs and month
-    from datetime import timezone
-    month_start = f"{month}-01" if month else datetime.now(timezone.utc).strftime("%Y-%m-01")
+    """Query one bounded month, enforcing a single export currency."""
 
-    # Validate table name format to prevent SQL injection
-    try:
-        project_id, dataset, table_pattern = table_fqn.split('.')
-    except ValueError:
-        raise ValueError(f"Invalid table reference format: {table_fqn}")
-    # Allow alphanumeric chars, underscores, hyphens, and wildcards in table_pattern
-    if not all(part.replace("_", "").replace("-", "").isalnum() for part in [project_id, dataset]) or \
-       not all(c.isalnum() or c in "_-*" for c in table_pattern):
-        raise ValueError(f"Invalid table reference format: {table_fqn}")
+    if not project_ids:
+        raise ValueError("At least one project ID is required")
+    _validate_table_reference(table_fqn)
+    month_start, month_end = _month_bounds(month)
+
     job_config = bigquery.QueryJobConfig(
         query_parameters=[
             bigquery.ArrayQueryParameter("project_ids", "STRING", project_ids),
-            bigquery.ScalarQueryParameter("month_start", "STRING", month_start)
+            bigquery.ScalarQueryParameter("month_start", "TIMESTAMP", month_start),
+            bigquery.ScalarQueryParameter("month_end", "TIMESTAMP", month_end),
         ]
     )
-    
+    job_config.maximum_bytes_billed = MAXIMUM_BYTES_BILLED
+
     sql = f"""
-    SELECT 
-        project.id AS project_id, 
-        service.description AS service, 
-        SUM(cost) AS cost_usd,
-        SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) AS credits_usd
+    SELECT
+        project.id AS project_id,
+        service.description AS service,
+        currency,
+        SUM(cost) AS cost,
+        SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) AS credits
     FROM `{table_fqn}`
-    WHERE usage_start_time >= TIMESTAMP_TRUNC(TIMESTAMP(@month_start), MONTH)
-      AND usage_start_time < TIMESTAMP_ADD(TIMESTAMP_TRUNC(TIMESTAMP(@month_start), MONTH), INTERVAL 1 MONTH)
+    WHERE _PARTITIONTIME >= @month_start
+      AND _PARTITIONTIME < @month_end
+      AND usage_start_time >= @month_start
+      AND usage_start_time < @month_end
       AND project.id IN UNNEST(@project_ids)
-    GROUP BY 1, 2 
-    ORDER BY 1, 3 DESC
+    GROUP BY 1, 2, 3
+    ORDER BY 1, 4 DESC
     """
-    
+
+    logger.info("Querying bounded BigQuery billing data for %d projects", len(project_ids))
     try:
-        logger.info(f"Querying BigQuery for {len(project_ids)} projects")
-        query_job = bq.query(sql, job_config=job_config)
-        rows = query_job.result()
-        
-        # Group by project
-        grouped: Dict[str, List[Dict[str, float]]] = {}
-        
-        for row in rows:
-            project_id = row.project_id
-            service = row.service
-            cost = float(row.cost_usd) if row.cost_usd else 0.0
-            credits = float(row.credits_usd) if row.credits_usd else 0.0
-            net_cost = cost - credits
-            
-            if project_id not in grouped:
-                grouped[project_id] = []
-            
-            grouped[project_id].append({
-                "service": service,
-                "cost_usd": cost,
-                "credits_usd": credits,
-                "net_cost_usd": net_cost
-            })
-        
-        # Format results
-        results = []
-        for project_id, services in grouped.items():
-            total_cost = sum(s["cost_usd"] for s in services)
-            total_credits = sum(s["credits_usd"] for s in services)
-            total_net = sum(s["net_cost_usd"] for s in services)
-            
-            results.append({
+        rows = list(bq.query(sql, job_config=job_config).result())
+    except Exception as exc:
+        raise CostDataError("BigQuery billing query failed") from exc
+
+    if not rows:
+        raise CostDataError("BigQuery billing export returned no rows for the configured projects and month")
+
+    currencies = {str(row.currency).upper() for row in rows if row.currency}
+    if len(currencies) != 1:
+        observed = ", ".join(sorted(currencies)) or "missing"
+        raise CostDataError(f"Expected one billing export currency, observed: {observed}")
+    currency = currencies.pop()
+
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for row in rows:
+        row_currency = str(row.currency).upper() if row.currency else ""
+        if row_currency != currency:
+            raise CostDataError("Billing row currency changed during aggregation")
+        cost = float(row.cost or 0)
+        credits = float(row.credits or 0)
+        grouped.setdefault(row.project_id, []).append(
+            {
+                "service": row.service,
+                "currency": currency,
+                "cost": cost,
+                "credits": credits,
+                # Billing export credit amounts are signed (normally negative).
+                "net_cost": cost + credits,
+            }
+        )
+
+    results: List[Dict[str, Any]] = []
+    for project_id, services in grouped.items():
+        results.append(
+            {
                 "project_id": project_id,
+                "currency": currency,
                 "services": services,
-                "total_cost_usd": total_cost,
-                "total_credits_usd": total_credits,
-                "total_net_usd": total_net
-            })
-        
-        logger.info(f"Retrieved costs for {len(results)} projects")
-        return results
-        
-    except Exception as e:
-        logger.error(f"Failed to query BigQuery: {str(e)}")
-        return []
+                "total_cost": sum(service["cost"] for service in services),
+                "total_credits": sum(service["credits"] for service in services),
+                "total_net": sum(service["net_cost"] for service in services),
+            }
+        )
+
+    logger.info("Retrieved aggregate billing data for %d projects in %s", len(results), currency)
+    return results
 
 
 def list_budgets(billing_account_id: str) -> List[Dict[str, Any]]:
-    """List budgets for the billing account."""
+    """List optional billing-account budgets without affecting cost evidence."""
+
     try:
         client = BudgetServiceClient()
         parent = f"billingAccounts/{billing_account_id}"
-        
         budgets = []
         for budget in client.list_budgets(parent=parent):
-            budget_amount = None
-            if hasattr(budget.amount, "specified_amount"):
-                if budget.amount.specified_amount:
-                    budget_amount = float(
-                        budget.amount.specified_amount.units + 
-                        budget.amount.specified_amount.nanos / 1e9
-                    )
-            
-            budgets.append({
-                "name": budget.name,
-                "display_name": budget.display_name,
-                "amount_usd": budget_amount,
-                "projects": list(budget.budget_filter.projects) if budget.budget_filter.projects else [],
-                "services": list(budget.budget_filter.services) if budget.budget_filter.services else []
-            })
-        
-        logger.info(f"Retrieved {len(budgets)} budgets")
+            amount = None
+            currency = None
+            if getattr(budget.amount, "specified_amount", None):
+                specified = budget.amount.specified_amount
+                amount = float(specified.units + specified.nanos / 1e9)
+                currency = specified.currency_code or None
+            budgets.append(
+                {
+                    "name": budget.name,
+                    "display_name": budget.display_name,
+                    "amount": amount,
+                    "currency": currency,
+                    "projects": list(budget.budget_filter.projects) if budget.budget_filter.projects else [],
+                    "services": list(budget.budget_filter.services) if budget.budget_filter.services else [],
+                }
+            )
+        logger.info("Retrieved %d budgets", len(budgets))
         return budgets
-        
-    except Exception as e:
-        logger.error(f"Failed to list budgets: {str(e)}")
+    except Exception as exc:
+        logger.warning("Optional billing budget lookup failed: %s", type(exc).__name__)
         return []
 
 
 def _get_all_projects_recursively(config_node: Any) -> List[str]:
-    """Recursively extract all project IDs from nested configuration."""
-    projects = []
+    """Recursively extract configured project IDs without row-level data."""
+
+    projects: List[str] = []
     if isinstance(config_node, list):
-        projects.extend(p for p in config_node if isinstance(p, str))
+        projects.extend(project for project in config_node if isinstance(project, str))
     elif isinstance(config_node, dict):
         for value in config_node.values():
             projects.extend(_get_all_projects_recursively(value))
     return projects
 
-def collect_gcp(
-    config: Dict[str, Any],
-    month: Optional[str] = None
-) -> Dict[str, Any]:
-    """Collect all GCP cost data."""
-    
-    # Extract configuration
+
+def collect_gcp(config: Dict[str, Any], month: Optional[str] = None) -> Dict[str, Any]:
+    """Collect GCP costs, failing closed on missing or inconsistent billing evidence."""
+
     billing_config = config.get("billing_export", {})
     project_id = billing_config.get("project_id")
-    dataset = billing_config.get("dataset")
+    dataset = billing_config.get("dataset", "billing_export_euw1")
     table_pattern = billing_config.get("table_pattern", "gcp_billing_export_v1_*")
+    expected_currency = str(billing_config.get("currency", "CZK")).upper()
     billing_account_id = config.get("billing_account_id")
-    
-    # Get all project IDs using recursive helper
+
+    if not project_id:
+        raise ValueError("gcp.billing_export.project_id is required")
+
     projects_config = config.get("projects", {})
-    all_projects = _get_all_projects_recursively(projects_config)
-    
+    all_projects = sorted(set(_get_all_projects_recursively(projects_config)))
     if not all_projects:
-        logger.warning("No projects configured for GCP monitoring")
-        return {}
-    
-    # Initialize BigQuery client
-    try:
-        bq_client = bigquery.Client(project=project_id)
-        
-        # Determine current month or use specified
-        if month:
-            current_month = month
-        else:
-            current_month = datetime.now().strftime("%Y-%m")
-        
-        # Build table reference (use wildcard pattern)
-        table_fqn = f"{project_id}.{dataset}.{table_pattern}"
-        
-        # Query costs
-        project_costs = query_month_costs_by_service(bq_client, table_fqn, all_projects, current_month)
-        
-        # Get budgets if billing account is configured
-        budgets = []
-        if billing_account_id and billing_account_id != "XXXX-XXXX-XXXX":
-            budgets = list_budgets(billing_account_id)
-        
-        # Calculate totals
-        total_cost = sum(p["total_cost_usd"] for p in project_costs)
-        total_credits = sum(p["total_credits_usd"] for p in project_costs)
-        total_net = sum(p["total_net_usd"] for p in project_costs)
-        
-        # Group by category for reporting
-        categorized_costs = {}
-        for category, category_data in projects_config.items():
-            categorized_costs[category] = {}
-            
-            if isinstance(category_data, list):
-                # Direct list of projects
-                category_projects = category_data
-                category_project_costs = [p for p in project_costs if p["project_id"] in category_projects]
-                categorized_costs[category] = {
-                    "projects": category_project_costs,
-                    "total_cost_usd": sum(p["total_cost_usd"] for p in category_project_costs),
-                    "total_net_usd": sum(p["total_net_usd"] for p in category_project_costs)
-                }
-            elif isinstance(category_data, dict):
-                # Nested structure (e.g., clients)
-                for subcategory, project_list in category_data.items():
-                    if isinstance(project_list, list):
-                        sub_project_costs = [p for p in project_costs if p["project_id"] in project_list]
-                        categorized_costs[category][subcategory] = {
-                            "projects": sub_project_costs,
-                            "total_cost_usd": sum(p["total_cost_usd"] for p in sub_project_costs),
-                            "total_net_usd": sum(p["total_net_usd"] for p in sub_project_costs)
-                        }
-        
-        return {
-            "month": current_month,
-            "billing_account": billing_account_id,
-            "projects_monitored": len(all_projects),
-            "project_costs": project_costs,
-            "categorized_costs": categorized_costs,
-            "budgets": budgets,
-            "total_cost_usd": total_cost,
-            "total_credits_usd": total_credits,
-            "total_net_usd": total_net
-        }
-        
-    except Exception as e:
-        logger.error(f"Failed to collect GCP data: {str(e)}")
-        return {
-            "error": str(e),
-            "projects_monitored": 0,
-            "project_costs": [],
-            "total_cost_usd": 0
-        }
+        raise ValueError("No projects configured for GCP monitoring")
+
+    current_month = month or datetime.now(timezone.utc).strftime("%Y-%m")
+    table_fqn = f"{project_id}.{dataset}.{table_pattern}"
+    bq_client = bigquery.Client(project=project_id)
+    project_costs = query_month_costs_by_service(bq_client, table_fqn, all_projects, current_month)
+
+    currencies = {project["currency"] for project in project_costs}
+    if currencies != {expected_currency}:
+        observed = ", ".join(sorted(currencies)) or "missing"
+        raise CostDataError(f"Billing export currency mismatch: configured {expected_currency}, observed {observed}")
+
+    budgets = []
+    if billing_account_id and billing_account_id != "XXXX-XXXX-XXXX":
+        budgets = list_budgets(billing_account_id)
+
+    categorized_costs: Dict[str, Any] = {}
+    for category, category_data in projects_config.items():
+        categorized_costs[category] = {}
+        if isinstance(category_data, list):
+            category_costs = [project for project in project_costs if project["project_id"] in category_data]
+            categorized_costs[category] = {
+                "projects": category_costs,
+                "currency": expected_currency,
+                "total_cost": sum(project["total_cost"] for project in category_costs),
+                "total_net": sum(project["total_net"] for project in category_costs),
+            }
+        elif isinstance(category_data, dict):
+            for subcategory, project_list in category_data.items():
+                if isinstance(project_list, list):
+                    subcategory_costs = [project for project in project_costs if project["project_id"] in project_list]
+                    categorized_costs[category][subcategory] = {
+                        "projects": subcategory_costs,
+                        "currency": expected_currency,
+                        "total_cost": sum(project["total_cost"] for project in subcategory_costs),
+                        "total_net": sum(project["total_net"] for project in subcategory_costs),
+                    }
+
+    return {
+        "month": current_month,
+        "billing_account": billing_account_id,
+        "currency": expected_currency,
+        "projects_monitored": len(all_projects),
+        "project_costs": project_costs,
+        "categorized_costs": categorized_costs,
+        "budgets": budgets,
+        "total_cost": sum(project["total_cost"] for project in project_costs),
+        "total_credits": sum(project["total_credits"] for project in project_costs),
+        "total_net": sum(project["total_net"] for project in project_costs),
+    }

--- a/platform/tools/cost-monitoring/cost_monitoring/monitor/github_monitor.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/monitor/github_monitor.py
@@ -2,13 +2,12 @@
 GitHub Enterprise and Copilot cost monitoring.
 """
 
-import os
-import time
-import math
-import requests
-from typing import Dict, Any, List, Tuple, Optional
-from github import Github
 import logging
+import os
+from typing import Any, Dict, List
+
+import requests
+from github import Github
 
 logger = logging.getLogger(__name__)
 
@@ -29,85 +28,65 @@ def _headers() -> Dict[str, str]:
 
 def list_org_members_count(gh: Github, org: str) -> int:
     """Get member count for an organization without logging PII."""
-    try:
-        members = gh.get_organization(org).get_members()
-        count = members.totalCount
-        logger.info(f"Organization {org} has {count} members")
-        return count
-    except Exception as e:
-        logger.error(f"Failed to get members for {org}: {str(e)}")
-        return 0
+    members = gh.get_organization(org).get_members()
+    count = members.totalCount
+    logger.info("Organization %s has %d members", org, count)
+    return count
 
 
 def get_copilot_enterprise(enterprise: str) -> Dict[str, Any]:
     """Get Copilot billing data for enterprise."""
-    try:
-        r = requests.get(
-            f"{API}/enterprises/{enterprise}/copilot/billing",
-            headers=_headers(),
-            timeout=30
-        )
-        if r.ok:
-            data = r.json()
-            logger.info(f"Copilot enterprise data retrieved for {enterprise}")
-            return data
-        else:
-            logger.warning(f"Failed to get Copilot enterprise data: {r.status_code}")
-            return {}
-    except Exception as e:
-        logger.error(f"Error getting Copilot enterprise data: {str(e)}")
+    response = requests.get(
+        f"{API}/enterprises/{enterprise}/copilot/billing",
+        headers=_headers(),
+        timeout=30,
+    )
+    if response.ok:
+        logger.info("Copilot enterprise data retrieved for %s", enterprise)
+        return response.json()
+    if response.status_code in (404, 422):
+        logger.info("Copilot enterprise endpoint unavailable; trying organization endpoints")
         return {}
+    raise RuntimeError(f"GitHub Copilot enterprise request failed with status {response.status_code}")
 
 
 def get_copilot_org(org: str) -> Dict[str, Any]:
     """Get Copilot billing data for organization."""
-    try:
-        r = requests.get(
-            f"{API}/orgs/{org}/copilot/billing",
-            headers=_headers(),
-            timeout=30
-        )
-        if r.ok:
-            data = r.json()
-            logger.info(f"Copilot org data retrieved for {org}")
-            return data
-        else:
-            logger.warning(f"Failed to get Copilot org data: {r.status_code}")
-            return {}
-    except Exception as e:
-        logger.error(f"Error getting Copilot org data: {str(e)}")
+    response = requests.get(
+        f"{API}/orgs/{org}/copilot/billing",
+        headers=_headers(),
+        timeout=30,
+    )
+    if response.ok:
+        logger.info("Copilot org data retrieved for %s", org)
+        return response.json()
+    if response.status_code == 404:
         return {}
+    raise RuntimeError(f"GitHub Copilot organization request failed with status {response.status_code}")
 
 
 def get_enterprise_cloud_seats(enterprise: str) -> Dict[str, Any]:
     """Get Enterprise Cloud seats data (best effort)."""
-    try:
-        # This endpoint may not be available for all accounts
-        r = requests.get(
-            f"{API}/enterprises/{enterprise}/settings/billing/enterprise-cloud",
-            headers=_headers(),
-            timeout=30
-        )
-        if r.ok:
-            return r.json()
-        else:
-            logger.info(f"Enterprise Cloud endpoint not available: {r.status_code}")
-            return {}
-    except Exception as e:
-        logger.info(f"Enterprise Cloud API not available: {str(e)}")
+    response = requests.get(
+        f"{API}/enterprises/{enterprise}/settings/billing/enterprise-cloud",
+        headers=_headers(),
+        timeout=30,
+    )
+    if response.ok:
+        return response.json()
+    if response.status_code in (404, 422):
+        logger.info("Enterprise Cloud endpoint is not available for this account")
         return {}
+    raise RuntimeError(f"GitHub Enterprise Cloud request failed with status {response.status_code}")
 
 
-def collect_github(
-    enterprise: str, 
-    orgs: List[str], 
-    pricing: Dict[str, float]
-) -> Dict[str, Any]:
+def collect_github(enterprise: str, orgs: List[str], pricing: Dict[str, float]) -> Dict[str, Any]:
     """Collect all GitHub cost data."""
-    
-    # Initialize Github client once
-    gh = Github(os.environ.get("GITHUB_TOKEN"))
-    
+
+    # Validate authentication before any best-effort endpoint handling.
+    _headers()
+    gh = Github(os.environ["GITHUB_TOKEN"])
+
     # Collect org member counts
     org_members = []
     # Note: Proper unique member counting would require fetching actual member IDs
@@ -115,53 +94,52 @@ def collect_github(
     # For now, we'll use the sum as an upper bound estimate
     for org in orgs:
         member_count = list_org_members_count(gh, org)
-        org_members.append({
-            "org": org,
-            "members": member_count
-        })
+        org_members.append({"org": org, "members": member_count})
     cop = get_copilot_enterprise(enterprise)
-    
+
     if not cop or "seats" not in cop:
         # Fallback: sum from individual orgs
         logger.info("Falling back to per-org Copilot data")
         seats_assigned = 0
         seats_purchased = 0
-        
+
+        org_sources = 0
         for org in orgs:
             org_data = get_copilot_org(org)
             if org_data:
+                org_sources += 1
                 seats_assigned += org_data.get("seats_assigned", 0)
                 seats_purchased += org_data.get("seats_purchased", 0)
-        
-        cop = {
-            "seats_assigned": seats_assigned,
-            "seats_purchased": seats_purchased
-        }
+
+        if org_sources == 0:
+            raise RuntimeError("No GitHub Copilot billing source returned authoritative data")
+
+        cop = {"seats_assigned": seats_assigned, "seats_purchased": seats_purchased}
     else:
         # Extract from enterprise response
         seats_data = cop.get("seats") or []
         cop = {
             "seats_assigned": seats_data[0].get("assigned", 0) if seats_data else 0,
-            "seats_purchased": seats_data[0].get("purchased", 0) if seats_data else 0
+            "seats_purchased": seats_data[0].get("purchased", 0) if seats_data else 0,
         }
-    
+
     # Calculate Copilot costs (based on purchased seats for billing)
     copilot_price_per_seat = float(pricing.get("copilot_usd_per_seat", 19.0))
     cop_cost = cop.get("seats_purchased", 0) * copilot_price_per_seat
-    
+
     # Try to get Enterprise Cloud seats
     ec = get_enterprise_cloud_seats(enterprise)
     ec_seats = int(ec.get("total_seats", 0) or 0)
     ec_price_per_seat = float(pricing.get("enterprise_cloud_usd_per_seat", 0.0))
     ec_cost = ec_seats * ec_price_per_seat
-    
+
     # If no EC data, estimate from unique users
     if ec_seats == 0 and ec_price_per_seat > 0:
         # Use total members as estimate
         total_members = sum([om["members"] for om in org_members])
         ec_seats = total_members
         ec_cost = ec_seats * ec_price_per_seat
-    
+
     return {
         "org_members": org_members,
         "total_members": sum([om["members"] for om in org_members]),
@@ -169,12 +147,8 @@ def collect_github(
             "seats_assigned": cop.get("seats_assigned", 0),
             "seats_purchased": cop.get("seats_purchased", 0),
             "monthly_cost_usd": cop_cost,
-            "price_per_seat": copilot_price_per_seat
+            "price_per_seat": copilot_price_per_seat,
         },
-        "enterprise_cloud": {
-            "seats": ec_seats,
-            "monthly_cost_usd": ec_cost,
-            "price_per_seat": ec_price_per_seat
-        },
-        "total_monthly_cost_usd": cop_cost + ec_cost
+        "enterprise_cloud": {"seats": ec_seats, "monthly_cost_usd": ec_cost, "price_per_seat": ec_price_per_seat},
+        "total_monthly_cost_usd": cop_cost + ec_cost,
     }

--- a/platform/tools/cost-monitoring/cost_monitoring/report/writers.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/report/writers.py
@@ -2,16 +2,24 @@
 Report writers for CSV, Markdown, and JSON formats.
 """
 
-from typing import List, Dict, Any, Optional
 import csv
-import json
 import datetime as dt
-from pathlib import Path
+import json
 import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from ..alerting.thresholds import format_alert_message
 
 logger = logging.getLogger(__name__)
+
+
+def format_money(value: float, currency: str) -> str:
+    """Format a value with an explicit currency without implicit conversion."""
+
+    if currency == "USD":
+        return f"${value:,.2f}"
+    return f"{value:,.2f} {currency}".strip()
 
 
 def write_markdown(path: str, data: Dict[str, Any]) -> None:
@@ -21,39 +29,39 @@ def write_markdown(path: str, data: Dict[str, Any]) -> None:
         github_data = data.get("github", {})
         gcp_data = data.get("gcp", {})
         alerts = data.get("alerts", [])
-        
+
         # Header
         f.write(f"# Cost Report {month}\n\n")
         f.write(f"Generated: {dt.datetime.now(dt.timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}\n\n")
-        
+
         # Summary
         github_total = github_data.get("total_monthly_cost_usd", 0)
-        gcp_total = gcp_data.get("total_net_usd", 0)
-        grand_total = github_total + gcp_total
-        
+        gcp_total = gcp_data.get("total_net", 0)
+        gcp_currency = gcp_data.get("currency", "")
+
         f.write("## Executive Summary\n\n")
-        f.write(f"- **Total Monthly Cost**: ${grand_total:,.2f}\n")
-        f.write(f"- **GitHub Costs**: ${github_total:,.2f}\n")
-        f.write(f"- **GCP Costs**: ${gcp_total:,.2f}\n")
+        f.write(f"- **GitHub Costs**: {format_money(github_total, 'USD')}\n")
+        f.write(f"- **GCP Costs**: {format_money(gcp_total, gcp_currency)}\n")
+        f.write("- **Cross-currency total**: not calculated\n")
         f.write(f"- **Alerts**: {len(alerts)}\n\n")
-        
+
         # GitHub Section
         f.write("## GitHub Enterprise\n\n")
-        
+
         copilot = github_data.get("copilot", {})
         ec = github_data.get("enterprise_cloud", {})
-        
+
         f.write("### Copilot\n")
         f.write(f"- Seats Assigned: {copilot.get('seats_assigned', 0)}\n")
         f.write(f"- Seats Purchased: {copilot.get('seats_purchased', 0)}\n")
         f.write(f"- Monthly Cost: ${copilot.get('monthly_cost_usd', 0):,.2f}\n")
         f.write(f"- Price per Seat: ${copilot.get('price_per_seat', 0):.2f}\n\n")
-        
+
         f.write("### Enterprise Cloud\n")
         f.write(f"- Seats: {ec.get('seats', 0)}\n")
         f.write(f"- Monthly Cost: ${ec.get('monthly_cost_usd', 0):,.2f}\n")
         f.write(f"- Price per Seat: ${ec.get('price_per_seat', 0):.2f}\n\n")
-        
+
         # Organization members
         org_members = github_data.get("org_members", [])
         if org_members:
@@ -63,74 +71,79 @@ def write_markdown(path: str, data: Dict[str, Any]) -> None:
             for om in org_members:
                 f.write(f"| {om['org']} | {om['members']} |\n")
             f.write("\n")
-        
+
         # GCP Section
         f.write("## GCP Costs\n\n")
         f.write(f"- **Projects Monitored**: {gcp_data.get('projects_monitored', 0)}\n")
-        f.write(f"- **Total Cost**: ${gcp_data.get('total_cost_usd', 0):,.2f}\n")
-        f.write(f"- **Total Credits**: ${gcp_data.get('total_credits_usd', 0):,.2f}\n")
-        f.write(f"- **Net Cost**: ${gcp_data.get('total_net_usd', 0):,.2f}\n\n")
-        
+        f.write(f"- **Total Cost**: {format_money(gcp_data.get('total_cost', 0), gcp_currency)}\n")
+        f.write(f"- **Total Credits**: {format_money(gcp_data.get('total_credits', 0), gcp_currency)}\n")
+        f.write(f"- **Net Cost**: {format_money(gcp_data.get('total_net', 0), gcp_currency)}\n\n")
+
         # Top projects by cost
         project_costs = gcp_data.get("project_costs", [])
         if project_costs:
             f.write("### Top Projects by Cost\n\n")
             f.write("| Project | Net Cost | Top Service | Service Cost |\n")
             f.write("|---------|----------:|-------------|-------------:|\n")
-            
+
             # Sort by net cost
-            sorted_projects = sorted(project_costs, key=lambda x: x["total_net_usd"], reverse=True)
-            
+            sorted_projects = sorted(project_costs, key=lambda x: x["total_net"], reverse=True)
+
             for project in sorted_projects[:10]:
                 project_id = project["project_id"]
-                net_cost = project["total_net_usd"]
-                
+                net_cost = project["total_net"]
+
                 # Get top service
                 services = project.get("services", [])
                 if services:
-                    top_service = max(services, key=lambda s: s["net_cost_usd"])
+                    top_service = max(services, key=lambda s: s["net_cost"])
                     service_name = top_service["service"][:30]  # Truncate long names
-                    service_cost = top_service["net_cost_usd"]
+                    service_cost = top_service["net_cost"]
                 else:
                     service_name = "N/A"
                     service_cost = 0
-                
-                f.write(f"| {project_id} | ${net_cost:,.2f} | {service_name} | ${service_cost:,.2f} |\n")
-            
+
+                f.write(
+                    f"| {project_id} | {format_money(net_cost, gcp_currency)} | {service_name} | "
+                    f"{format_money(service_cost, gcp_currency)} |\n"
+                )
+
             f.write("\n")
-        
+
         # Budgets
         budgets = gcp_data.get("budgets", [])
         if budgets:
             f.write("### Configured Budgets\n\n")
             f.write("| Budget | Amount | Projects |\n")
             f.write("|--------|--------:|----------|\n")
-            
+
             for budget in budgets[:10]:
                 name = budget.get("display_name", budget.get("name", ""))[:40]
-                amount = budget.get("amount_usd", 0)
+                amount = budget.get("amount")
+                budget_currency = budget.get("currency") or gcp_currency
                 projects = ", ".join(budget.get("projects", [])[:3])
                 if len(budget.get("projects", [])) > 3:
                     projects += f" (+{len(budget['projects']) - 3} more)"
-                
-                f.write(f"| {name} | ${amount:,.2f} | {projects} |\n")
-            
+
+                amount_display = "N/A" if amount is None else format_money(amount, budget_currency)
+                f.write(f"| {name} | {amount_display} | {projects} |\n")
+
             f.write("\n")
-        
+
         # Alerts
         if alerts:
             f.write("## ⚠️ Threshold Alerts\n\n")
-            
+
             # Group by severity
             high_alerts = [a for a in alerts if a.get("severity") == "high"]
             medium_alerts = [a for a in alerts if a.get("severity") == "medium"]
-            
+
             if high_alerts:
                 f.write("### 🔴 High Priority\n\n")
                 for alert in high_alerts:
                     f.write(f"- {format_alert_message(alert)}\n")
                 f.write("\n")
-            
+
             if medium_alerts:
                 f.write("### 🟡 Medium Priority\n\n")
                 for alert in medium_alerts[:10]:  # Limit to 10
@@ -138,11 +151,11 @@ def write_markdown(path: str, data: Dict[str, Any]) -> None:
                 if len(medium_alerts) > 10:
                     f.write(f"- ... and {len(medium_alerts) - 10} more\n")
                 f.write("\n")
-        
+
         # Footer
         f.write("---\n\n")
         f.write("*For full details, see the CSV and JSON reports.*\n")
-        
+
     logger.info(f"Markdown report written to {path}")
 
 
@@ -151,13 +164,13 @@ def write_csv(path: str, rows: List[Dict[str, Any]]) -> None:
     if not rows:
         logger.warning("No data to write to CSV")
         return
-    
+
     with open(path, "w", newline="", encoding="utf-8") as f:
         fields = ["source", "scope", "project", "service", "metric", "value", "currency", "month"]
         writer = csv.DictWriter(f, fieldnames=fields)
         writer.writeheader()
         writer.writerows(rows)
-    
+
     logger.info(f"CSV report written to {path} ({len(rows)} rows)")
 
 
@@ -165,7 +178,7 @@ def write_json(path: str, payload: Dict[str, Any]) -> None:
     """Write JSON report."""
     with open(path, "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2, ensure_ascii=False, default=str)
-    
+
     logger.info(f"JSON report written to {path}")
 
 
@@ -173,142 +186,146 @@ def prepare_csv_rows(data: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Prepare data rows for CSV export."""
     rows = []
     month = data.get("month", dt.datetime.now().strftime("%Y-%m"))
-    
+
     # GitHub rows
     github_data = data.get("github", {})
-    
+
     # Copilot
     copilot = github_data.get("copilot", {})
-    rows.append({
-        "source": "github",
-        "scope": "enterprise",
-        "project": "",
-        "service": "Copilot",
-        "metric": "seats_assigned",
-        "value": copilot.get("seats_assigned", 0),
-        "currency": "count",
-        "month": month
-    })
-    rows.append({
-        "source": "github",
-        "scope": "enterprise",
-        "project": "",
-        "service": "Copilot",
-        "metric": "monthly_cost",
-        "value": copilot.get("monthly_cost_usd", 0),
-        "currency": "USD",
-        "month": month
-    })
-    
+    rows.append(
+        {
+            "source": "github",
+            "scope": "enterprise",
+            "project": "",
+            "service": "Copilot",
+            "metric": "seats_assigned",
+            "value": copilot.get("seats_assigned", 0),
+            "currency": "count",
+            "month": month,
+        }
+    )
+    rows.append(
+        {
+            "source": "github",
+            "scope": "enterprise",
+            "project": "",
+            "service": "Copilot",
+            "metric": "monthly_cost",
+            "value": copilot.get("monthly_cost_usd", 0),
+            "currency": "USD",
+            "month": month,
+        }
+    )
+
     # Enterprise Cloud
     ec = github_data.get("enterprise_cloud", {})
-    rows.append({
-        "source": "github",
-        "scope": "enterprise",
-        "project": "",
-        "service": "Enterprise Cloud",
-        "metric": "seats",
-        "value": ec.get("seats", 0),
-        "currency": "count",
-        "month": month
-    })
-    rows.append({
-        "source": "github",
-        "scope": "enterprise",
-        "project": "",
-        "service": "Enterprise Cloud",
-        "metric": "monthly_cost",
-        "value": ec.get("monthly_cost_usd", 0),
-        "currency": "USD",
-        "month": month
-    })
-    
+    rows.append(
+        {
+            "source": "github",
+            "scope": "enterprise",
+            "project": "",
+            "service": "Enterprise Cloud",
+            "metric": "seats",
+            "value": ec.get("seats", 0),
+            "currency": "count",
+            "month": month,
+        }
+    )
+    rows.append(
+        {
+            "source": "github",
+            "scope": "enterprise",
+            "project": "",
+            "service": "Enterprise Cloud",
+            "metric": "monthly_cost",
+            "value": ec.get("monthly_cost_usd", 0),
+            "currency": "USD",
+            "month": month,
+        }
+    )
+
     # Organization members
     for om in github_data.get("org_members", []):
-        rows.append({
-            "source": "github",
-            "scope": "organization",
-            "project": om["org"],
-            "service": "Members",
-            "metric": "count",
-            "value": om["members"],
-            "currency": "count",
-            "month": month
-        })
-    
+        rows.append(
+            {
+                "source": "github",
+                "scope": "organization",
+                "project": om["org"],
+                "service": "Members",
+                "metric": "count",
+                "value": om["members"],
+                "currency": "count",
+                "month": month,
+            }
+        )
+
     # GCP rows
     gcp_data = data.get("gcp", {})
-    
+
     # Project costs
     for project_cost in gcp_data.get("project_costs", []):
         project_id = project_cost["project_id"]
-        
+
         # Total for project
-        rows.append({
-            "source": "gcp",
-            "scope": "project",
-            "project": project_id,
-            "service": "Total",
-            "metric": "net_cost",
-            "value": project_cost["total_net_usd"],
-            "currency": "USD",
-            "month": month
-        })
-        
+        rows.append(
+            {
+                "source": "gcp",
+                "scope": "project",
+                "project": project_id,
+                "service": "Total",
+                "metric": "net_cost",
+                "value": project_cost["total_net"],
+                "currency": project_cost["currency"],
+                "month": month,
+            }
+        )
+
         # Per service
         for service in project_cost.get("services", []):
-            rows.append({
-                "source": "gcp",
-                "scope": "service",
-                "project": project_id,
-                "service": service["service"],
-                "metric": "net_cost",
-                "value": service["net_cost_usd"],
-                "currency": "USD",
-                "month": month
-            })
-    
+            rows.append(
+                {
+                    "source": "gcp",
+                    "scope": "service",
+                    "project": project_id,
+                    "service": service["service"],
+                    "metric": "net_cost",
+                    "value": service["net_cost"],
+                    "currency": service["currency"],
+                    "month": month,
+                }
+            )
+
     return rows
 
 
-def write_all_reports(
-    output_dir: str,
-    data: Dict[str, Any],
-    month: Optional[str] = None
-) -> Dict[str, str]:
+def write_all_reports(output_dir: str, data: Dict[str, Any], month: Optional[str] = None) -> Dict[str, str]:
     """Write all report formats."""
-    
+
     # Ensure output directory exists
     Path(output_dir).mkdir(parents=True, exist_ok=True)
-    
+
     # Determine month
     if not month:
         month = dt.datetime.now().strftime("%Y-%m")
-    
+
     # File paths
     base_name = f"costs_report_{month.replace('-', '_')}"
     csv_path = Path(output_dir) / f"{base_name}.csv"
     md_path = Path(output_dir) / f"{base_name}.md"
     json_path = Path(output_dir) / f"{base_name}.json"
-    
+
     # Add month to data if not present
     data["month"] = month
-    
+
     # Write CSV
     csv_rows = prepare_csv_rows(data)
     write_csv(str(csv_path), csv_rows)
-    
+
     # Write Markdown
     write_markdown(str(md_path), data)
-    
+
     # Write JSON
     data["generated_at"] = dt.datetime.now(dt.timezone.utc).isoformat()
     write_json(str(json_path), data)
-    
-    return {
-        "csv": str(csv_path),
-        "markdown": str(md_path),
-        "json": str(json_path)
-    }
 
-
+    return {"csv": str(csv_path), "markdown": str(md_path), "json": str(json_path)}

--- a/platform/tools/cost-monitoring/pyproject.toml
+++ b/platform/tools/cost-monitoring/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "PyGithub>=2.1.1",
     "google-cloud-bigquery>=3.13.0",
     "google-cloud-firestore>=2.16.0",
-    "google-cloud-billing>=1.11.2",
+    "google-cloud-billing-budgets>=1.11.2",
     "google-api-core>=2.14.0",
 ]
 

--- a/platform/tools/cost-monitoring/tests/test_currency_reporting.py
+++ b/platform/tools/cost-monitoring/tests/test_currency_reporting.py
@@ -1,0 +1,78 @@
+import pytest
+
+from cost_monitoring.alerting.thresholds import evaluate_gcp_thresholds
+from cost_monitoring.report.writers import prepare_csv_rows, write_markdown
+
+
+def sample_data():
+    return {
+        "month": "2026-08",
+        "github": {
+            "total_monthly_cost_usd": 100.0,
+            "copilot": {"monthly_cost_usd": 100.0},
+            "enterprise_cloud": {"monthly_cost_usd": 0.0},
+        },
+        "gcp": {
+            "currency": "CZK",
+            "projects_monitored": 1,
+            "total_cost": 2500.0,
+            "total_credits": -500.0,
+            "total_net": 2000.0,
+            "project_costs": [
+                {
+                    "project_id": "project-a",
+                    "currency": "CZK",
+                    "total_net": 2000.0,
+                    "services": [{"service": "BigQuery", "currency": "CZK", "net_cost": 2000.0}],
+                }
+            ],
+            "budgets": [],
+        },
+        "alerts": [],
+    }
+
+
+def test_markdown_keeps_github_usd_and_gcp_czk_separate(tmp_path):
+    output = tmp_path / "report.md"
+    write_markdown(str(output), sample_data())
+    report = output.read_text(encoding="utf-8")
+
+    assert "**GitHub Costs**: $100.00" in report
+    assert "**GCP Costs**: 2,000.00 CZK" in report
+    assert "**Cross-currency total**: not calculated" in report
+    assert "Total Monthly Cost" not in report
+
+
+def test_csv_propagates_source_currencies():
+    rows = prepare_csv_rows(sample_data())
+    currencies = {(row["source"], row["currency"]) for row in rows if row["metric"] != "count"}
+
+    assert ("github", "USD") in currencies
+    assert ("gcp", "CZK") in currencies
+
+
+def test_gcp_threshold_currency_mismatch_fails_closed():
+    gcp_data = sample_data()["gcp"]
+    thresholds = {"gcp": {"currency": "USD", "defaults": {"total_monthly": 10}}}
+
+    with pytest.raises(ValueError, match="currency mismatch"):
+        evaluate_gcp_thresholds(gcp_data, thresholds)
+
+
+def test_gcp_threshold_alert_carries_currency():
+    gcp_data = sample_data()["gcp"]
+    thresholds = {"gcp": {"currency": "CZK", "defaults": {"total_monthly": 1000}}}
+
+    alerts = evaluate_gcp_thresholds(gcp_data, thresholds)
+
+    assert alerts == [
+        {
+            "scope": "gcp",
+            "project": "project-a",
+            "type": "total_cost",
+            "currency": "CZK",
+            "value": 2000.0,
+            "threshold": 1000,
+            "severity": "high",
+        }
+    ]

--- a/platform/tools/cost-monitoring/tests/test_fail_closed_cli_and_workflow.py
+++ b/platform/tools/cost-monitoring/tests/test_fail_closed_cli_and_workflow.py
@@ -89,6 +89,14 @@ def test_soft_fail_applies_only_to_threshold_alerts(monkeypatch, tmp_path):
         },
     )
     monkeypatch.setattr(cli_module, "write_all_reports", lambda *args, **kwargs: {})
+    notification_calls = []
+
+    def record_notification(*args, **kwargs):
+        notification_calls.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr(cli_module, "send_cost_report_to_slack", record_notification)
+    monkeypatch.setattr(cli_module, "create_github_issue_for_alerts", record_notification)
 
     result = CliRunner().invoke(
         cli_module.cli,
@@ -106,6 +114,7 @@ def test_soft_fail_applies_only_to_threshold_alerts(monkeypatch, tmp_path):
     )
 
     assert result.exit_code == 0
+    assert notification_calls == []
 
 
 def test_workflow_does_not_blanket_suppress_generate_failures():
@@ -119,3 +128,13 @@ def test_workflow_does_not_blanket_suppress_generate_failures():
     assert "--soft-fail" in generate_block
     assert "|| EXIT=" not in generate_block
     assert '"${CMD[@]}"' in generate_block
+
+
+def test_workflow_dry_run_suppresses_separate_ai_usage_notifier():
+    repo_root = Path(__file__).resolve().parents[4]
+    workflow = (repo_root / ".github/workflows/cost-monitoring.yml").read_text(encoding="utf-8")
+
+    ai_alert_block = workflow.split("- name: AI Usage Telemetry Alerts (Budgets)", 1)[1].split(
+        "- name: Generate Step Summary", 1
+    )[0]
+    assert "if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true" in ai_alert_block

--- a/platform/tools/cost-monitoring/tests/test_fail_closed_cli_and_workflow.py
+++ b/platform/tools/cost-monitoring/tests/test_fail_closed_cli_and_workflow.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from cost_monitoring import cli as cli_module
+
+
+def write_configs(tmp_path):
+    settings = tmp_path / "settings.yml"
+    thresholds = tmp_path / "thresholds.yml"
+    settings.write_text(
+        yaml.safe_dump(
+            {
+                "github": {"enterprise": "example", "orgs": ["example"], "pricing": {}},
+                "gcp": {"billing_export": {"project_id": "billing-project"}, "projects": {"core": ["p"]}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    thresholds.write_text(
+        yaml.safe_dump({"github": {"copilot": {}}, "gcp": {"currency": "CZK", "defaults": {}}}),
+        encoding="utf-8",
+    )
+    return settings, thresholds
+
+
+def test_soft_fail_does_not_hide_collection_errors(monkeypatch, tmp_path):
+    settings, thresholds = write_configs(tmp_path)
+    monkeypatch.setattr(cli_module, "collect_github", lambda *args, **kwargs: {"total_monthly_cost_usd": 0})
+
+    def fail_gcp(*args, **kwargs):
+        raise RuntimeError("query failed")
+
+    monkeypatch.setattr(cli_module, "collect_gcp", fail_gcp)
+
+    result = CliRunner().invoke(
+        cli_module.cli,
+        [
+            "generate",
+            "--config",
+            str(settings),
+            "--thresholds",
+            str(thresholds),
+            "--outdir",
+            str(tmp_path / "reports"),
+            "--dry-run",
+            "--soft-fail",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Fatal cost-monitoring error (RuntimeError)" in result.output
+    assert "query failed" not in result.output
+
+
+def test_soft_fail_applies_only_to_threshold_alerts(monkeypatch, tmp_path):
+    settings, thresholds = write_configs(tmp_path)
+    monkeypatch.setattr(
+        cli_module,
+        "collect_github",
+        lambda *args, **kwargs: {
+            "total_monthly_cost_usd": 0,
+            "copilot": {},
+            "enterprise_cloud": {},
+            "total_members": 0,
+        },
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "collect_gcp",
+        lambda *args, **kwargs: {
+            "currency": "CZK",
+            "projects_monitored": 1,
+            "total_cost": 1,
+            "total_credits": 0,
+            "total_net": 1,
+            "project_costs": [],
+        },
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "evaluate_all_thresholds",
+        lambda *args, **kwargs: {
+            "alerts": [{"scope": "gcp", "type": "total_cost", "currency": "CZK"}],
+            "threshold_exceeded": True,
+            "high_count": 0,
+            "medium_count": 1,
+        },
+    )
+    monkeypatch.setattr(cli_module, "write_all_reports", lambda *args, **kwargs: {})
+
+    result = CliRunner().invoke(
+        cli_module.cli,
+        [
+            "generate",
+            "--config",
+            str(settings),
+            "--thresholds",
+            str(thresholds),
+            "--outdir",
+            str(tmp_path / "reports"),
+            "--dry-run",
+            "--soft-fail",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+
+def test_workflow_does_not_blanket_suppress_generate_failures():
+    repo_root = Path(__file__).resolve().parents[4]
+    workflow = (repo_root / ".github/workflows/cost-monitoring.yml").read_text(encoding="utf-8")
+
+    generate_block = workflow.split("- name: Generate cost report", 1)[1].split("- name: AI Usage Telemetry Alerts", 1)[
+        0
+    ]
+    assert "continue-on-error" not in generate_block
+    assert "--soft-fail" in generate_block
+    assert "|| EXIT=" not in generate_block
+    assert '"${CMD[@]}"' in generate_block

--- a/platform/tools/cost-monitoring/tests/test_gcp_monitor.py
+++ b/platform/tools/cost-monitoring/tests/test_gcp_monitor.py
@@ -1,0 +1,125 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from cost_monitoring.monitor import gcp_monitor
+
+
+class FakeQueryJob:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def result(self):
+        return self._rows
+
+
+class FakeBigQueryClient:
+    def __init__(self, rows=None, error=None):
+        self.rows = rows or []
+        self.error = error
+        self.sql = None
+        self.job_config = None
+
+    def query(self, sql, job_config):
+        self.sql = sql
+        self.job_config = job_config
+        if self.error:
+            raise self.error
+        return FakeQueryJob(self.rows)
+
+
+def billing_row(*, project="project-a", service="BigQuery", currency="CZK", cost=100.0, credits=-25.0):
+    return SimpleNamespace(
+        project_id=project,
+        service=service,
+        currency=currency,
+        cost=cost,
+        credits=credits,
+    )
+
+
+def test_query_is_partition_and_usage_bounded_with_five_gib_guard():
+    client = FakeBigQueryClient([billing_row()])
+
+    result = gcp_monitor.query_month_costs_by_service(
+        client,
+        "merglbot-platform-prd.billing_export_euw1.gcp_billing_export_v1_*",
+        ["project-a"],
+        "2026-08",
+    )
+
+    assert "_PARTITIONTIME >= @month_start" in client.sql
+    assert "_PARTITIONTIME < @month_end" in client.sql
+    assert "usage_start_time >= @month_start" in client.sql
+    assert "usage_start_time < @month_end" in client.sql
+    assert client.job_config.maximum_bytes_billed == 5 * 1024 * 1024 * 1024
+    assert result[0]["total_cost"] == pytest.approx(100.0)
+    assert result[0]["total_credits"] == pytest.approx(-25.0)
+    assert result[0]["total_net"] == pytest.approx(75.0)
+    assert result[0]["currency"] == "CZK"
+
+
+def test_query_rejects_mixed_currencies():
+    client = FakeBigQueryClient([billing_row(currency="CZK"), billing_row(project="project-b", currency="USD")])
+
+    with pytest.raises(gcp_monitor.CostDataError, match="Expected one billing export currency"):
+        gcp_monitor.query_month_costs_by_service(
+            client,
+            "billing-project.billing_export_euw1.gcp_billing_export_v1_*",
+            ["project-a", "project-b"],
+            "2026-08",
+        )
+
+
+def test_query_rejects_empty_export_result():
+    client = FakeBigQueryClient([])
+
+    with pytest.raises(gcp_monitor.CostDataError, match="returned no rows"):
+        gcp_monitor.query_month_costs_by_service(
+            client,
+            "billing-project.billing_export_euw1.gcp_billing_export_v1_*",
+            ["project-a"],
+            "2026-08",
+        )
+
+
+def test_query_failure_is_sanitized_and_propagated():
+    client = FakeBigQueryClient(error=RuntimeError("provider payload must not escape"))
+
+    with pytest.raises(gcp_monitor.CostDataError, match="BigQuery billing query failed") as exc_info:
+        gcp_monitor.query_month_costs_by_service(
+            client,
+            "billing-project.billing_export_euw1.gcp_billing_export_v1_*",
+            ["project-a"],
+            "2026-08",
+        )
+
+    assert "provider payload" not in str(exc_info.value)
+
+
+def test_collect_gcp_fails_on_configured_currency_mismatch(monkeypatch):
+    monkeypatch.setattr(gcp_monitor.bigquery, "Client", Mock(return_value=object()))
+    monkeypatch.setattr(
+        gcp_monitor,
+        "query_month_costs_by_service",
+        Mock(
+            return_value=[
+                {
+                    "project_id": "project-a",
+                    "currency": "USD",
+                    "services": [],
+                    "total_cost": 1.0,
+                    "total_credits": 0.0,
+                    "total_net": 1.0,
+                }
+            ]
+        ),
+    )
+    config = {
+        "billing_export": {"project_id": "billing-project", "currency": "CZK"},
+        "projects": {"core": ["project-a"]},
+    }
+
+    with pytest.raises(gcp_monitor.CostDataError, match="currency mismatch"):
+        gcp_monitor.collect_gcp(config, "2026-08")

--- a/platform/tools/cost-monitoring/tests/test_github_monitor_fail_closed.py
+++ b/platform/tools/cost-monitoring/tests/test_github_monitor_fail_closed.py
@@ -1,0 +1,10 @@
+import pytest
+
+from cost_monitoring.monitor import github_monitor
+
+
+def test_collect_github_requires_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    with pytest.raises(RuntimeError, match="Missing GITHUB_TOKEN"):
+        github_monitor.collect_github("example", ["example"], {})


### PR DESCRIPTION
## Summary

- use the canonical `billing_export_euw1` export with partition and usage-time bounds plus a 5 GiB query guard
- calculate signed GCP credits correctly and keep GCP CZK separate from GitHub USD throughout reports and alerts
- fail closed on auth, query, schema, empty-data, and mixed-currency errors while retaining `--soft-fail` only for threshold alerts
- remove the workflow's blanket error suppression and fix the Billing Budgets client dependency
- make workflow-dispatch dry runs suppress both the main CLI notifier path and the separate AI usage budget notifier

## Root cause

The daily monitor queried the legacy empty export, treated signed credits as positive deductions, combined unlike currencies, and converted collection errors into zero-cost success reports. The workflow then suppressed the command failure. Its separate AI usage budget step could also notify Slack during a requested dry run.

## Validation

- `pytest`: 25 passed on Python 3.12 and Python 3.14
- scoped Ruff `E,F,I,B`: pass
- Black check for touched Python files: pass
- `actionlint .github/workflows/cost-monitoring.yml`: pass
- offline negative coverage: negative credits, mixed currency, empty export, query failure, authentication failure, partition/bytes guard, threshold-only soft-fail, and notification-free dry-run behavior

## Runtime

No workflow was dispatched and no Slack notification or GitHub issue was created. A manual post-merge dry run remains required to validate aggregate output without notifications.

## Safety

- aggregate cost data only
- no secret values, raw billing rows, client payloads, or identity dumps
- no API enablement or infrastructure mutation
