### PR TITLE
fix(finops): use aggregate Copilot billing schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Setup Python for cost-monitoring tests
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: platform/tools/cost-monitoring/pyproject.toml
       - name: Validate PR Assistant helper scripts
         run: |
           set -euo pipefail
@@ -38,6 +44,11 @@ jobs:
         run: |
           set -euo pipefail
           python3 -m unittest discover -s tests -p 'test_*.py' -v
+      - name: Run cost-monitoring tests
+        run: |
+          set -euo pipefail
+          python3 -m pip install -e 'platform/tools/cost-monitoring[dev]'
+          python3 -m pytest -q platform/tools/cost-monitoring/tests
       - name: Validate PR Assistant rollout manifest
         run: |
           set -euo pipefail

--- a/platform/tools/cost-monitoring/README.md
+++ b/platform/tools/cost-monitoring/README.md
@@ -97,7 +97,7 @@ gcp:
 ## 🔑 Authentication
 
 ### GitHub
-Set a separately scoped token for enterprise and organization billing reads. Keep
+Set a separately scoped token for organization aggregate billing reads. Keep
 `GITHUB_TOKEN` distinct for optional issue creation:
 ```bash
 export ENTERPRISE_GITHUB_TOKEN="<enterprise-read-token>"
@@ -105,8 +105,16 @@ export GITHUB_TOKEN="<run-token-for-issue-creation>"
 ```
 
 Required scopes:
-- `read:org` - Read organization data
-- `read:enterprise` - Read enterprise billing data
+- classic PAT: `manage_billing:copilot` or `read:org`;
+- fine-grained PAT / GitHub App: organization `GitHub Copilot Business: read`
+  or `Administration: read`.
+
+The calling account must be an owner of every configured organization.
+
+The monitor uses only the aggregate organization Copilot billing response. It
+does not call the enterprise seat-list endpoint or ingest seat identities.
+Missing organizations are skipped, while authorization, billing-configuration,
+provider, and schema errors fail the report closed.
 
 ### GCP
 For local development:

--- a/platform/tools/cost-monitoring/cost_monitoring/cli.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/cli.py
@@ -219,7 +219,8 @@ def display_github_summary(data: Dict[str, Any]):
     table.add_row("Copilot Cost", f"${copilot.get('monthly_cost_usd', 0):,.2f}")
     table.add_row("Enterprise Seats", str(ec.get("seats", 0)))
     table.add_row("Enterprise Cost", f"${ec.get('monthly_cost_usd', 0):,.2f}")
-    table.add_row("Total Members", str(data.get("total_members", 0)))
+    total_members = data.get("total_members")
+    table.add_row("Total Members", str(total_members) if total_members is not None else "Not collected")
     table.add_row("[bold]Total Cost[/bold]", f"[bold]${data.get('total_monthly_cost_usd', 0):,.2f}[/bold]")
 
     console.print(table)

--- a/platform/tools/cost-monitoring/cost_monitoring/monitor/github_monitor.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/monitor/github_monitor.py
@@ -4,14 +4,36 @@ GitHub Enterprise and Copilot cost monitoring.
 
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any
 
 import requests
-from github import Github
 
 logger = logging.getLogger(__name__)
 
 API = "https://api.github.com"
+GRAPHQL_API = "https://api.github.com/graphql"
+API_VERSION = "2026-03-10"
+COPILOT_UNAVAILABLE_STATUSES = {404}
+
+
+class GitHubCopilotOrgAuthorizationError(RuntimeError):
+    """The aggregate organization endpoint rejected the configured token."""
+
+
+class GitHubCopilotOrgConfigurationError(RuntimeError):
+    """The aggregate organization endpoint reported a billing configuration problem."""
+
+
+class GitHubCopilotOrgRequestError(RuntimeError):
+    """The aggregate organization endpoint failed outside auth/configuration errors."""
+
+
+class GitHubCopilotOrgSchemaError(RuntimeError):
+    """The aggregate organization response did not match the reviewed schema."""
+
+
+class GitHubCopilotAggregateUnavailableError(RuntimeError):
+    """No configured organization returned authoritative aggregate billing data."""
 
 
 def _enterprise_token() -> str:
@@ -23,56 +45,91 @@ def _enterprise_token() -> str:
     return token
 
 
-def _headers() -> Dict[str, str]:
+def _headers() -> dict[str, str]:
     """Get headers for read-only enterprise and organization API calls."""
 
     return {
         "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
+        "X-GitHub-Api-Version": API_VERSION,
         "Authorization": f"Bearer {_enterprise_token()}",
     }
 
 
-def list_org_members_count(gh: Github, org: str) -> int:
-    """Get member count for an organization without logging PII."""
-    members = gh.get_organization(org).get_members()
-    count = members.totalCount
+def get_org_members_count(org: str) -> int:
+    """Get only the aggregate organization member count via GraphQL."""
+
+    response = requests.post(
+        GRAPHQL_API,
+        headers=_headers(),
+        json={
+            "query": "query($login: String!) { organization(login: $login) { membersWithRole { totalCount } } }",
+            "variables": {"login": org},
+        },
+        timeout=30,
+    )
+    if not response.ok:
+        raise RuntimeError(f"GitHub organization aggregate request failed with status {response.status_code}")
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise RuntimeError("GitHub organization aggregate response is not valid JSON") from exc
+
+    organization = payload.get("data", {}).get("organization") if isinstance(payload, dict) else None
+    members = organization.get("membersWithRole") if isinstance(organization, dict) else None
+    count = members.get("totalCount") if isinstance(members, dict) else None
+    if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+        raise RuntimeError("GitHub organization response has invalid aggregate member schema")
+
     logger.info("Organization %s has %d members", org, count)
     return count
 
 
-def get_copilot_enterprise(enterprise: str) -> Dict[str, Any]:
-    """Get Copilot billing data for enterprise."""
-    response = requests.get(
-        f"{API}/enterprises/{enterprise}/copilot/billing",
-        headers=_headers(),
-        timeout=30,
-    )
-    if response.ok:
-        logger.info("Copilot enterprise data retrieved for %s", enterprise)
-        return response.json()
-    if response.status_code in (404, 422):
-        logger.info("Copilot enterprise endpoint unavailable; trying organization endpoints")
-        return {}
-    raise RuntimeError(f"GitHub Copilot enterprise request failed with status {response.status_code}")
+def _normalize_copilot_org_billing(data: dict[str, Any]) -> dict[str, int]:
+    """Normalize the current aggregate-only Copilot organization response.
+
+    The endpoint's ``seat_breakdown.total`` is the billable seat total.  Do not
+    use the enterprise seat-list endpoint: its response contains identities and
+    is not needed for cost reporting.
+    """
+
+    breakdown = data.get("seat_breakdown")
+    total = breakdown.get("total") if isinstance(breakdown, dict) else None
+    if isinstance(total, bool) or not isinstance(total, int) or total < 0:
+        raise GitHubCopilotOrgSchemaError("GitHub Copilot organization response has invalid aggregate seat schema")
+
+    return {"seats_assigned": total, "seats_purchased": total}
 
 
-def get_copilot_org(org: str) -> Dict[str, Any]:
-    """Get Copilot billing data for organization."""
+def get_copilot_org(org: str) -> dict[str, Any]:
+    """Get privacy-preserving aggregate Copilot billing data for an organization."""
     response = requests.get(
         f"{API}/orgs/{org}/copilot/billing",
         headers=_headers(),
         timeout=30,
     )
     if response.ok:
-        logger.info("Copilot org data retrieved for %s", org)
-        return response.json()
-    if response.status_code == 404:
+        try:
+            normalized = _normalize_copilot_org_billing(response.json())
+        except ValueError as exc:
+            raise GitHubCopilotOrgSchemaError("GitHub Copilot organization response is not valid JSON") from exc
+        logger.info("Copilot aggregate org data retrieved for %s", org)
+        return normalized
+    if response.status_code in COPILOT_UNAVAILABLE_STATUSES:
+        logger.info("Copilot aggregate org endpoint unavailable for %s (status %d)", org, response.status_code)
         return {}
-    raise RuntimeError(f"GitHub Copilot organization request failed with status {response.status_code}")
+    if response.status_code in (401, 403):
+        raise GitHubCopilotOrgAuthorizationError(
+            f"GitHub Copilot organization billing request failed with status {response.status_code}"
+        )
+    if response.status_code == 422:
+        raise GitHubCopilotOrgConfigurationError("GitHub Copilot organization billing request failed with status 422")
+    raise GitHubCopilotOrgRequestError(
+        f"GitHub Copilot organization billing request failed with status {response.status_code}"
+    )
 
 
-def get_enterprise_cloud_seats(enterprise: str) -> Dict[str, Any]:
+def get_enterprise_cloud_seats(enterprise: str) -> dict[str, Any]:
     """Get Enterprise Cloud seats data (best effort)."""
     response = requests.get(
         f"{API}/enterprises/{enterprise}/settings/billing/enterprise-cloud",
@@ -87,69 +144,61 @@ def get_enterprise_cloud_seats(enterprise: str) -> Dict[str, Any]:
     raise RuntimeError(f"GitHub Enterprise Cloud request failed with status {response.status_code}")
 
 
-def collect_github(enterprise: str, orgs: List[str], pricing: Dict[str, float]) -> Dict[str, Any]:
+def collect_github(enterprise: str, orgs: list[str], pricing: dict[str, float]) -> dict[str, Any]:
     """Collect all GitHub cost data."""
 
-    # Validate authentication before any best-effort endpoint handling.
-    enterprise_token = _enterprise_token()
-    gh = Github(enterprise_token)
+    # Validate authentication before any endpoint handling.
+    _enterprise_token()
 
-    # Collect org member counts
+    # Enterprise member counts are only cost-relevant when that configured
+    # price is non-zero. Avoid unnecessary member APIs for the normal zero-price
+    # configuration; when needed, fetch only GraphQL aggregate totalCount.
+    ec_price_per_seat = float(pricing.get("enterprise_cloud_usd_per_seat", 0.0))
     org_members = []
-    # Note: Proper unique member counting would require fetching actual member IDs
-    # and tracking them across orgs, which may have privacy implications.
-    # For now, we'll use the sum as an upper bound estimate
-    for org in orgs:
-        member_count = list_org_members_count(gh, org)
-        org_members.append({"org": org, "members": member_count})
-    cop = get_copilot_enterprise(enterprise)
-
-    if not cop or "seats" not in cop:
-        # Fallback: sum from individual orgs
-        logger.info("Falling back to per-org Copilot data")
-        seats_assigned = 0
-        seats_purchased = 0
-
-        org_sources = 0
+    if ec_price_per_seat > 0:
         for org in orgs:
-            org_data = get_copilot_org(org)
-            if org_data:
-                org_sources += 1
-                seats_assigned += org_data.get("seats_assigned", 0)
-                seats_purchased += org_data.get("seats_purchased", 0)
+            member_count = get_org_members_count(org)
+            org_members.append({"org": org, "members": member_count})
+    # Sum authoritative organization aggregates. The enterprise Copilot seat
+    # endpoint is intentionally not used because it returns seat identities.
+    seats_assigned = 0
+    seats_purchased = 0
+    org_sources = 0
+    for org in orgs:
+        org_data = get_copilot_org(org)
+        if org_data:
+            org_sources += 1
+            seats_assigned += org_data["seats_assigned"]
+            seats_purchased += org_data["seats_purchased"]
 
-        if org_sources == 0:
-            raise RuntimeError("No GitHub Copilot billing source returned authoritative data")
+    if org_sources == 0:
+        raise GitHubCopilotAggregateUnavailableError(
+            "No GitHub Copilot billing source returned authoritative aggregate data"
+        )
 
-        cop = {"seats_assigned": seats_assigned, "seats_purchased": seats_purchased}
-    else:
-        # Extract from enterprise response
-        seats_data = cop.get("seats") or []
-        cop = {
-            "seats_assigned": seats_data[0].get("assigned", 0) if seats_data else 0,
-            "seats_purchased": seats_data[0].get("purchased", 0) if seats_data else 0,
-        }
+    cop = {"seats_assigned": seats_assigned, "seats_purchased": seats_purchased}
 
     # Calculate Copilot costs (based on purchased seats for billing)
     copilot_price_per_seat = float(pricing.get("copilot_usd_per_seat", 19.0))
     cop_cost = cop.get("seats_purchased", 0) * copilot_price_per_seat
 
-    # Try to get Enterprise Cloud seats
-    ec = get_enterprise_cloud_seats(enterprise)
-    ec_seats = int(ec.get("total_seats", 0) or 0)
-    ec_price_per_seat = float(pricing.get("enterprise_cloud_usd_per_seat", 0.0))
-    ec_cost = ec_seats * ec_price_per_seat
-
-    # If no EC data, estimate from unique users
-    if ec_seats == 0 and ec_price_per_seat > 0:
-        # Use total members as estimate
-        total_members = sum([om["members"] for om in org_members])
-        ec_seats = total_members
+    ec_seats = 0
+    ec_cost = 0.0
+    if ec_price_per_seat > 0:
+        # This source is only relevant when Enterprise Cloud pricing is enabled.
+        ec = get_enterprise_cloud_seats(enterprise)
+        ec_seats = int(ec.get("total_seats", 0) or 0)
         ec_cost = ec_seats * ec_price_per_seat
+
+        # If no EC data, estimate from aggregate organization member counts.
+        if ec_seats == 0:
+            ec_seats = sum(om["members"] for om in org_members)
+            ec_cost = ec_seats * ec_price_per_seat
 
     return {
         "org_members": org_members,
-        "total_members": sum([om["members"] for om in org_members]),
+        "total_members": sum(om["members"] for om in org_members) if org_members else None,
+        "member_census_status": "collected" if org_members else "not_collected_unpriced",
         "copilot": {
             "seats_assigned": cop.get("seats_assigned", 0),
             "seats_purchased": cop.get("seats_purchased", 0),

--- a/platform/tools/cost-monitoring/cost_monitoring/report/writers.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/report/writers.py
@@ -71,6 +71,9 @@ def write_markdown(path: str, data: Dict[str, Any]) -> None:
             for om in org_members:
                 f.write(f"| {om['org']} | {om['members']} |\n")
             f.write("\n")
+        elif github_data.get("member_census_status") == "not_collected_unpriced":
+            f.write("### Organization Members\n\n")
+            f.write("Not collected (Enterprise Cloud seat price is not configured).\n\n")
 
         # GCP Section
         f.write("## GCP Costs\n\n")

--- a/platform/tools/cost-monitoring/tests/test_currency_reporting.py
+++ b/platform/tools/cost-monitoring/tests/test_currency_reporting.py
@@ -11,6 +11,8 @@ def sample_data():
             "total_monthly_cost_usd": 100.0,
             "copilot": {"monthly_cost_usd": 100.0},
             "enterprise_cloud": {"monthly_cost_usd": 0.0},
+            "total_members": None,
+            "member_census_status": "not_collected_unpriced",
         },
         "gcp": {
             "currency": "CZK",
@@ -41,6 +43,7 @@ def test_markdown_keeps_github_usd_and_gcp_czk_separate(tmp_path):
     assert "**GCP Costs**: 2,000.00 CZK" in report
     assert "**Cross-currency total**: not calculated" in report
     assert "Total Monthly Cost" not in report
+    assert "Not collected (Enterprise Cloud seat price is not configured)." in report
 
 
 def test_csv_propagates_source_currencies():

--- a/platform/tools/cost-monitoring/tests/test_github_monitor_fail_closed.py
+++ b/platform/tools/cost-monitoring/tests/test_github_monitor_fail_closed.py
@@ -19,3 +19,176 @@ def test_enterprise_headers_do_not_use_run_token(monkeypatch):
 
     assert headers["Authorization"] == "Bearer enterprise-read-token"
     assert "run-token-for-issues-only" not in headers["Authorization"]
+    assert headers["X-GitHub-Api-Version"] == "2026-03-10"
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload=None, json_error=None):
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self._payload = payload
+        self._json_error = json_error
+
+    def json(self):
+        if self._json_error:
+            raise self._json_error
+        return self._payload
+
+
+def test_copilot_org_parses_current_aggregate_schema(monkeypatch):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    requested_urls = []
+
+    def fake_get(url, **kwargs):
+        requested_urls.append(url)
+        return FakeResponse(200, {"seat_breakdown": {"total": 7, "active_this_cycle": 6}})
+
+    monkeypatch.setattr(github_monitor.requests, "get", fake_get)
+
+    assert github_monitor.get_copilot_org("example") == {"seats_assigned": 7, "seats_purchased": 7}
+    assert requested_urls == ["https://api.github.com/orgs/example/copilot/billing"]
+    assert all("/billing/seats" not in url for url in requested_urls)
+
+
+def test_copilot_org_skips_only_not_found(monkeypatch):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    monkeypatch.setattr(
+        github_monitor.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse(404, {"message": "must not be inspected"}),
+    )
+
+    assert github_monitor.get_copilot_org("example") == {}
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_copilot_org_fails_closed_on_auth_error(monkeypatch, status):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    monkeypatch.setattr(
+        github_monitor.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse(status, {"message": "must not be inspected"}),
+    )
+
+    with pytest.raises(github_monitor.GitHubCopilotOrgAuthorizationError, match=rf"failed with status {status}"):
+        github_monitor.get_copilot_org("example")
+
+
+def test_copilot_org_fails_closed_on_billing_configuration_error(monkeypatch):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    monkeypatch.setattr(
+        github_monitor.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse(422, {"message": "must not be inspected"}),
+    )
+
+    with pytest.raises(github_monitor.GitHubCopilotOrgConfigurationError, match="failed with status 422"):
+        github_monitor.get_copilot_org("example")
+
+
+def test_copilot_org_fails_closed_on_provider_error(monkeypatch):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    monkeypatch.setattr(
+        github_monitor.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse(500, {"message": "must not be inspected"}),
+    )
+
+    with pytest.raises(github_monitor.GitHubCopilotOrgRequestError, match="failed with status 500"):
+        github_monitor.get_copilot_org("example")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"seat_breakdown": {}},
+        {"seat_breakdown": {"total": "7"}},
+        {"seat_breakdown": {"total": -1}},
+        {"seat_breakdown": {"total": True}},
+    ],
+)
+def test_copilot_org_fails_closed_on_invalid_aggregate_schema(monkeypatch, payload):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    monkeypatch.setattr(github_monitor.requests, "get", lambda *args, **kwargs: FakeResponse(200, payload))
+
+    with pytest.raises(github_monitor.GitHubCopilotOrgSchemaError, match="invalid aggregate seat schema"):
+        github_monitor.get_copilot_org("example")
+
+
+def test_copilot_org_fails_closed_on_invalid_json(monkeypatch):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    monkeypatch.setattr(
+        github_monitor.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse(200, json_error=ValueError("raw parser detail")),
+    )
+
+    with pytest.raises(github_monitor.GitHubCopilotOrgSchemaError, match="response is not valid JSON") as exc_info:
+        github_monitor.get_copilot_org("example")
+    assert "raw parser detail" not in str(exc_info.value)
+
+
+def test_collect_github_uses_org_aggregates_and_skips_unpriced_enterprise_endpoint(monkeypatch):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    org_values = {"one": 2, "two": 5}
+    monkeypatch.setattr(
+        github_monitor,
+        "get_copilot_org",
+        lambda org: {"seats_assigned": org_values[org], "seats_purchased": org_values[org]},
+    )
+
+    def forbidden_enterprise_lookup(enterprise):
+        raise AssertionError("unpriced Enterprise Cloud endpoint must not be queried")
+
+    def forbidden_member_lookup(org):
+        raise AssertionError("unpriced member census must not be queried")
+
+    monkeypatch.setattr(github_monitor, "get_enterprise_cloud_seats", forbidden_enterprise_lookup)
+    monkeypatch.setattr(github_monitor, "get_org_members_count", forbidden_member_lookup)
+
+    result = github_monitor.collect_github(
+        "example-enterprise",
+        ["one", "two"],
+        {"copilot_usd_per_seat": 19, "enterprise_cloud_usd_per_seat": 0},
+    )
+
+    assert result["copilot"] == {
+        "seats_assigned": 7,
+        "seats_purchased": 7,
+        "monthly_cost_usd": 133.0,
+        "price_per_seat": 19.0,
+    }
+    assert result["enterprise_cloud"]["seats"] == 0
+    assert result["org_members"] == []
+    assert result["total_members"] is None
+    assert result["member_census_status"] == "not_collected_unpriced"
+
+
+def test_collect_github_fails_closed_when_all_org_aggregates_unavailable(monkeypatch):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    monkeypatch.setattr(github_monitor, "get_copilot_org", lambda org: {})
+
+    with pytest.raises(
+        github_monitor.GitHubCopilotAggregateUnavailableError,
+        match="No GitHub Copilot billing source returned authoritative aggregate data",
+    ):
+        github_monitor.collect_github("example-enterprise", ["one", "two"], {})
+
+
+def test_member_count_query_requests_aggregate_only(monkeypatch):
+    monkeypatch.setenv("ENTERPRISE_GITHUB_TOKEN", "enterprise-read-token")
+    captured = {}
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured["query"] = kwargs["json"]["query"]
+        return FakeResponse(200, {"data": {"organization": {"membersWithRole": {"totalCount": 11}}}})
+
+    monkeypatch.setattr(github_monitor.requests, "post", fake_post)
+
+    assert github_monitor.get_org_members_count("example") == 11
+    assert captured["url"] == "https://api.github.com/graphql"
+    assert "totalCount" in captured["query"]
+    assert "nodes" not in captured["query"]
+    assert "edges" not in captured["query"]


### PR DESCRIPTION
## Summary

Fix the post-#757 Cost Monitoring dry-run failure by using GitHub's current privacy-preserving organization Copilot billing aggregate instead of the unavailable legacy enterprise endpoint.

## What changed

- read only `/orgs/{org}/copilot/billing` and normalize `seat_breakdown.total`;
- never call the Copilot seat-list endpoint or ingest seat identities;
- use GitHub API version `2026-03-10`;
- skip only a missing organization (`404`), while auth (`401/403`), billing configuration (`422`), provider, schema, JSON, and all-sources-empty states fail closed with sanitized typed errors;
- do not query organization members or Enterprise Cloud billing when its configured price is zero;
- report the intentionally omitted member census as `Not collected`, not a false zero;
- run the full cost-monitoring pytest suite inside the required `ci` workflow.

## Evidence

- exact base: `77a939c68fe567fe534cbf685300344de15ba96f`
- local cost-monitoring tests: `42 passed`
- repo contract tests: `36 passed`
- scoped Ruff: PASS
- scoped Black: PASS
- actionlint: PASS
- `git diff --check`: PASS
- status-only live check: legacy enterprise Copilot billing endpoint is unavailable; all three configured organization aggregate endpoints respond successfully and expose the reviewed `seat_breakdown.total` schema

## Safety

- no workflow dispatch, Slack notification, or issue-notifier execution;
- no secret values, raw payloads/logs, identities, or seat-list reads;
- failures remain nonzero rather than substituting zero billing data;
- no LPW/review workflow was triggered manually.

## Post-merge validation

Run one guarded `workflow_dispatch` of **Cost Monitoring** on `main` with `month=2026-07` and `dry_run=true`; require a successful report, skipped AI Usage notifier, no Slack/issue path, and separate GCP CZK / GitHub USD output.
