### PR TITLE
docs: verify the EPIC #23 closeout instead of re-dating it

### DIFF
--- a/docs/LESSONS_LEARNED_EPIC23.md
+++ b/docs/LESSONS_LEARNED_EPIC23.md
@@ -1,12 +1,17 @@
 ---
 title: "Lessons Learned – EPIC #23 (MERGLBOT Standards Implementation)"
-summary: "Shrnutí klíčových poučení a best practices z implementace MERGLBOT standardů (security, bot-driven, release) v rámci EPIC #23. Změny promítnuty do tréninkových materiálů a projektových pravidel."
+summary: "Shrnutí klíčových poučení a best practices z implementace MERGLBOT standardů (security, bot-driven, release) v rámci EPIC #23. Změny promítnuty do tréninkových materiálů a projektových pravidel. Historický záznam uzavřeného EPICu; závěry ověřeny 2026-08-14."
 owner: "platform"
-last_updated: 2025-10-12
-status: stable
+last_updated: 2026-08-14
+status: historical
 ---
 
 # Lessons Learned – EPIC #23
+
+> **Historický záznam uzavřeného EPICu (říjen 2025).** Obsah popisuje stav a rozhodnutí té doby a
+> záměrně se nepřepisuje. Co se od té doby stalo s jeho závazky, je shrnuté v sekci
+> [Ověření závěrů (2026-08-14)](#ověření-závěrů-2026-08-14) na konci — tam se dívej,
+> pokud chceš vědět, co z EPICu doopravdy dojelo do estate.
 
 ## 1) Security & Git Hygiene
 - Audit-before-rotate: Před rotací tajemství vždy audit logů (zachování důkazů)
@@ -58,6 +63,48 @@ status: stable
 ---
 
 # Next Steps
+
+*(Původní seznam z října 2025; stav k 2026-08-14 je v tabulce níže.)*
+
 - Přenést vybrané části do kanonické dokumentace v `merglbot-public/docs` (MERGLBOT_*.md)
 - Nastavit CODEOWNERS pro `training/security/certification-quiz-answers.md`
 - Přidat GitHub Actions check na grep `--force --all` v markdown příkladech (lint)
+
+---
+
+# Ověření závěrů (2026-08-14)
+
+Tenhle dokument je lessons-learned záznam, ne živý runbook — jeho hodnota není v tom, aby měl
+čerstvé datum, ale v tom, aby se dalo dohledat, co z něj skutečně dojelo. Následující tabulka je
+výsledek revize proti živému stavu (klon `merglbot-core/github` na `main`, klon
+`merglbot-public/docs` na `main`, oboje čerstvě staženo 2026-08-14).
+
+## Implemented Changes — všechny soubory existují
+
+Všech sedm souborů z odstavce *Implemented Changes* je v tomto repozitáři přítomných
+(`training/security/01-gitignore-security.md`, `certification-quiz.md`,
+`certification-quiz-answers.md`, `03-iam-access-control.md`,
+`training/quick-start/new-developer-day1.md`, `training/README.md`,
+`training/quick-reference/ai-safety-cheatsheet.md`). Rozdělení kvízu a jeho odpovědí do dvou
+souborů tedy drží.
+
+## Doporučení pro MERGLBOT (globální) — splněno
+
+| Doporučení | Stav | Kde to dnes žije |
+|---|---|---|
+| Zákaz kombinace `--force` + `--all` u `git push` v AI policy | ✅ splněno | `merglbot-public/docs/MERGLBOT_SECURITY_INCIDENT_RESPONSE.md` (explicitní NEVER-příklad) |
+| „Audit logs BEFORE rotation" v Security playbooku | ✅ splněno | tamtéž, § *Audit-before-rotate (MUST)*; changelog dokumentu má řádek „2025-10-12: Přidán audit-before-rotate a guardrails k force push (EPIC #23)" |
+| `su-exec` pattern + zákaz `chown /etc/*` v container guidelines | ✅ splněno | `merglbot-public/docs/MERGLBOT_CONTAINER_HARDENING.md` (a je vidět i v `MERGLBOT_TECHNOLOGY_INDEX.md`) |
+
+## Next Steps — dva ze tří hotové
+
+| Next step | Stav | Důkaz |
+|---|---|---|
+| Přenést části do kanonické dokumentace | ✅ hotovo | viz tabulka výše — vznikl kvůli tomu celý `MERGLBOT_SECURITY_INCIDENT_RESPONSE.md` |
+| GitHub Actions lint na nebezpečný force-push příklad v markdownu | ✅ hotovo | `.github/workflows/markdown-danger-lint.yml` — na každém PR grepuje změněné `.md` a failuje, pokud najde ten vzor bez varovného kontextu (`never` / `do not` / `nepoužívej`) |
+| Dedikovaný CODEOWNERS řádek pro `certification-quiz-answers.md` | ⚠️ nezaveden | `.github/CODEOWNERS` obsahuje jediné pravidlo `* @milan-merglevsky`. Soubor je tím sice pokrytý, ale wildcardem — samostatné pravidlo, které by přežilo případné zúžení `*`, tam není. Nízká priorita, dokud je repo single-maintainer. |
+
+Metoda: existence souborů ověřena přímo v klonech (`rg --files`, ne `gh search code` — ten v tomhle
+estate vrací prázdno i pro positive control, takže se z něj nedá číst absence). U hledání v
+kanonických docs byl použit positive control (`rg -c -i 'wif'` → 135 zásahů), aby prázdný výsledek
+u hledaného vzoru znamenal opravdovou absenci, a ne rozbitý dotaz.


### PR DESCRIPTION
Docs keeper hlásil `docs/LESSONS_LEARNED_EPIC23.md` jako freshness nález (`2025-10-12 older than 180d`). Je to ale lessons-learned záznam uzavřeného EPICu — jeho hodnota není čerstvé datum, ale dohledatelná odpověď na otázku, jestli z něj něco doopravdy dojelo. Dokument je proto označen `status: historical` a dostal ověřovací sekci; původní text zůstal beze změny.

## Co bylo ověřeno a čím (2026-08-14)

Proti čerstvým klonům tohoto repa a `merglbot-public/docs`:

**Implemented Changes** — všech sedm souborů existuje, včetně rozdělení `certification-quiz.md` a `certification-quiz-answers.md`.

**Doporučení pro MERGLBOT (globální)** — všechna tři jsou v kanonické dokumentaci. Zákaz nebezpečné kombinace flagů u `git push` i krok „audit logs BEFORE rotation" žijí v `MERGLBOT_SECURITY_INCIDENT_RESPONSE.md`, jehož vlastní changelog má řádek „2025-10-12: Přidán audit-before-rotate a guardrails k force push (EPIC #23)". `su-exec` pattern je v `MERGLBOT_CONTAINER_HARDENING.md`.

**Next Steps — dva ze tří hotové:**

- Přenesení do kanonické dokumentace: ✅ hotovo (viz výše, vznikl kvůli tomu celý incident-response dokument).
- Actions lint na nebezpečný force-push příklad v markdownu: ✅ hotovo — `.github/workflows/markdown-danger-lint.yml` přesně to dělá.
- Dedikovaný CODEOWNERS řádek pro `certification-quiz-answers.md`: ⚠️ **nezaveden.** `.github/CODEOWNERS` má jediné pravidlo `* @milan-merglevsky`. Soubor je tím pokrytý, ale wildcardem, ne pravidlem, které by přežilo zúžení `*`. Zapsáno jako otevřené, nízká priorita, dokud je repo single-maintainer.

## Metoda

Existence souborů ověřena přímo v klonech (`rg --files`), ne přes `gh search code` — ten v tomhle estate vrací prázdno i pro positive control, takže se z něj nedá číst absence. U hledání v kanonických docs byl použit positive control (`rg -c -i 'wif'` → 135 zásahů), aby prázdný výsledek u hledaného vzoru znamenal opravdovou absenci.

## Vědomě odložené

Nic. Datum posunuto na 2026-08-14 až po téhle revizi — tvrdí přesně to, co se stalo: k tomuto dni někdo závěry EPICu ověřil proti živému stavu.

## Archivace

Nenavrhuji. Dokument nepopisuje retirovaný systém a jeho závěry jsou dodnes platné a v estate implementované; `status: historical` + ověřovací sekce je přesnější než odsun do archivu.
