### PR TITLE
fix(finops): use enterprise token for billing reads

### DIFF
--- a/.github/workflows/cost-monitoring.yml
+++ b/.github/workflows/cost-monitoring.yml
@@ -72,6 +72,9 @@ jobs:
         working-directory: platform/tools/cost-monitoring
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # Read-only enterprise/org billing APIs require the separately scoped token.
+          ENTERPRISE_GITHUB_TOKEN: ${{ secrets.ENTERPRISE_GITHUB_TOKEN }}
+          # Keep the run token isolated to optional issue creation.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MONITOR_MONTH: ${{ inputs.month }}
           MONITOR_DRY_RUN: ${{ inputs.dry_run }}

--- a/platform/tools/cost-monitoring/README.md
+++ b/platform/tools/cost-monitoring/README.md
@@ -97,9 +97,11 @@ gcp:
 ## 🔑 Authentication
 
 ### GitHub
-Set the `GITHUB_TOKEN` environment variable:
+Set a separately scoped token for enterprise and organization billing reads. Keep
+`GITHUB_TOKEN` distinct for optional issue creation:
 ```bash
-export GITHUB_TOKEN="ghp_your_personal_access_token"
+export ENTERPRISE_GITHUB_TOKEN="<enterprise-read-token>"
+export GITHUB_TOKEN="<run-token-for-issue-creation>"
 ```
 
 Required scopes:
@@ -278,9 +280,9 @@ The tool tracks:
 
 ### Common Issues
 
-1. **"Missing GITHUB_TOKEN"**
-   - Ensure the token is set in environment
-   - Verify token has required scopes
+1. **"Missing ENTERPRISE_GITHUB_TOKEN"**
+   - Ensure the separately scoped enterprise billing-read token is configured
+   - Verify the token has the required read scopes
 
 2. **"Failed to query BigQuery"**
    - Check GCP authentication

--- a/platform/tools/cost-monitoring/cost_monitoring/monitor/github_monitor.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/monitor/github_monitor.py
@@ -14,15 +14,22 @@ logger = logging.getLogger(__name__)
 API = "https://api.github.com"
 
 
-def _headers() -> Dict[str, str]:
-    """Get headers with GitHub token for API calls."""
-    token = os.environ.get("GITHUB_TOKEN", "")
+def _enterprise_token() -> str:
+    """Return the separately scoped token used for enterprise billing reads."""
+
+    token = os.environ.get("ENTERPRISE_GITHUB_TOKEN", "")
     if not token:
-        raise RuntimeError("Missing GITHUB_TOKEN")
+        raise RuntimeError("Missing ENTERPRISE_GITHUB_TOKEN")
+    return token
+
+
+def _headers() -> Dict[str, str]:
+    """Get headers for read-only enterprise and organization API calls."""
+
     return {
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
-        "Authorization": f"Bearer {token}",
+        "Authorization": f"Bearer {_enterprise_token()}",
     }
 
 
@@ -84,8 +91,8 @@ def collect_github(enterprise: str, orgs: List[str], pricing: Dict[str, float]) 
     """Collect all GitHub cost data."""
 
     # Validate authentication before any best-effort endpoint handling.
-    _headers()
-    gh = Github(os.environ["GITHUB_TOKEN"])
+    enterprise_token = _enterprise_token()
+    gh = Github(enterprise_token)
 
     # Collect org member counts
     org_members = []

--- a/platform/tools/cost-monitoring/tests/test_fail_closed_cli_and_workflow.py
+++ b/platform/tools/cost-monitoring/tests/test_fail_closed_cli_and_workflow.py
@@ -138,3 +138,14 @@ def test_workflow_dry_run_suppresses_separate_ai_usage_notifier():
         "- name: Generate Step Summary", 1
     )[0]
     assert "if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true" in ai_alert_block
+
+
+def test_workflow_separates_enterprise_reads_from_issue_token():
+    repo_root = Path(__file__).resolve().parents[4]
+    workflow = (repo_root / ".github/workflows/cost-monitoring.yml").read_text(encoding="utf-8")
+
+    generate_block = workflow.split("- name: Generate cost report", 1)[1].split("- name: AI Usage Telemetry Alerts", 1)[
+        0
+    ]
+    assert "ENTERPRISE_GITHUB_TOKEN: ${{ secrets.ENTERPRISE_GITHUB_TOKEN }}" in generate_block
+    assert "GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in generate_block

--- a/platform/tools/cost-monitoring/tests/test_github_monitor_fail_closed.py
+++ b/platform/tools/cost-monitoring/tests/test_github_monitor_fail_closed.py
@@ -4,7 +4,18 @@ from cost_monitoring.monitor import github_monitor
 
 
 def test_collect_github_requires_token(monkeypatch):
-    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "run-token-must-not-be-used-for-enterprise-reads")
+    monkeypatch.delenv("ENTERPRISE_GITHUB_TOKEN", raising=False)
 
-    with pytest.raises(RuntimeError, match="Missing GITHUB_TOKEN"):
+    with pytest.raises(RuntimeError, match="Missing ENTERPRISE_GITHUB_TOKEN"):
         github_monitor.collect_github("example", ["example"], {})
+
+
+def test_enterprise_headers_do_not_use_run_token(monkeypatch):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "run-token-for-issues-only")
+
+    headers = github_monitor._headers()
+
+    assert headers["Authorization"] == "Bearer enterprise-read-token"
+    assert "run-token-for-issues-only" not in headers["Authorization"]


### PR DESCRIPTION
## Summary

- authenticate enterprise and organization cost reads with the existing separately scoped `ENTERPRISE_GITHUB_TOKEN`
- keep the workflow `GITHUB_TOKEN` isolated to optional issue creation
- fail closed when the enterprise token is missing, even if the workflow run token exists
- preserve notification-free workflow-dispatch dry runs

## Evidence

- owner-merged #756 added fail-closed reporting; its notification-free dry run stopped in the report step
- metadata-only secret-name audit confirmed the enterprise token secret exists
- this successor contains no secret values and does not log either token

## Validation

- `pytest`: 27 passed on Python 3.12
- scoped Ruff `E,F,I,B`: pass
- Black: pass
- `actionlint .github/workflows/cost-monitoring.yml`: pass
- `pip check`: pass
- `git diff --check`: pass

## Runtime

No workflow was dispatched, no Slack message was sent, and no GitHub issue was created. A notification-free dry-run dispatch is intentionally deferred until after merge.
