### PR TITLE
feat(finops): add durable equal-window savings verifier

### DIFF
--- a/.github/workflows/finops-realized-savings.yml
+++ b/.github/workflows/finops-realized-savings.yml
@@ -12,6 +12,7 @@ on:
         default: true
 
 permissions:
+  actions: read
   contents: read
   id-token: write
 
@@ -42,17 +43,44 @@ jobs:
       - name: Install verifier
         run: python -m pip install -e platform/tools/cost-monitoring
 
+      - name: Restore prior aggregate verdict state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          artifact_id="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=finops-realized-savings-state&per_page=10" \
+            --jq '.artifacts | map(select(.expired == false)) | sort_by(.created_at) | reverse | .[0].id // empty')"
+          if [ -n "$artifact_id" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > /tmp/finops-state.zip
+            unzip -p /tmp/finops-state.zip realized-savings.json > /tmp/previous-realized-savings.json
+          fi
+
       - name: Verify equal windows
+        id: verify
         working-directory: platform/tools/cost-monitoring
         env:
           QUERY_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.query_dry_run || false }}
         run: |
           set -euo pipefail
           ARGS=(realized-savings --config config/realized-savings.yml --out reports/realized-savings.json)
+          if [ -s /tmp/previous-realized-savings.json ]; then
+            ARGS+=(--previous /tmp/previous-realized-savings.json)
+          fi
           if [ "$QUERY_DRY_RUN" = "true" ]; then
             ARGS+=(--query-dry-run)
           fi
           python -m cost_monitoring.cli "${ARGS[@]}"
+          {
+            echo "verdict=$(jq -r '.verdict' reports/realized-savings.json)"
+            echo "transition=$(jq -r '.delivery.transition' reports/realized-savings.json)"
+            echo "fingerprint=$(jq -r '.delivery.fingerprint' reports/realized-savings.json)"
+            if jq -e '.query_dry_run == true' reports/realized-savings.json > /dev/null; then
+              echo "artifact_name=finops-realized-savings-dry-run-${GITHUB_RUN_ID}"
+            else
+              echo "artifact_name=finops-realized-savings-state"
+            fi
+          } >> "$GITHUB_OUTPUT"
 
       - name: Publish aggregate-only summary
         if: always() && hashFiles('platform/tools/cost-monitoring/reports/realized-savings.json') != ''
@@ -68,6 +96,7 @@ jobs:
           print(f"- Verdict: `{receipt['verdict']}`")
           print(f"- Query dry-run: `{receipt['query_dry_run']}`")
           print(f"- Bytes processed: `{receipt['total_bytes_processed']}` (cap 5 GiB)")
+          print(f"- Delivery transition: `{receipt['delivery']['transition']}`")
           for state, count in sorted(counts.items()):
               print(f"- {state}: `{count}`")
           print("- Portfolio/cross-currency total: `not calculated`")
@@ -77,6 +106,19 @@ jobs:
         if: always() && hashFiles('platform/tools/cost-monitoring/reports/realized-savings.json') != ''
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: finops-realized-savings-${{ github.run_id }}
+          name: ${{ steps.verify.outputs.artifact_name }}
           path: platform/tools/cost-monitoring/reports/realized-savings.json
           retention-days: 90
+
+      - name: Deliver new aggregate verdict
+        if: steps.verify.outputs.transition == 'DELIVER_NEW_VERDICT'
+        env:
+          VERDICT: ${{ steps.verify.outputs.verdict }}
+          FINGERPRINT: ${{ steps.verify.outputs.fingerprint }}
+        run: |
+          set -euo pipefail
+          if [ "$VERDICT" = "REALIZED" ]; then
+            echo "::notice title=New FinOps equal-window verdict::REALIZED; sanitized receipt fingerprint ${FINGERPRINT}"
+          else
+            echo "::warning title=New FinOps equal-window verdict::${VERDICT}; sanitized receipt fingerprint ${FINGERPRINT}"
+          fi

--- a/.github/workflows/finops-realized-savings.yml
+++ b/.github/workflows/finops-realized-savings.yml
@@ -1,0 +1,82 @@
+name: FinOps Realized Savings
+
+on:
+  schedule:
+    - cron: "23 9 * * 1" # Weekly; ineligible equal windows remain silent.
+  workflow_dispatch:
+    inputs:
+      query_dry_run:
+        description: "Estimate query bytes without reading billing rows"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: finops-realized-savings
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: platform/tools/cost-monitoring/pyproject.toml
+
+      - name: Authenticate to canonical billing export via WIF
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_WIF_SERVICE_ACCOUNT }}
+          export_environment_variables: true
+
+      - name: Install verifier
+        run: python -m pip install -e platform/tools/cost-monitoring
+
+      - name: Verify equal windows
+        working-directory: platform/tools/cost-monitoring
+        env:
+          QUERY_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.query_dry_run || false }}
+        run: |
+          set -euo pipefail
+          ARGS=(realized-savings --config config/realized-savings.yml --out reports/realized-savings.json)
+          if [ "$QUERY_DRY_RUN" = "true" ]; then
+            ARGS+=(--query-dry-run)
+          fi
+          python -m cost_monitoring.cli "${ARGS[@]}"
+
+      - name: Publish aggregate-only summary
+        if: always() && hashFiles('platform/tools/cost-monitoring/reports/realized-savings.json') != ''
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from collections import Counter
+          from pathlib import Path
+
+          receipt = json.loads(Path("platform/tools/cost-monitoring/reports/realized-savings.json").read_text())
+          counts = Counter(item["state"] for item in receipt["actions"])
+          print("## FinOps equal-window verifier")
+          print(f"- Verdict: `{receipt['verdict']}`")
+          print(f"- Query dry-run: `{receipt['query_dry_run']}`")
+          print(f"- Bytes processed: `{receipt['total_bytes_processed']}` (cap 5 GiB)")
+          for state, count in sorted(counts.items()):
+              print(f"- {state}: `{count}`")
+          print("- Portfolio/cross-currency total: `not calculated`")
+          PY
+
+      - name: Upload sanitized aggregate receipt
+        if: always() && hashFiles('platform/tools/cost-monitoring/reports/realized-savings.json') != ''
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: finops-realized-savings-${{ github.run_id }}
+          path: platform/tools/cost-monitoring/reports/realized-savings.json
+          retention-days: 90

--- a/platform/tools/cost-monitoring/README.md
+++ b/platform/tools/cost-monitoring/README.md
@@ -124,6 +124,27 @@ gcloud auth application-default login
 
 For CI/CD, use Workload Identity Federation. Service account JSON keys are not supported.
 
+## Equal-window realized savings
+
+The durable FinOps verifier compares independent 30-day pre/post windows only
+after the configured billing lag. It reads only the canonical
+`merglbot-platform-prd.billing_export_euw1` standard export, enforces both
+`_PARTITIONTIME` and usage-time bounds, and hard-caps the single aggregate query
+at 5 GiB. Receipts never include billing rows or identities and never calculate
+a cross-action or cross-currency grand total.
+
+```bash
+# Safe provider-side byte estimate; no billing rows are read.
+cost-monitor realized-savings --query-dry-run
+
+# Scheduled verification (read-only aggregate query).
+cost-monitor realized-savings --out reports/realized-savings.json
+```
+
+The Secret Manager scenario stays `NOT_ELIGIBLE_YET` until both a full-expansion
+timestamp and its immutable owner/hook receipt SHA-256 are committed to the
+measurement contract. The unreceipted 2026-08-07 bulk destruction is excluded.
+
 ### Slack (Optional)
 Set the webhook URL:
 ```bash

--- a/platform/tools/cost-monitoring/README.md
+++ b/platform/tools/cost-monitoring/README.md
@@ -145,6 +145,14 @@ The Secret Manager scenario stays `NOT_ELIGIBLE_YET` until both a full-expansion
 timestamp and its immutable owner/hook receipt SHA-256 are committed to the
 measurement contract. The unreceipted 2026-08-07 bulk destruction is excluded.
 
+Scheduled runs restore the last non-dry-run aggregate receipt and hash only the
+stable verdict payload. Ordinary waiting and unchanged verdicts remain silent;
+only a new `REALIZED`, `MISMATCH`, or `DATA_GAP` state emits a workflow
+annotation. Dry-run artifacts are isolated from this state. The authorized
+FinOps closeout consumer links the resulting aggregate artifact fingerprint to
+the closed audit issue; this least-privilege workflow does not receive a
+cross-repository write token.
+
 ### Slack (Optional)
 Set the webhook URL:
 ```bash

--- a/platform/tools/cost-monitoring/config/realized-savings.yml
+++ b/platform/tools/cost-monitoring/config/realized-savings.yml
@@ -1,0 +1,66 @@
+schema_version: 1
+billing_table: merglbot-platform-prd.billing_export_euw1.gcp_billing_export_v1_01E453_6322D7_41E77E
+window_days: 30
+maximum_bytes_billed: 5368709120
+
+# Every selector is an independent attribution scenario. The verifier never
+# produces a portfolio grand total, so parent/child scopes cannot be double
+# counted and currencies cannot be combined.
+actions:
+  - id: gcs_cerano
+    cutoff: "2026-08-02T07:41:09Z"
+    project_ids: [merglbot-cerano-extract]
+    services: [Cloud Storage]
+    billing_lag_days: 3
+
+  - id: gcs_denatura
+    cutoff: "2026-08-03T05:53:24Z"
+    project_ids: [merglbot-denatura-extract]
+    services: [Cloud Storage]
+    billing_lag_days: 3
+
+  - id: bq07_monitor_pause
+    cutoff: "2026-08-07T20:02:04Z"
+    project_ids: [merglbot-cerano-main]
+    services: [BigQuery]
+    billing_lag_days: 3
+
+  - id: run01_v1_pause
+    cutoff: "2026-08-07T20:08:29Z"
+    project_ids: [proteinaco-main]
+    services: [Cloud Run]
+    billing_lag_days: 3
+
+  - id: orphan_cloud_armor
+    cutoff: "2026-08-08T19:09:55Z"
+    project_ids: [mb-portal-prd]
+    services: [Network Security]
+    sku_contains: [Cloud Armor]
+    billing_lag_days: 3
+
+  - id: legacy_admin_lb
+    cutoff: "2026-08-09T10:24:00Z"
+    project_ids: [mb-portal-prd]
+    services: [Compute Engine]
+    sku_contains: [Load Balancing, Forwarding Rule]
+    billing_lag_days: 3
+
+  - id: ruzovyslon_offboarding
+    cutoff: "2026-08-08T18:14:14.616Z"
+    project_ids:
+      - merglbot-ruzovyslon-extract
+      - merglbot-ruzovyslon-main
+      - ruzovyslon-data-extract
+      - ruzovyslon-main
+    billing_lag_days: 3
+    parent_scenario: RZ-01
+
+  # Fail closed until the full-expansion owner/hook receipt exists. The
+  # unreceipted 2026-08-07 bulk destruction is deliberately not a baseline.
+  - id: secret_retention_full_expansion
+    cutoff: null
+    project_ids: [merglbot-extractors]
+    services: [Secret Manager]
+    billing_lag_days: 3
+    requires_receipted_expansion: true
+    expansion_receipt_sha256: null

--- a/platform/tools/cost-monitoring/cost_monitoring/cli.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/cli.py
@@ -22,7 +22,13 @@ from .alerting.thresholds import evaluate_all_thresholds, format_alert_message
 from .monitor.gcp_monitor import collect_gcp
 from .monitor.github_monitor import collect_github
 from .report.writers import write_all_reports
-from .realized_savings import RealizedSavingsError, verify as verify_realized_savings, write_receipt
+from .realized_savings import (
+    RealizedSavingsError,
+    attach_delivery_state as attach_realized_savings_delivery_state,
+    read_previous_receipt as read_previous_realized_savings_receipt,
+    verify as verify_realized_savings,
+    write_receipt,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -142,9 +148,10 @@ def generate(month, config, thresholds, outdir, formats, dry_run, soft_fail):
 @cli.command("realized-savings")
 @click.option("--config", default="config/realized-savings.yml", help="Path to the action measurement contract")
 @click.option("--out", default="reports/realized-savings.json", help="Sanitized aggregate receipt path")
+@click.option("--previous", default=None, help="Prior aggregate receipt used only to suppress unchanged delivery")
 @click.option("--as-of", default=None, help="UTC ISO-8601 evaluation time (tests/manual replay only)")
 @click.option("--query-dry-run", is_flag=True, default=False, help="Estimate bytes without reading billing rows")
-def realized_savings(config, out, as_of, query_dry_run):
+def realized_savings(config, out, previous, as_of, query_dry_run):
     """Verify equal 30-day pre/post FinOps billing windows."""
 
     try:
@@ -158,10 +165,10 @@ def realized_savings(config, out, as_of, query_dry_run):
             as_of=evaluation_time,
             query_dry_run=query_dry_run,
         )
+        previous_receipt = read_previous_realized_savings_receipt(previous) if previous else None
+        receipt = attach_realized_savings_delivery_state(receipt, previous_receipt)
         write_receipt(out, receipt)
         console.print(receipt["verdict"])
-        if receipt["verdict"] in {"DATA_GAP", "MISMATCH"}:
-            raise click.exceptions.Exit(1)
     except click.exceptions.Exit:
         raise
     except (OSError, ValueError, RealizedSavingsError) as exc:

--- a/platform/tools/cost-monitoring/cost_monitoring/cli.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/cli.py
@@ -22,6 +22,7 @@ from .alerting.thresholds import evaluate_all_thresholds, format_alert_message
 from .monitor.gcp_monitor import collect_gcp
 from .monitor.github_monitor import collect_github
 from .report.writers import write_all_reports
+from .realized_savings import RealizedSavingsError, verify as verify_realized_savings, write_receipt
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -136,6 +137,36 @@ def generate(month, config, thresholds, outdir, formats, dry_run, soft_fail):
         console.print(f"\n[red]Fatal cost-monitoring error ({error_class})[/red]")
         logger.error("Fatal cost-monitoring error (%s)", error_class)
         sys.exit(1)
+
+
+@cli.command("realized-savings")
+@click.option("--config", default="config/realized-savings.yml", help="Path to the action measurement contract")
+@click.option("--out", default="reports/realized-savings.json", help="Sanitized aggregate receipt path")
+@click.option("--as-of", default=None, help="UTC ISO-8601 evaluation time (tests/manual replay only)")
+@click.option("--query-dry-run", is_flag=True, default=False, help="Estimate bytes without reading billing rows")
+def realized_savings(config, out, as_of, query_dry_run):
+    """Verify equal 30-day pre/post FinOps billing windows."""
+
+    try:
+        evaluation_time = None
+        if as_of:
+            evaluation_time = dt.datetime.fromisoformat(as_of.replace("Z", "+00:00"))
+            if evaluation_time.tzinfo is None:
+                raise ValueError("--as-of must include a timezone")
+        receipt = verify_realized_savings(
+            config,
+            as_of=evaluation_time,
+            query_dry_run=query_dry_run,
+        )
+        write_receipt(out, receipt)
+        console.print(receipt["verdict"])
+        if receipt["verdict"] in {"DATA_GAP", "MISMATCH"}:
+            raise click.exceptions.Exit(1)
+    except click.exceptions.Exit:
+        raise
+    except (OSError, ValueError, RealizedSavingsError) as exc:
+        console.print(f"[red]Realized-savings verifier failed closed ({type(exc).__name__})[/red]")
+        raise click.exceptions.Exit(1) from None
 
 
 @cli.command()

--- a/platform/tools/cost-monitoring/cost_monitoring/realized_savings.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/realized_savings.py
@@ -1,0 +1,412 @@
+"""Privacy-safe equal-window verification of realized GCP FinOps savings.
+
+The verifier intentionally produces only aggregate action/currency totals.  It
+never exposes billing rows, resource identities, or provider error payloads.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import yaml
+from google.cloud import bigquery
+
+from .monitor.gcp_monitor import MAXIMUM_BYTES_BILLED
+
+CANONICAL_TABLE = "merglbot-platform-prd.billing_export_euw1." "gcp_billing_export_v1_01E453_6322D7_41E77E"
+WINDOW_DAYS = 30
+
+
+class RealizedSavingsError(RuntimeError):
+    """A sanitized fail-closed verifier error."""
+
+
+@dataclass(frozen=True)
+class Action:
+    action_id: str
+    cutoff: datetime | None
+    project_ids: tuple[str, ...]
+    services: tuple[str, ...]
+    sku_contains: tuple[str, ...]
+    billing_lag_days: int
+    mismatch_tolerance_percent: float
+    mismatch_tolerance_absolute: float
+    requires_receipted_expansion: bool
+    expansion_receipt_sha256: str | None
+    parent_scenario: str | None
+
+    @property
+    def pre_start(self) -> datetime:
+        assert self.cutoff is not None
+        return self.cutoff - timedelta(days=WINDOW_DAYS)
+
+    @property
+    def post_end(self) -> datetime:
+        assert self.cutoff is not None
+        return self.cutoff + timedelta(days=WINDOW_DAYS)
+
+    @property
+    def eligible_at(self) -> datetime | None:
+        if self.cutoff is None:
+            return None
+        return self.post_end + timedelta(days=self.billing_lag_days)
+
+
+def _utc(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Invalid action cutoff; expected an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("Action cutoff must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _is_sha256(value: str | None) -> bool:
+    return bool(value and len(value) == 64 and all(character in "0123456789abcdef" for character in value))
+
+
+def load_actions(path: str | Path) -> tuple[list[Action], str]:
+    """Load and strictly validate the versioned measurement contract."""
+
+    config_path = Path(path)
+    raw = config_path.read_bytes()
+    try:
+        config = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError("Invalid realized-savings configuration") from exc
+
+    if config.get("billing_table") != CANONICAL_TABLE:
+        raise ValueError("billing_table must be the canonical billing_export_euw1 standard export")
+    if config.get("window_days") != WINDOW_DAYS:
+        raise ValueError("window_days must be exactly 30")
+    if config.get("maximum_bytes_billed") != MAXIMUM_BYTES_BILLED:
+        raise ValueError("maximum_bytes_billed must be exactly 5 GiB")
+
+    actions: list[Action] = []
+    seen: set[str] = set()
+    for item in config.get("actions", []):
+        action_id = str(item.get("id", ""))
+        if not action_id or action_id in seen:
+            raise ValueError("Action IDs must be present and unique")
+        seen.add(action_id)
+        project_ids = tuple(sorted(set(item.get("project_ids") or [])))
+        if not project_ids:
+            raise ValueError(f"Action {action_id} requires project_ids")
+        services = tuple(sorted(set(item.get("services") or [])))
+        sku_contains = tuple(sorted(set(item.get("sku_contains") or [])))
+        cutoff = _utc(item["cutoff"]) if item.get("cutoff") else None
+        requires_receipt = bool(item.get("requires_receipted_expansion", False))
+        receipt = item.get("expansion_receipt_sha256")
+        if receipt is not None:
+            receipt = str(receipt).lower()
+            if not _is_sha256(receipt):
+                raise ValueError(f"Action {action_id} has an invalid expansion receipt SHA-256")
+        if requires_receipt and ((cutoff is None) != (receipt is None)):
+            raise ValueError(f"Action {action_id} requires both cutoff and expansion receipt, or neither")
+        billing_lag_days = int(item.get("billing_lag_days", 3))
+        if not 1 <= billing_lag_days <= 14:
+            raise ValueError(f"Action {action_id} billing_lag_days must be between 1 and 14")
+        actions.append(
+            Action(
+                action_id=action_id,
+                cutoff=cutoff,
+                project_ids=project_ids,
+                services=services,
+                sku_contains=sku_contains,
+                billing_lag_days=billing_lag_days,
+                mismatch_tolerance_percent=float(item.get("mismatch_tolerance_percent", 5.0)),
+                mismatch_tolerance_absolute=float(item.get("mismatch_tolerance_absolute", 1.0)),
+                requires_receipted_expansion=requires_receipt,
+                expansion_receipt_sha256=receipt,
+                parent_scenario=item.get("parent_scenario"),
+            )
+        )
+    if not actions:
+        raise ValueError("At least one action is required")
+    return actions, hashlib.sha256(raw).hexdigest()
+
+
+def classify_action(
+    action: Action,
+    rows: list[dict[str, Any]],
+    health: dict[str, Any],
+    as_of: datetime,
+) -> dict[str, Any]:
+    """Classify one action from aggregate-only offline evidence."""
+
+    base: dict[str, Any] = {
+        "action_id": action.action_id,
+        "parent_scenario": action.parent_scenario,
+        "cutoff": action.cutoff.isoformat().replace("+00:00", "Z") if action.cutoff else None,
+        "eligible_at": action.eligible_at.isoformat().replace("+00:00", "Z") if action.eligible_at else None,
+        "state": "NOT_ELIGIBLE_YET",
+        "amounts_by_currency": {},
+    }
+    if action.requires_receipted_expansion and not (
+        action.cutoff is not None and _is_sha256(action.expansion_receipt_sha256)
+    ):
+        base["reason"] = "receipted_expansion_not_available"
+        return base
+    if action.eligible_at is None or as_of < action.eligible_at:
+        base["reason"] = "equal_post_window_or_billing_lag_incomplete"
+        return base
+
+    latest_usage = health.get("latest_usage_date")
+    latest_partition = health.get("latest_partition_date")
+    if not latest_usage or not latest_partition:
+        base.update(state="DATA_GAP", reason="export_freshness_missing")
+        return base
+    if int(health.get("missing_partition_days", 0)):
+        base.update(state="DATA_GAP", reason="missing_post_window_partitions")
+        return base
+    required_last_day = (action.post_end - timedelta(microseconds=1)).date()
+    if latest_usage < required_last_day or latest_partition < required_last_day:
+        base.update(state="DATA_GAP", reason="post_window_export_incomplete")
+        return base
+
+    by_currency: dict[str, dict[str, float]] = {}
+    for row in rows:
+        if row["action_id"] != action.action_id:
+            continue
+        currency = str(row["currency"]).upper()
+        window = str(row["window"]).lower()
+        if window not in {"pre", "post"} or not currency:
+            base.update(state="DATA_GAP", reason="invalid_aggregate_schema")
+            return base
+        values = by_currency.setdefault(currency, {})
+        if window in values:
+            base.update(state="DATA_GAP", reason="duplicate_currency_window")
+            return base
+        values[window] = float(row["net_cost"])
+    if not by_currency or any(set(values) != {"pre", "post"} for values in by_currency.values()):
+        base.update(state="DATA_GAP", reason="incomplete_equal_window_aggregates")
+        return base
+
+    mismatch = False
+    for currency, values in sorted(by_currency.items()):
+        pre = values["pre"]
+        post = values["post"]
+        savings = pre - post
+        tolerance = max(action.mismatch_tolerance_absolute, abs(pre) * action.mismatch_tolerance_percent / 100)
+        if savings <= tolerance:
+            mismatch = True
+        base["amounts_by_currency"][currency] = {
+            "pre_net": round(pre, 6),
+            "post_net": round(post, 6),
+            "realized_savings": round(savings, 6),
+            "tolerance": round(tolerance, 6),
+        }
+    base["state"] = "MISMATCH" if mismatch else "REALIZED"
+    base["reason"] = "no_material_reduction" if mismatch else "equal_window_reduction_verified"
+    return base
+
+
+def _query_sql(actions: list[Action]) -> tuple[str, list[bigquery.QueryParameter]]:
+    """Build one bounded aggregate query for all currently eligible actions."""
+
+    if not actions:
+        raise ValueError("No eligible actions to query")
+    parameters: list[bigquery.QueryParameter] = []
+    action_parts: list[str] = []
+    health_parts: list[str] = []
+    for index, action in enumerate(actions):
+        assert action.cutoff is not None
+        parameters.extend(
+            [
+                bigquery.ScalarQueryParameter(f"action_{index}", "STRING", action.action_id),
+                bigquery.ScalarQueryParameter(f"pre_start_{index}", "TIMESTAMP", action.pre_start),
+                bigquery.ScalarQueryParameter(f"cutoff_{index}", "TIMESTAMP", action.cutoff),
+                bigquery.ScalarQueryParameter(f"post_end_{index}", "TIMESTAMP", action.post_end),
+                bigquery.ArrayQueryParameter(f"projects_{index}", "STRING", list(action.project_ids)),
+                bigquery.ArrayQueryParameter(f"services_{index}", "STRING", list(action.services)),
+                bigquery.ArrayQueryParameter(f"skus_{index}", "STRING", list(action.sku_contains)),
+            ]
+        )
+        action_parts.append(f"""
+            SELECT @action_{index} AS action_id,
+                   IF(usage_start_time < @cutoff_{index}, 'pre', 'post') AS period,
+                   currency,
+                   cost + IFNULL((SELECT SUM(credit.amount) FROM UNNEST(credits) credit), 0) AS net_cost
+              FROM source
+             WHERE project_id IN UNNEST(@projects_{index})
+               AND usage_start_time >= @pre_start_{index}
+               AND usage_start_time < @post_end_{index}
+               AND (ARRAY_LENGTH(@services_{index}) = 0 OR service IN UNNEST(@services_{index}))
+               AND (ARRAY_LENGTH(@skus_{index}) = 0 OR EXISTS (
+                     SELECT 1 FROM UNNEST(@skus_{index}) needle WHERE STRPOS(LOWER(sku), LOWER(needle)) > 0))
+            """)
+        health_parts.append(f"""
+            SELECT @action_{index} AS action_id,
+                   COUNTIF(day NOT IN (SELECT partition_day FROM partitions)) AS missing_partition_days
+              FROM UNNEST(GENERATE_DATE_ARRAY(DATE(@cutoff_{index}), DATE(@post_end_{index}) - 1)) day
+            """)
+    earliest = min(action.pre_start for action in actions)
+    latest = max(action.post_end for action in actions)
+    parameters.extend(
+        [
+            bigquery.ScalarQueryParameter("earliest_usage", "TIMESTAMP", earliest),
+            bigquery.ScalarQueryParameter("latest_usage", "TIMESTAMP", latest),
+            bigquery.ScalarQueryParameter("partition_end", "TIMESTAMP", datetime.now(UTC)),
+        ]
+    )
+    sql = f"""
+    WITH source AS (
+      SELECT usage_start_time, _PARTITIONTIME AS partition_time, project.id AS project_id,
+             service.description AS service, sku.description AS sku, currency, cost, credits
+        FROM `{CANONICAL_TABLE}`
+       WHERE _PARTITIONTIME >= @earliest_usage
+         AND _PARTITIONTIME < @partition_end
+         AND usage_start_time >= @earliest_usage
+         AND usage_start_time < @latest_usage
+    ),
+    partitions AS (SELECT DISTINCT DATE(partition_time) AS partition_day FROM source),
+    matched AS ({' UNION ALL '.join(action_parts)}),
+    currencies AS (SELECT DISTINCT action_id, currency FROM matched WHERE currency IS NOT NULL),
+    periods AS (SELECT 'pre' AS period UNION ALL SELECT 'post'),
+    totals AS (SELECT action_id, period, currency, SUM(net_cost) AS net_cost
+                 FROM matched GROUP BY 1, 2, 3),
+    aggregate_rows AS (
+      SELECT currencies.action_id, periods.period, currencies.currency,
+             IFNULL(totals.net_cost, 0) AS net_cost
+        FROM currencies CROSS JOIN periods
+        LEFT JOIN totals USING (action_id, period, currency)
+    ),
+    health AS ({' UNION ALL '.join(health_parts)}),
+    freshness AS (
+      SELECT MAX(DATE(usage_start_time)) AS latest_usage_date,
+             MAX(DATE(partition_time)) AS latest_partition_date FROM source
+    )
+    SELECT aggregate_rows.*, health.missing_partition_days,
+           freshness.latest_usage_date, freshness.latest_partition_date
+      FROM aggregate_rows JOIN health USING (action_id) CROSS JOIN freshness
+     ORDER BY action_id, currency, period
+    """
+    return sql, parameters
+
+
+def query_aggregates(
+    client: bigquery.Client, actions: list[Action], *, query_dry_run: bool = False
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]], int]:
+    """Execute one privacy-safe query under the 5 GiB hard cap."""
+
+    sql, parameters = _query_sql(actions)
+    config = bigquery.QueryJobConfig(query_parameters=parameters, dry_run=query_dry_run, use_query_cache=False)
+    config.maximum_bytes_billed = MAXIMUM_BYTES_BILLED
+    try:
+        job = client.query(sql, job_config=config)
+        processed = int(job.total_bytes_processed or 0)
+        if processed > MAXIMUM_BYTES_BILLED:
+            raise RealizedSavingsError("BigQuery dry-run estimate exceeds the 5 GiB safety cap")
+        if query_dry_run:
+            return [], {}, processed
+        raw_rows = list(job.result())
+    except RealizedSavingsError:
+        raise
+    except Exception as exc:
+        raise RealizedSavingsError("BigQuery realized-savings query failed") from exc
+
+    rows: list[dict[str, Any]] = []
+    health: dict[str, dict[str, Any]] = {}
+    for row in raw_rows:
+        action_id = str(row.action_id)
+        rows.append(
+            {
+                "action_id": action_id,
+                "window": str(row.period),
+                "currency": str(row.currency),
+                "net_cost": float(row.net_cost or 0),
+            }
+        )
+        health[action_id] = {
+            "missing_partition_days": int(row.missing_partition_days or 0),
+            "latest_usage_date": row.latest_usage_date,
+            "latest_partition_date": row.latest_partition_date,
+        }
+    return rows, health, processed
+
+
+def verify(
+    config_path: str | Path,
+    *,
+    as_of: datetime | None = None,
+    query_dry_run: bool = False,
+    client: bigquery.Client | None = None,
+) -> dict[str, Any]:
+    """Run the verifier and return a sanitized aggregate receipt."""
+
+    now = (as_of or datetime.now(UTC)).astimezone(UTC)
+    actions, config_sha = load_actions(config_path)
+    eligible = [
+        action
+        for action in actions
+        if action.eligible_at is not None
+        and now >= action.eligible_at
+        and (not action.requires_receipted_expansion or _is_sha256(action.expansion_receipt_sha256))
+    ]
+    rows: list[dict[str, Any]] = []
+    health: dict[str, dict[str, Any]] = {}
+    bytes_processed = 0
+    if eligible:
+        rows, health, bytes_processed = query_aggregates(
+            client or bigquery.Client(project="merglbot-platform-prd"), eligible, query_dry_run=query_dry_run
+        )
+
+    results = []
+    for action in actions:
+        if query_dry_run and action in eligible:
+            results.append(
+                {
+                    "action_id": action.action_id,
+                    "parent_scenario": action.parent_scenario,
+                    "cutoff": action.cutoff.isoformat().replace("+00:00", "Z") if action.cutoff else None,
+                    "eligible_at": (
+                        action.eligible_at.isoformat().replace("+00:00", "Z") if action.eligible_at else None
+                    ),
+                    "state": "NOT_ELIGIBLE_YET",
+                    "reason": "query_dry_run_only",
+                    "amounts_by_currency": {},
+                }
+            )
+        else:
+            results.append(classify_action(action, rows, health.get(action.action_id, {}), now))
+
+    states = {result["state"] for result in results}
+    if "DATA_GAP" in states:
+        verdict = "DATA_GAP"
+    elif "MISMATCH" in states:
+        verdict = "MISMATCH"
+    elif "REALIZED" in states:
+        verdict = "REALIZED"
+    else:
+        verdict = "NOT_ELIGIBLE_YET"
+    return {
+        "schema_version": 1,
+        "generated_at": now.isoformat().replace("+00:00", "Z"),
+        "verdict": verdict,
+        "billing_table": CANONICAL_TABLE,
+        "config_sha256": config_sha,
+        "window_days": WINDOW_DAYS,
+        "maximum_bytes_billed": MAXIMUM_BYTES_BILLED,
+        "query_dry_run": query_dry_run,
+        "total_bytes_processed": bytes_processed,
+        "portfolio_total": None,
+        "portfolio_total_reason": "action scenarios and currencies are intentionally not summed",
+        "actions": results,
+        "privacy": {
+            "row_level_data_emitted": 0,
+            "identity_data_emitted": 0,
+            "raw_provider_payloads_emitted": 0,
+        },
+    }
+
+
+def write_receipt(path: str | Path, receipt: dict[str, Any]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/platform/tools/cost-monitoring/cost_monitoring/realized_savings.py
+++ b/platform/tools/cost-monitoring/cost_monitoring/realized_savings.py
@@ -163,7 +163,7 @@ def classify_action(
         base.update(state="DATA_GAP", reason="export_freshness_missing")
         return base
     if int(health.get("missing_partition_days", 0)):
-        base.update(state="DATA_GAP", reason="missing_post_window_partitions")
+        base.update(state="DATA_GAP", reason="missing_equal_window_partitions")
         return base
     required_last_day = (action.post_end - timedelta(microseconds=1)).date()
     if latest_usage < required_last_day or latest_partition < required_last_day:
@@ -243,15 +243,19 @@ def _query_sql(actions: list[Action]) -> tuple[str, list[bigquery.QueryParameter
             """)
         health_parts.append(f"""
             SELECT @action_{index} AS action_id,
-                   COUNTIF(day NOT IN (SELECT partition_day FROM partitions)) AS missing_partition_days
-              FROM UNNEST(GENERATE_DATE_ARRAY(DATE(@cutoff_{index}), DATE(@post_end_{index}) - 1)) day
+                   COUNTIF(day NOT IN (SELECT partition_day FROM partition_inventory)) AS missing_partition_days
+              FROM UNNEST(GENERATE_DATE_ARRAY(
+                     DATE(@pre_start_{index}),
+                     DATE(TIMESTAMP_SUB(@post_end_{index}, INTERVAL 1 MICROSECOND)))) day
             """)
     earliest = min(action.pre_start for action in actions)
     latest = max(action.post_end for action in actions)
+    partition_start = earliest.replace(hour=0, minute=0, second=0, microsecond=0)
     parameters.extend(
         [
             bigquery.ScalarQueryParameter("earliest_usage", "TIMESTAMP", earliest),
             bigquery.ScalarQueryParameter("latest_usage", "TIMESTAMP", latest),
+            bigquery.ScalarQueryParameter("partition_start", "TIMESTAMP", partition_start),
             bigquery.ScalarQueryParameter("partition_end", "TIMESTAMP", datetime.now(UTC)),
         ]
     )
@@ -259,13 +263,18 @@ def _query_sql(actions: list[Action]) -> tuple[str, list[bigquery.QueryParameter
     WITH source AS (
       SELECT usage_start_time, _PARTITIONTIME AS partition_time, project.id AS project_id,
              service.description AS service, sku.description AS sku, currency, cost, credits
-        FROM `{CANONICAL_TABLE}`
-       WHERE _PARTITIONTIME >= @earliest_usage
+       FROM `{CANONICAL_TABLE}`
+       WHERE _PARTITIONTIME >= @partition_start
          AND _PARTITIONTIME < @partition_end
          AND usage_start_time >= @earliest_usage
          AND usage_start_time < @latest_usage
     ),
-    partitions AS (SELECT DISTINCT DATE(partition_time) AS partition_day FROM source),
+    partition_inventory AS (
+      SELECT DISTINCT DATE(_PARTITIONTIME) AS partition_day
+        FROM `{CANONICAL_TABLE}`
+       WHERE _PARTITIONTIME >= @partition_start
+         AND _PARTITIONTIME < @partition_end
+    ),
     matched AS ({' UNION ALL '.join(action_parts)}),
     currencies AS (SELECT DISTINCT action_id, currency FROM matched WHERE currency IS NOT NULL),
     periods AS (SELECT 'pre' AS period UNION ALL SELECT 'post'),
@@ -280,7 +289,8 @@ def _query_sql(actions: list[Action]) -> tuple[str, list[bigquery.QueryParameter
     health AS ({' UNION ALL '.join(health_parts)}),
     freshness AS (
       SELECT MAX(DATE(usage_start_time)) AS latest_usage_date,
-             MAX(DATE(partition_time)) AS latest_partition_date FROM source
+             (SELECT MAX(partition_day) FROM partition_inventory) AS latest_partition_date
+        FROM source
     )
     SELECT aggregate_rows.*, health.missing_partition_days,
            freshness.latest_usage_date, freshness.latest_partition_date
@@ -300,12 +310,15 @@ def query_aggregates(
     config.maximum_bytes_billed = MAXIMUM_BYTES_BILLED
     try:
         job = client.query(sql, job_config=config)
-        processed = int(job.total_bytes_processed or 0)
-        if processed > MAXIMUM_BYTES_BILLED:
-            raise RealizedSavingsError("BigQuery dry-run estimate exceeds the 5 GiB safety cap")
         if query_dry_run:
+            processed = int(job.total_bytes_processed or 0)
+            if processed > MAXIMUM_BYTES_BILLED:
+                raise RealizedSavingsError("BigQuery dry-run estimate exceeds the 5 GiB safety cap")
             return [], {}, processed
         raw_rows = list(job.result())
+        processed = int(job.total_bytes_processed or 0)
+        if processed > MAXIMUM_BYTES_BILLED:
+            raise RealizedSavingsError("BigQuery query exceeded the 5 GiB safety cap")
     except RealizedSavingsError:
         raise
     except Exception as exc:
@@ -404,6 +417,59 @@ def verify(
             "raw_provider_payloads_emitted": 0,
         },
     }
+
+
+def receipt_fingerprint(receipt: dict[str, Any]) -> str:
+    """Return a stable hash for a sanitized verdict, excluding run metadata."""
+
+    actions = sorted(receipt.get("actions", []), key=lambda item: str(item.get("action_id", "")))
+    payload = {
+        "schema_version": receipt.get("schema_version"),
+        "verdict": receipt.get("verdict"),
+        "billing_table": receipt.get("billing_table"),
+        "config_sha256": receipt.get("config_sha256"),
+        "window_days": receipt.get("window_days"),
+        "actions": [
+            {
+                "action_id": item.get("action_id"),
+                "cutoff": item.get("cutoff"),
+                "eligible_at": item.get("eligible_at"),
+                "state": item.get("state"),
+                "reason": item.get("reason"),
+                "amounts_by_currency": item.get("amounts_by_currency", {}),
+            }
+            for item in actions
+        ],
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def attach_delivery_state(receipt: dict[str, Any], previous_receipt: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Mark only a new eligible verdict for delivery; ordinary waiting stays silent."""
+
+    fingerprint = receipt_fingerprint(receipt)
+    previous_fingerprint = receipt_fingerprint(previous_receipt) if previous_receipt else None
+    if receipt.get("verdict") == "NOT_ELIGIBLE_YET":
+        transition = "SILENT_WAITING"
+    elif previous_fingerprint == fingerprint:
+        transition = "SILENT_UNCHANGED"
+    else:
+        transition = "DELIVER_NEW_VERDICT"
+    receipt["delivery"] = {"fingerprint": fingerprint, "transition": transition}
+    return receipt
+
+
+def read_previous_receipt(path: str | Path) -> dict[str, Any]:
+    """Load one aggregate-only prior receipt and reject unrelated state."""
+
+    try:
+        receipt = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("Previous realized-savings receipt is unreadable") from exc
+    if not isinstance(receipt, dict) or receipt.get("billing_table") != CANONICAL_TABLE:
+        raise ValueError("Previous realized-savings receipt has an invalid schema")
+    return receipt
 
 
 def write_receipt(path: str | Path, receipt: dict[str, Any]) -> None:

--- a/platform/tools/cost-monitoring/tests/test_realized_savings.py
+++ b/platform/tools/cost-monitoring/tests/test_realized_savings.py
@@ -69,7 +69,7 @@ def test_missing_partitions_are_data_gap():
         eligible_time(item),
     )
     assert result["state"] == "DATA_GAP"
-    assert result["reason"] == "missing_post_window_partitions"
+    assert result["reason"] == "missing_equal_window_partitions"
 
 
 def test_negative_credits_are_reflected_in_net_savings():
@@ -124,14 +124,25 @@ def test_query_has_exact_source_partition_usage_and_five_gib_guards():
     sql, parameters = realized_savings._query_sql([action()])
     names = {parameter.name for parameter in parameters}
     assert f"`{realized_savings.CANONICAL_TABLE}`" in sql
-    assert "_PARTITIONTIME >= @earliest_usage" in sql
+    assert "_PARTITIONTIME >= @partition_start" in sql
+    assert "_PARTITIONTIME >= @earliest_usage" not in sql
     assert "_PARTITIONTIME < @partition_end" in sql
     assert "usage_start_time >= @earliest_usage" in sql
     assert "usage_start_time < @latest_usage" in sql
     assert "cost + IFNULL" in sql
     assert " AS window" not in sql
     assert "STRPOS(LOWER(sku), LOWER(needle))" in sql
-    assert {"earliest_usage", "latest_usage", "partition_end"} <= names
+    assert "DATE(TIMESTAMP_SUB(@post_end_0, INTERVAL 1 MICROSECOND))" in sql
+    assert sql.count(f"`{realized_savings.CANONICAL_TABLE}`") == 2
+    assert {"earliest_usage", "latest_usage", "partition_start", "partition_end"} <= names
+
+
+def test_partition_start_is_utc_midnight_before_exact_usage_start():
+    item = action(cutoff=datetime(2026, 1, 31, 19, 21, 43, tzinfo=UTC))
+    _, parameters = realized_savings._query_sql([item])
+    values = {parameter.name: parameter.value for parameter in parameters if hasattr(parameter, "value")}
+    assert values["earliest_usage"] == datetime(2026, 1, 1, 19, 21, 43, tzinfo=UTC)
+    assert values["partition_start"] == datetime(2026, 1, 1, tzinfo=UTC)
 
 
 class DryRunClient:
@@ -144,6 +155,19 @@ class DryRunClient:
         self.sql = sql
         self.config = job_config
         return SimpleNamespace(total_bytes_processed=self.processed)
+
+
+class LiveQueryJob:
+    total_bytes_processed = None
+
+    def result(self):
+        self.total_bytes_processed = 4321
+        return []
+
+
+class LiveQueryClient:
+    def query(self, sql, job_config):
+        return LiveQueryJob()
 
 
 def test_bounded_query_dry_run_reads_no_rows():
@@ -160,6 +184,15 @@ def test_query_dry_run_fails_if_provider_estimate_exceeds_cap():
     client = DryRunClient(realized_savings.MAXIMUM_BYTES_BILLED + 1)
     with pytest.raises(realized_savings.RealizedSavingsError, match="exceeds the 5 GiB"):
         realized_savings.query_aggregates(client, [action()], query_dry_run=True)
+
+
+def test_live_query_records_final_processed_bytes_after_completion():
+    result_rows, result_health, processed = realized_savings.query_aggregates(
+        LiveQueryClient(), [action()], query_dry_run=False
+    )
+    assert result_rows == []
+    assert result_health == {}
+    assert processed == 4321
 
 
 def test_versioned_config_keeps_secret_unstarted_and_actions_independent():
@@ -179,3 +212,49 @@ def test_versioned_config_keeps_secret_unstarted_and_actions_independent():
     secret = next(item for item in actions if item.action_id == "secret_retention_full_expansion")
     assert secret.cutoff is None
     assert secret.expansion_receipt_sha256 is None
+
+
+def receipt(verdict="REALIZED", state="REALIZED", amount=40):
+    return {
+        "schema_version": 1,
+        "billing_table": realized_savings.CANONICAL_TABLE,
+        "config_sha256": "a" * 64,
+        "window_days": 30,
+        "generated_at": "2026-01-01T00:00:00Z",
+        "verdict": verdict,
+        "actions": [
+            {
+                "action_id": "test-action",
+                "cutoff": "2026-01-01T00:00:00Z",
+                "eligible_at": "2026-03-05T00:00:00Z",
+                "state": state,
+                "reason": "equal_window_reduction_verified",
+                "amounts_by_currency": {"CZK": {"realized_savings": amount}},
+            }
+        ],
+    }
+
+
+def test_waiting_delivery_is_always_silent():
+    current = receipt(verdict="NOT_ELIGIBLE_YET", state="NOT_ELIGIBLE_YET", amount=0)
+    result = realized_savings.attach_delivery_state(current)
+    assert result["delivery"]["transition"] == "SILENT_WAITING"
+
+
+def test_new_eligible_verdict_is_delivered_once():
+    current = receipt()
+    first = realized_savings.attach_delivery_state(current.copy())
+    previous = current.copy()
+    previous["generated_at"] = "2026-01-02T00:00:00Z"
+    previous["total_bytes_processed"] = 123456
+    previous["delivery"] = {"transition": "DELIVER_NEW_VERDICT", "fingerprint": "ignored"}
+    repeated = realized_savings.attach_delivery_state(current.copy(), previous)
+    assert first["delivery"]["transition"] == "DELIVER_NEW_VERDICT"
+    assert repeated["delivery"]["transition"] == "SILENT_UNCHANGED"
+
+
+def test_changed_eligible_verdict_is_delivered_again():
+    previous = receipt(amount=40)
+    current = receipt(verdict="MISMATCH", state="MISMATCH", amount=0)
+    result = realized_savings.attach_delivery_state(current, previous)
+    assert result["delivery"]["transition"] == "DELIVER_NEW_VERDICT"

--- a/platform/tools/cost-monitoring/tests/test_realized_savings.py
+++ b/platform/tools/cost-monitoring/tests/test_realized_savings.py
@@ -1,0 +1,181 @@
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from cost_monitoring import realized_savings
+
+
+def action(**overrides):
+    values = {
+        "action_id": "test-action",
+        "cutoff": datetime(2026, 1, 31, tzinfo=UTC),
+        "project_ids": ("project-a",),
+        "services": ("BigQuery",),
+        "sku_contains": (),
+        "billing_lag_days": 3,
+        "mismatch_tolerance_percent": 5.0,
+        "mismatch_tolerance_absolute": 1.0,
+        "requires_receipted_expansion": False,
+        "expansion_receipt_sha256": None,
+        "parent_scenario": None,
+    }
+    values.update(overrides)
+    return realized_savings.Action(**values)
+
+
+def rows(*values):
+    return [
+        {"action_id": "test-action", "window": window, "currency": currency, "net_cost": amount}
+        for window, currency, amount in values
+    ]
+
+
+def health(**overrides):
+    values = {
+        "latest_usage_date": date(2026, 3, 5),
+        "latest_partition_date": date(2026, 3, 5),
+        "missing_partition_days": 0,
+    }
+    values.update(overrides)
+    return values
+
+
+def eligible_time(item):
+    return item.eligible_at + timedelta(seconds=1)
+
+
+def test_billing_lag_is_not_eligible_and_does_not_infer_savings():
+    item = action()
+    result = realized_savings.classify_action(item, [], {}, item.post_end + timedelta(days=2))
+    assert result["state"] == "NOT_ELIGIBLE_YET"
+    assert result["amounts_by_currency"] == {}
+
+
+def test_incomplete_equal_window_is_data_gap():
+    item = action()
+    result = realized_savings.classify_action(item, rows(("pre", "CZK", 100)), health(), eligible_time(item))
+    assert result["state"] == "DATA_GAP"
+    assert result["reason"] == "incomplete_equal_window_aggregates"
+
+
+def test_missing_partitions_are_data_gap():
+    item = action()
+    result = realized_savings.classify_action(
+        item,
+        rows(("pre", "CZK", 100), ("post", "CZK", 50)),
+        health(missing_partition_days=1),
+        eligible_time(item),
+    )
+    assert result["state"] == "DATA_GAP"
+    assert result["reason"] == "missing_post_window_partitions"
+
+
+def test_negative_credits_are_reflected_in_net_savings():
+    item = action()
+    # Aggregate query semantics are cost + signed credits: 100-20 vs 50-10.
+    result = realized_savings.classify_action(
+        item,
+        rows(("pre", "CZK", 80), ("post", "CZK", 40)),
+        health(),
+        eligible_time(item),
+    )
+    assert result["state"] == "REALIZED"
+    assert result["amounts_by_currency"]["CZK"]["realized_savings"] == 40
+
+
+def test_mixed_currencies_remain_separate_and_have_no_portfolio_total(tmp_path):
+    item = action()
+    result = realized_savings.classify_action(
+        item,
+        rows(
+            ("pre", "CZK", 100),
+            ("post", "CZK", 50),
+            ("pre", "USD", 20),
+            ("post", "USD", 10),
+        ),
+        health(),
+        eligible_time(item),
+    )
+    assert result["state"] == "REALIZED"
+    assert set(result["amounts_by_currency"]) == {"CZK", "USD"}
+
+
+def test_no_material_reduction_is_mismatch():
+    item = action()
+    result = realized_savings.classify_action(
+        item,
+        rows(("pre", "CZK", 100), ("post", "CZK", 99)),
+        health(),
+        eligible_time(item),
+    )
+    assert result["state"] == "MISMATCH"
+
+
+def test_secret_is_ineligible_without_receipted_expansion():
+    item = action(cutoff=None, requires_receipted_expansion=True)
+    result = realized_savings.classify_action(item, [], {}, datetime(2030, 1, 1, tzinfo=UTC))
+    assert result["state"] == "NOT_ELIGIBLE_YET"
+    assert result["reason"] == "receipted_expansion_not_available"
+
+
+def test_query_has_exact_source_partition_usage_and_five_gib_guards():
+    sql, parameters = realized_savings._query_sql([action()])
+    names = {parameter.name for parameter in parameters}
+    assert f"`{realized_savings.CANONICAL_TABLE}`" in sql
+    assert "_PARTITIONTIME >= @earliest_usage" in sql
+    assert "_PARTITIONTIME < @partition_end" in sql
+    assert "usage_start_time >= @earliest_usage" in sql
+    assert "usage_start_time < @latest_usage" in sql
+    assert "cost + IFNULL" in sql
+    assert " AS window" not in sql
+    assert "STRPOS(LOWER(sku), LOWER(needle))" in sql
+    assert {"earliest_usage", "latest_usage", "partition_end"} <= names
+
+
+class DryRunClient:
+    def __init__(self, processed):
+        self.processed = processed
+        self.sql = None
+        self.config = None
+
+    def query(self, sql, job_config):
+        self.sql = sql
+        self.config = job_config
+        return SimpleNamespace(total_bytes_processed=self.processed)
+
+
+def test_bounded_query_dry_run_reads_no_rows():
+    client = DryRunClient(1234)
+    result_rows, result_health, processed = realized_savings.query_aggregates(client, [action()], query_dry_run=True)
+    assert result_rows == []
+    assert result_health == {}
+    assert processed == 1234
+    assert client.config.dry_run is True
+    assert client.config.maximum_bytes_billed == 5 * 1024 * 1024 * 1024
+
+
+def test_query_dry_run_fails_if_provider_estimate_exceeds_cap():
+    client = DryRunClient(realized_savings.MAXIMUM_BYTES_BILLED + 1)
+    with pytest.raises(realized_savings.RealizedSavingsError, match="exceeds the 5 GiB"):
+        realized_savings.query_aggregates(client, [action()], query_dry_run=True)
+
+
+def test_versioned_config_keeps_secret_unstarted_and_actions_independent():
+    config = Path(__file__).resolve().parents[1] / "config/realized-savings.yml"
+    actions, digest = realized_savings.load_actions(config)
+    assert len(digest) == 64
+    assert {item.action_id for item in actions} >= {
+        "gcs_cerano",
+        "gcs_denatura",
+        "bq07_monitor_pause",
+        "run01_v1_pause",
+        "orphan_cloud_armor",
+        "legacy_admin_lb",
+        "ruzovyslon_offboarding",
+        "secret_retention_full_expansion",
+    }
+    secret = next(item for item in actions if item.action_id == "secret_retention_full_expansion")
+    assert secret.cutoff is None
+    assert secret.expansion_receipt_sha256 is None


### PR DESCRIPTION
## Outcome

Implements the repository-owned equal-window verifier tracked by
`merglbot-core/monitoring#587` next to the existing production cost monitor and
its already-authorized billing-export WIF identity.

## Safety contract

- canonical standard export only: `merglbot-platform-prd.billing_export_euw1`;
- one aggregate query with UTC-day `_PARTITIONTIME` and exact usage-time bounds;
- independent full-window partition inventory, including terminal partial days;
- hard `5 GiB` `maximum_bytes_billed` cap;
- exact equal 30-day pre/post windows plus per-action billing lag;
- currencies remain separate and no action/portfolio grand total is calculated;
- sanitized aggregate receipt only: no billing rows, identities, or raw provider payloads;
- Secret Manager remains `NOT_ELIGIBLE_YET` until both the receipted full-expansion timestamp and immutable receipt SHA-256 are committed;
- the unreceipted 2026-08-07 bulk Secret destruction is excluded.

The weekly workflow has no Slack/issue mutation path. It restores only the last
non-dry-run aggregate receipt: ordinary waiting and unchanged verdicts stay
silent, while each new `REALIZED`, `DATA_GAP`, or `MISMATCH` state produces one
workflow annotation and a 90-day aggregate artifact. Dry runs cannot replace
the durable comparison state. The authorized FinOps closeout consumer links a
final aggregate artifact fingerprint to the closed audit issue.

## Verification

- cost-monitoring tests: `58/58 PASS`;
- repository unittest discovery after final main sync: `53/53 PASS`;
- scoped Ruff, Black, actionlint and diff checks: `PASS`;
- bounded provider dry-run: `PASS`, rows read `0`, estimated bytes
  `133346472 / 5368709120`, receipt SHA-256
  `c6247511b1a902029d24d637fe8e70563039f8f5da17b06b6010c042d4bc0f2b`;
- dry-run verdict: `NOT_ELIGIBLE_YET`, 8/8 actions intentionally non-final,
  delivery transition `SILENT_WAITING`, all privacy counters `0`.

No API enablement, secret value read, raw logs/payloads, identity output, GCS
object listing, Terraform action, Cloud Run rightsizing, admin/bypass, or force.

Tracks merglbot-core/monitoring#587. The tracker remains open until an eligible
equal-window verdict and final aggregate receipt linkage exist.
