### PR TITLE
fix(gate): ban inline source maps, not just files named *.map

### DIFF
--- a/scripts/frontend-artifact-gate/gate.mjs
+++ b/scripts/frontend-artifact-gate/gate.mjs
@@ -201,12 +201,24 @@ function main() {
   // Found by merglbot-core/merglbot-admin#744 review, which closed the same hole in admin's
   // separate build-side gate; this is the shared half.
   //
-  // The matcher is anchored to a COMMENT OPENER, not to the bare word. The spec forms are `//#`
-  // and `//@` (JS) and `/*#` (CSS, and JS block comments), so requiring one of them is what keeps
-  // ordinary content — a banner string, a variable named sourceMappingURL, a URL in a data table —
-  // from failing a build. A false RED here is not a harmless over-catch: it blocks a release, and
-  // the fix everyone reaches for is to stop trusting the check.
-  const SOURCE_MAPPING_DIRECTIVE = /(?:\/\/|\/\*)\s*[#@]\s*sourceMappingURL\s*=/
+  // The matcher is anchored to a comment opener AT THE START OF A LINE. Both halves are needed and
+  // each was learned the hard way:
+  //
+  //   * the bare word matches `const sourceMappingURL = …`;
+  //   * a comment opener alone still matches `const banner = "docs: //# sourceMappingURL=x"`,
+  //     because `//` can sit inside a string literal. Bundler runtime code and source-map tooling
+  //     quote this syntax routinely.
+  //
+  // A false RED here is not a harmless over-catch: it blocks a release, and the fix everyone
+  // reaches for is to stop trusting the check.
+  //
+  // Line-start is the discriminator that costs nothing, because a REAL inline directive is always
+  // emitted on its own line at the end of the file — that is how every bundler writes it.
+  //
+  // Known residual, and deliberate: a template literal holding the directive at line start still
+  // trips this, and a hand-placed mid-line directive would be missed. Neither is a shape a bundler
+  // emits, and the first fails safe while the second is not reachable by the setting this guards.
+  const SOURCE_MAPPING_DIRECTIVE = /^[ \t]*(?:\/\/|\/\*)\s*[#@]\s*sourceMappingURL\s*=/m
   //
   // 🔴 The scanned set is DERIVED from allowed_extensions, minus the types that are not text.
   // A second hand-kept list of "scannable" extensions is the shape that goes stale: the day a

--- a/scripts/frontend-artifact-gate/gate.mjs
+++ b/scripts/frontend-artifact-gate/gate.mjs
@@ -12,6 +12,11 @@
 //     (Vite's default is `sourcemap: false` and no vite.config.js overrides it), so this is pure
 //     regression cover: it goes red the day someone sets `build.sourcemap: true`.
 //
+//   * A `sourceMappingURL` directive in the BYTES of a served text file — the other half of that
+//     ban. `sourcemap: 'inline'` writes no `.map` at all, so the filename rule above sees a clean
+//     build while the full source rides inside the bundle. Filenames catch `'hidden'`, the byte
+//     scan catches `'inline'`; neither is sufficient alone.
+//
 //   * Extension allowlist, NOT a denylist. "A new public artifact type appears" is the audit's own
 //     wording, and a denylist is open-by-default — it can only ever ban the types someone thought
 //     of. Filenames are content-hashed here, so a type-based rule never churns on a rebuild.
@@ -174,6 +179,34 @@ function main() {
       violations.push(
         `${f} has undeclared extension "${ext || '(none)'}" — a new public artifact TYPE must be ` +
           'added to allowed_extensions deliberately, with review',
+      )
+    }
+  }
+
+  // 🔴 A source map does not have to be a FILE, so the `**/*.map` glob above is only half the ban.
+  //
+  // `build.sourcemap: 'inline'` appends the whole map, base64-encoded, into the bundle itself as a
+  // `sourceMappingURL=data:` comment. No `.map` lands on disk, so dist/ looks exactly like a clean
+  // build while the original sources ship inside a file that is already public. `'hidden'` is the
+  // mirror case: the file exists and the comment does not.
+  //
+  // That makes this the check the header's own promise depends on — "it goes red the day someone
+  // sets build.sourcemap: true" was true for `true` and false for `'inline'`, which is the setting
+  // a person reaches for when they want maps without extra requests.
+  //
+  // Text types only, and `.html` is in the list on purpose: an inline-script build shape puts the
+  // directive inside index.html, where a scan restricted to script extensions would never look.
+  // Found by merglbot-core/merglbot-admin#744 review, which closed the same hole in admin's
+  // separate build-side gate; this is the shared half.
+  const SOURCE_MAPPING_DIRECTIVE = /[#@]\s*sourceMappingURL\s*=/
+  const SCANNABLE_TEXT = /\.(?:js|mjs|cjs|css|html)$/i
+  for (const f of files.filter((f) => SCANNABLE_TEXT.test(f))) {
+    if (SOURCE_MAPPING_DIRECTIVE.test(readFileSync(join(dist, f), 'utf8'))) {
+      // Names the FILE, never the directive's value — that value IS the map.
+      violations.push(
+        `${f} carries a sourceMappingURL directive, so its source travels with it to whoever the ` +
+          "bundle is served to. Set build.sourcemap=false; 'inline' and 'hidden' both defeat the " +
+          '**/*.map filename ban.',
       )
     }
   }

--- a/scripts/frontend-artifact-gate/gate.mjs
+++ b/scripts/frontend-artifact-gate/gate.mjs
@@ -218,7 +218,11 @@ function main() {
   // Known residual, and deliberate: a template literal holding the directive at line start still
   // trips this, and a hand-placed mid-line directive would be missed. Neither is a shape a bundler
   // emits, and the first fails safe while the second is not reachable by the setting this guards.
-  const SOURCE_MAPPING_DIRECTIVE = /^[ \t]*(?:\/\/|\/\*)\s*[#@]\s*sourceMappingURL\s*=/m
+  // `[ \t]*` throughout rather than `\s*`: `\s` matches a NEWLINE, so `\s*` would let the pattern
+  // span lines and treat a bare `//` followed by a line starting `# sourceMappingURL=` as one
+  // directive. A directive lives on a single line by construction, so the narrower class is both
+  // more correct and cheaper.
+  const SOURCE_MAPPING_DIRECTIVE = /^[ \t]*(?:\/\/|\/\*)[ \t]*[#@][ \t]*sourceMappingURL[ \t]*=/m
   //
   // 🔴 The scanned set is DERIVED from allowed_extensions, minus the types that are not text.
   // A second hand-kept list of "scannable" extensions is the shape that goes stale: the day a

--- a/scripts/frontend-artifact-gate/gate.mjs
+++ b/scripts/frontend-artifact-gate/gate.mjs
@@ -45,6 +45,10 @@ const EXIT_OK = 0
 const EXIT_VIOLATION = 1
 const EXIT_CANNOT_CONCLUDE = 2
 
+// Image types, used twice: the 5a content-hash freeze, and (minus .svg) the not-text exclusion for
+// the source-map byte scan. One list so the two cannot drift apart.
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.ico', '.avif'])
+
 function fail(message) {
   console.error(`✖ ${message}`)
 }
@@ -194,13 +198,39 @@ function main() {
   // sets build.sourcemap: true" was true for `true` and false for `'inline'`, which is the setting
   // a person reaches for when they want maps without extra requests.
   //
-  // Text types only, and `.html` is in the list on purpose: an inline-script build shape puts the
-  // directive inside index.html, where a scan restricted to script extensions would never look.
   // Found by merglbot-core/merglbot-admin#744 review, which closed the same hole in admin's
   // separate build-side gate; this is the shared half.
-  const SOURCE_MAPPING_DIRECTIVE = /[#@]\s*sourceMappingURL\s*=/
-  const SCANNABLE_TEXT = /\.(?:js|mjs|cjs|css|html)$/i
-  for (const f of files.filter((f) => SCANNABLE_TEXT.test(f))) {
+  //
+  // The matcher is anchored to a COMMENT OPENER, not to the bare word. The spec forms are `//#`
+  // and `//@` (JS) and `/*#` (CSS, and JS block comments), so requiring one of them is what keeps
+  // ordinary content — a banner string, a variable named sourceMappingURL, a URL in a data table —
+  // from failing a build. A false RED here is not a harmless over-catch: it blocks a release, and
+  // the fix everyone reaches for is to stop trusting the check.
+  const SOURCE_MAPPING_DIRECTIVE = /(?:\/\/|\/\*)\s*[#@]\s*sourceMappingURL\s*=/
+  //
+  // 🔴 The scanned set is DERIVED from allowed_extensions, minus the types that are not text.
+  // A second hand-kept list of "scannable" extensions is the shape that goes stale: the day a
+  // caller adds `.svg` (or `.json`, or `.xml`) to its contract, a fixed list silently stops
+  // covering the artifact it just approved — and svg in particular is markup that can carry a
+  // script. Deriving it means a newly allowed text type is scanned the moment it is allowed.
+  //
+  // Files outside allowed_extensions are already a violation above, so nothing is lost by
+  // scanning only allowed ones.
+  // 🔴 `.svg` is deliberately NOT here even though it is an image for the 5a freeze below. SVG is
+  // markup: it can hold a <script>, and therefore a directive. Classifying it by what it is used
+  // for rather than by what it is made of would skip exactly the allowed type most likely to
+  // carry executable text.
+  const NOT_TEXT = new Set([
+    ...[...IMAGE_EXTENSIONS].filter((e) => e !== '.svg'),
+    '.woff', '.woff2', '.ttf', '.otf', '.eot',
+    '.mp4', '.webm', '.mp3', '.wav',
+    '.pdf', '.zip', '.gz', '.br', '.wasm',
+  ])
+  const scannable = files.filter((f) => {
+    const ext = extname(f).toLowerCase()
+    return allowed.has(ext) && !NOT_TEXT.has(ext)
+  })
+  for (const f of scannable) {
     if (SOURCE_MAPPING_DIRECTIVE.test(readFileSync(join(dist, f), 'utf8'))) {
       // Names the FILE, never the directive's value — that value IS the map.
       violations.push(
@@ -215,11 +245,10 @@ function main() {
   const inv = baseline.image_inventory
   if (inv && inv.mode === 'frozen') {
     const known = new Map(inv.entries.map((e) => [e.sha256, e]))
-    const imageExts = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.ico', '.avif'])
     const roots = [dist, ...(extraAssets && existsSync(extraAssets) ? [extraAssets] : [])]
     for (const root of roots) {
       for (const f of walk(root)) {
-        if (!imageExts.has(extname(f).toLowerCase())) continue
+        if (!IMAGE_EXTENSIONS.has(extname(f).toLowerCase())) continue
         const digest = sha256(join(root, f))
         if (!known.has(digest)) {
           violations.push(

--- a/tests/test_frontend_artifact_gate.py
+++ b/tests/test_frontend_artifact_gate.py
@@ -162,6 +162,60 @@ class FrontendArtifactGateTests(unittest.TestCase):
         rc, out = self.run_gate(files)
         self.assertEqual(EXIT_OK, rc, out)
 
+    def test_the_scan_does_not_fire_on_the_bare_word_or_an_unanchored_hash(self) -> None:
+        """False REDs are not a harmless over-catch: they block a release, and the fix everyone
+        reaches for is to stop trusting the check.
+
+        The directive's spec forms open a COMMENT (`//#`, `//@`, `/*#`). Content that merely
+        contains the word — a banner string, a variable, a URL in a data table — must not fail.
+        """
+        files = self.clean_dist()
+        files["assets/index-abc123.js"] = (
+            b"const sourceMappingURL='x';\n"
+            b"const banner='@sourceMappingURL=not-a-comment';\n"
+            b'const doc="see #sourceMappingURL= in the spec";\n'
+        )
+        rc, out = self.run_gate(files)
+        self.assertEqual(EXIT_OK, rc, out)
+
+    def test_the_scanned_set_follows_allowed_extensions_and_covers_svg(self) -> None:
+        """SVG is an image by use and MARKUP by construction — it can hold a <script>, and so a
+        directive. The scanned set is derived from allowed_extensions rather than hand-kept, so a
+        type is covered the moment a caller approves it.
+
+        Both halves in one case: the same .svg passes while clean and fails while carrying the
+        directive, so this cannot be satisfied by a gate that rejects every svg.
+        """
+        baseline = json.loads(json.dumps(BASELINE))
+        baseline["allowed_extensions"] = baseline["allowed_extensions"] + [".svg"]
+        clean_svg = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+
+        files = self.clean_dist()
+        files["assets/logo-abc123.svg"] = clean_svg
+        rc, out = self.run_gate(files, baseline=baseline)
+        self.assertEqual(EXIT_OK, rc, out)
+
+        files["assets/logo-abc123.svg"] = (
+            b'<svg xmlns="http://www.w3.org/2000/svg"><script>0\n'
+            b"//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==\n"
+            b"</script></svg>"
+        )
+        rc, out = self.run_gate(files, baseline=baseline)
+        self.assertEqual(EXIT_VIOLATION, rc, out)
+        self.assertIn("logo-abc123.svg", out)
+
+    def test_a_png_is_not_read_as_text_by_the_scan(self) -> None:
+        """The other side of deriving the set: binary types stay out, so a byte sequence in an
+        image cannot produce a false violation."""
+        files = self.clean_dist()
+        files["assets/pixel-abc123.png"] = (
+            b"\x89PNG\r\n\x1a\n//# sourceMappingURL=data:application/json;base64,eyJ2IjoxfQ=="
+        )
+        baseline = json.loads(json.dumps(BASELINE))
+        baseline["image_inventory"] = {"mode": "open"}
+        rc, out = self.run_gate(files, baseline=baseline)
+        self.assertEqual(EXIT_OK, rc, out)
+
     def test_a_dotenv_file_is_a_violation(self) -> None:
         files = self.clean_dist()
         # Content is irrelevant — the rule matches on the FILENAME. Deliberately not shaped like a

--- a/tests/test_frontend_artifact_gate.py
+++ b/tests/test_frontend_artifact_gate.py
@@ -174,9 +174,40 @@ class FrontendArtifactGateTests(unittest.TestCase):
             b"const sourceMappingURL='x';\n"
             b"const banner='@sourceMappingURL=not-a-comment';\n"
             b'const doc="see #sourceMappingURL= in the spec";\n'
+            # 🔴 The case the comment-opener anchor alone did NOT cover: `//` inside a STRING.
+            # Source-map tooling and bundler runtime code quote this syntax routinely, so this is
+            # the shape that would have falsely blocked a release.
+            b'const quoted="docs: //# sourceMappingURL=example";\n'
+            b"const block='/*# sourceMappingURL=also-quoted */';\n"
         )
         rc, out = self.run_gate(files)
         self.assertEqual(EXIT_OK, rc, out)
+
+    def test_a_real_directive_at_line_start_is_still_caught_after_the_anchor(self) -> None:
+        """The counterpart to the case above — without it, tightening the matcher to line-start
+        could be satisfied by a matcher that never fires at all.
+
+        Line-start is what every bundler emits: the directive goes on its own line at end of file.
+        """
+        files = self.clean_dist()
+        files["assets/index-abc123.js"] = (
+            b'const quoted="docs: //# sourceMappingURL=example";\n'
+            b"//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==\n"
+        )
+        rc, out = self.run_gate(files)
+        self.assertEqual(EXIT_VIOLATION, rc, out)
+        self.assertIn("index-abc123.js", out)
+
+    def test_an_indented_directive_is_caught(self) -> None:
+        """Leading whitespace is allowed before the opener: CSS maps and HTML-embedded scripts are
+        commonly indented, and requiring column zero would miss them."""
+        files = self.clean_dist()
+        files["assets/index-abc123.js"] = (
+            b"console.log(1)\n"
+            b"    //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==\n"
+        )
+        rc, out = self.run_gate(files)
+        self.assertEqual(EXIT_VIOLATION, rc, out)
 
     def test_the_scanned_set_follows_allowed_extensions_and_covers_svg(self) -> None:
         """SVG is an image by use and MARKUP by construction — it can hold a <script>, and so a

--- a/tests/test_frontend_artifact_gate.py
+++ b/tests/test_frontend_artifact_gate.py
@@ -209,21 +209,18 @@ class FrontendArtifactGateTests(unittest.TestCase):
         rc, out = self.run_gate(files)
         self.assertEqual(EXIT_VIOLATION, rc, out)
 
-    def test_the_scanned_set_follows_allowed_extensions_and_covers_svg(self) -> None:
-        """SVG is an image by use and MARKUP by construction — it can hold a <script>, and so a
-        directive. The scanned set is derived from allowed_extensions rather than hand-kept, so a
-        type is covered the moment a caller approves it.
+    def test_svg_is_byte_scanned_even_though_it_is_an_image_type(self) -> None:
+        """SVG is an image by USE and markup by CONSTRUCTION — it can hold a <script>, and so a
+        directive. It is therefore in IMAGE_EXTENSIONS for the 5a freeze and deliberately NOT in
+        NOT_TEXT for this scan.
 
-        Both halves in one case: the same .svg passes while clean and fails while carrying the
-        directive, so this cannot be satisfied by a gate that rejects every svg.
+        Both directions in one case: the same .svg passes while clean and fails while carrying the
+        directive, so a gate that simply rejected every svg would not satisfy it.
         """
-        baseline = json.loads(json.dumps(BASELINE))
-        baseline["allowed_extensions"] = baseline["allowed_extensions"] + [".svg"]
         clean_svg = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
-
         files = self.clean_dist()
         files["assets/logo-abc123.svg"] = clean_svg
-        rc, out = self.run_gate(files, baseline=baseline)
+        rc, out = self.run_gate(files)
         self.assertEqual(EXIT_OK, rc, out)
 
         files["assets/logo-abc123.svg"] = (
@@ -231,9 +228,61 @@ class FrontendArtifactGateTests(unittest.TestCase):
             b"//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==\n"
             b"</script></svg>"
         )
-        rc, out = self.run_gate(files, baseline=baseline)
+        rc, out = self.run_gate(files)
         self.assertEqual(EXIT_VIOLATION, rc, out)
         self.assertIn("logo-abc123.svg", out)
+
+    def test_the_scanned_set_is_DERIVED_from_allowed_extensions(self) -> None:
+        """🔴 The property the case above cannot prove.
+
+        `.svg` is already in this suite's BASELINE, so appending it and watching the scan work is
+        satisfied just as well by a hard-coded scannable list that happens to contain `.svg` — a
+        test driven by the very constant it is checking. The first version of this case did exactly
+        that and proved nothing about derivation.
+
+        `.xml` is genuinely absent from BASELINE and absent from NOT_TEXT, so it can only enter the
+        scannable set by being derived from allowed_extensions. Three states pin it:
+
+          1. not allowed at all  → rejected as an undeclared TYPE (and never reaches the scan);
+          2. allowed and clean   → passes;
+          3. allowed and dirty   → caught by the byte scan.
+
+        State 3 is only reachable through derivation. Replace the derivation with a fixed list and
+        it fails.
+        """
+        dirty = (
+            b"<data>\n"
+            b"//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==\n"
+            b"</data>"
+        )
+        self.assertNotIn(".xml", BASELINE["allowed_extensions"], "fixture would be vacuous")
+
+        files = self.clean_dist()
+        files["assets/data-abc123.xml"] = dirty
+        rc, out = self.run_gate(files)
+        self.assertEqual(EXIT_VIOLATION, rc, out)
+        self.assertIn(".xml", out, "not yet allowed: rejected as a TYPE, before any scan")
+
+        allowing = json.loads(json.dumps(BASELINE))
+        allowing["allowed_extensions"] = allowing["allowed_extensions"] + [".xml"]
+
+        files["assets/data-abc123.xml"] = b"<data></data>"
+        rc, out = self.run_gate(files, baseline=allowing)
+        self.assertEqual(EXIT_OK, rc, out)
+
+        files["assets/data-abc123.xml"] = dirty
+        rc, out = self.run_gate(files, baseline=allowing)
+        self.assertEqual(EXIT_VIOLATION, rc, out)
+        self.assertIn("sourceMappingURL", out)
+        self.assertIn("data-abc123.xml", out)
+
+    def test_the_pattern_cannot_span_a_newline(self) -> None:
+        """`\\s` matches a newline, so `\\s*` would join a bare `//` line to the next line and read
+        the pair as one directive. A real directive lives on a single line by construction."""
+        files = self.clean_dist()
+        files["assets/index-abc123.js"] = b"//\n# sourceMappingURL=data:application/json;base64,e30=\n"
+        rc, out = self.run_gate(files)
+        self.assertEqual(EXIT_OK, rc, out)
 
     def test_a_png_is_not_read_as_text_by_the_scan(self) -> None:
         """The other side of deriving the set: binary types stay out, so a byte sequence in an

--- a/tests/test_frontend_artifact_gate.py
+++ b/tests/test_frontend_artifact_gate.py
@@ -109,6 +109,59 @@ class FrontendArtifactGateTests(unittest.TestCase):
         self.assertEqual(EXIT_VIOLATION, rc, out)
         self.assertIn("index-abc123.js.map", out)
 
+    def test_an_inline_source_map_is_a_violation_even_with_no_map_file(self) -> None:
+        """The half the `**/*.map` glob cannot see.
+
+        `build.sourcemap: 'inline'` writes no `.map` at all — it appends the whole map, base64
+        encoded, into the bundle. dist/ then looks exactly like a clean build while the original
+        sources ship inside a file that is already public.
+
+        The assertion that there is no `.map` in the fixture is load-bearing: without it this test
+        could pass on the filename rule and prove nothing about the byte scan.
+        """
+        files = self.clean_dist()
+        files["assets/index-abc123.js"] = (
+            b"console.log(1)\n"
+            b"//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==\n"
+        )
+        self.assertFalse([f for f in files if f.endswith(".map")])
+        rc, out = self.run_gate(files)
+        self.assertEqual(EXIT_VIOLATION, rc, out)
+        self.assertIn("sourceMappingURL", out)
+        self.assertIn("index-abc123.js", out)
+
+    def test_an_inline_source_map_inside_index_html_is_a_violation(self) -> None:
+        """`.html` is a served text type, and an inline-script build shape puts the directive
+        there — where a scan restricted to script extensions would never look."""
+        files = self.clean_dist()
+        files["index.html"] = (
+            b"<!doctype html><script>console.log(1)\n"
+            b"//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==\n"
+            b"</script>"
+        )
+        rc, out = self.run_gate(files)
+        self.assertEqual(EXIT_VIOLATION, rc, out)
+        self.assertIn("index.html", out)
+
+    def test_a_hidden_source_map_is_still_caught_by_the_filename_rule(self) -> None:
+        """The mirror case, pinned so the two halves are not confused for one another:
+        `sourcemap: 'hidden'` emits the FILE and omits the directive."""
+        files = self.clean_dist()
+        files["assets/index-abc123.js.map"] = b'{"version":3}'
+        self.assertNotIn(b"sourceMappingURL", files["assets/index-abc123.js"])
+        rc, out = self.run_gate(files)
+        self.assertEqual(EXIT_VIOLATION, rc, out)
+
+    def test_the_byte_scan_does_not_fire_on_an_ordinary_bundle(self) -> None:
+        """Both halves. A scan that flagged every JS file would satisfy the three tests above and
+        fail every real build — only this one tells them apart."""
+        files = self.clean_dist()
+        files["assets/index-abc123.js"] = (
+            b"const sourceMappingURL='not a directive';console.log(sourceMappingURL)"
+        )
+        rc, out = self.run_gate(files)
+        self.assertEqual(EXIT_OK, rc, out)
+
     def test_a_dotenv_file_is_a_violation(self) -> None:
         files = self.clean_dist()
         # Content is irrelevant — the rule matches on the FILENAME. Deliberately not shaped like a


### PR DESCRIPTION
The gate's own header promises: *"it goes red the day someone sets `build.sourcemap: true`"*. That is true for `true` and **false for `'inline'`** — which is the setting a person reaches for when they want maps without the extra requests.

## Co ta díra je

`build.sourcemap: 'inline'` **nevytvoří žádný `.map`**. Připojí celou mapu base64 zakódovanou dovnitř bundlu jako `sourceMappingURL=data:` komentář. `dist/` pak vypadá přesně jako čistý build, zatímco původní zdroje cestují uvnitř souboru, který je už tak veřejný.

`'hidden'` je zrcadlový případ: soubor ano, komentář ne.

| nastavení | `.map` soubor | direktiva v bajtech | chytil to gate PŘED touhle změnou? |
|---|---|---|---|
| `true` | ✅ | ✅ | ano (podle názvu) |
| `'hidden'` | ✅ | ❌ | ano (podle názvu) |
| `'inline'` | ❌ | ✅ | 🔴 **ne** |

Proto byte scan **doplňuje** `**/*.map` glob, nenahrazuje ho — každá půlka chytá jiné nastavení.

`.html` je ve skenované množině záměrně: build shape, který inlinuje skripty, dá direktivu dovnitř `index.html`, kam by se scan omezený na skriptové přípony nepodíval.

## Odkud to je

Našla to review na `merglbot-core/merglbot-admin#744`, která tutéž díru zavřela v adminově vlastním build-side gatu. Tohle je ta sdílená půlka — **měl ji každý konzument tohohle gatu**, tedy i `merglbot-public/website`.

Hláška jmenuje **soubor**, nikdy hodnotu direktivy: ta hodnota *je* ta mapa.

## Ověření

| kontrola | výsledek |
|---|---|
| suite | 21 passed |
| mutace: byte scan vypnut | 2 failed |
| mutace: `.html` vyňat ze skenované množiny | 1 failed |
| mutace: scan firuje bezpodmínečně | 4 failed |

Ta poslední je pointa: scan, který by označil každý JS soubor, by splnil **všechny** asserce typu „chytí inline mapu" a přitom shodil každý reálný build. Odlišit je umí jen případ s obyčejným bundlem — a ten je taky nový.

Fixture s inline mapou navíc asertuje, že v ní **není žádný `.map` soubor**; bez toho by test mohl projít na pravidle podle názvu a o byte scanu nedokázat nic.

## Pro konzumenty

Volající si tenhle repo pinují SHA (website `ci.yml` pinuje `d0525b6d`), takže **merge sem se nepropaguje sám**. Každý volající si pin zvedne vědomě — což je záměr, ne opomenutí. Zvednutí pinu ve website je samostatná změna a sahá na `.github/workflows/**`, takže půjde přes owner merge.

Refs merglbot-core/infra#1912 · merglbot-core/merglbot-admin#744